### PR TITLE
Implement Collision System & General Advancements

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,26 @@
+---
+name: Bug Report
+about: Something is not working correctly
+labels: bug
+---
+
+### Description
+What went wrong?
+
+### Steps to Reproduce
+1. 
+2. 
+
+### Expected Behaviour
+What should have happened?
+
+### Actual Behaviour
+What happened instead?
+
+### Environment
+- OS:
+- GPU / Driver:
+- Build type (Debug / Release):
+
+### Additional Context
+Screenshots, logs, or anything else relevant.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,17 @@
+---
+name: Feature Request
+about: Propose a new feature or improvement
+labels: enhancement
+---
+
+### Summary
+One-sentence description of the feature.
+
+### Motivation
+Why is this useful? What problem does it solve?
+
+### Proposed Approach
+How might it be implemented? Reference relevant files from ARCHITECTURE.md if applicable.
+
+### Alternatives Considered
+Other approaches you thought about and why you ruled them out.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,15 @@
+### What does this PR do?
+Short summary of the change.
+
+### Related Issue
+Closes #
+
+### Changes
+<!-- List the files you changed and briefly explain why -->
+- 
+
+### Testing
+How did you verify the change? What did you check for regressions?
+
+### Screenshots / Videos
+<!-- For visual changes — before/after if possible -->

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,1117 @@
+# Contributing to OpenVerse — Codebase Reference
+
+This document is the definitive architectural reference for the **OpenVerse** solar system simulator — a real-time N-body gravity simulator with OpenGL rendering, written in C99. It is intended for both human contributors and LLM assistants to quickly understand where everything lives and how the pieces fit together.
+
+---
+
+## Table of Contents
+
+1. [Project Overview](#1-project-overview)
+2. [Repository Layout](#2-repository-layout)
+3. [Build System](#3-build-system)
+4. [Core Data Structures](#4-core-data-structures)
+5. [Module Reference](#5-module-reference)
+   - [main.c — Entry Point & Event Loop](#maincentry-point--event-loop)
+   - [body.c / body.h — Body Data & Keplerian Mechanics](#bodycbodyh--body-data--keplerian-mechanics)
+   - [physics.c / physics.h — N-Body RESPA Integrator](#physicscphysicsh--n-body-respa-integrator)
+   - [universe.c / universe.h — JSON Universe Loader](#universecuniverseh--json-universe-loader)
+   - [render.c / render.h — Scene Renderer](#rendercrenderh--scene-renderer)
+   - [trails.c / trails.h — Orbital Trail Rendering](#trailsctrailsh--orbital-trail-rendering)
+   - [labels.c / labels.h — Body Name Labels](#labelaclabelsh--body-name-labels)
+   - [starfield.c / starfield.h — Background Stars](#starfieldcstarfieldh--background-stars)
+   - [rings.c / rings.h — Planetary Ring System](#ringscringsh--planetary-ring-system)
+   - [asteroids.c / asteroids.h — Asteroid Belts](#asteroidscasteroidsh--asteroid-belts)
+   - [collision.c / collision.h — Impact & Merge System](#collisioncollisionh--impact--merge-system)
+   - [build.c / build.h — Sandbox Body Placement](#buildcbuildh--sandbox-body-placement)
+   - [ui.c / ui.h — 2D HUD Overlay](#uicuih--2d-hud-overlay)
+   - [camera.c / camera.h — Free-Look Camera](#cameraccamerah--free-look-camera)
+   - [json.c / json.h — JSON Parser](#jsoncjsonh--json-parser)
+   - [gl_utils.c / gl_utils.h — OpenGL Helpers](#gl_utilscgl_utilsh--opengl-helpers)
+   - [common.h — Shared Constants](#commonh--shared-constants)
+   - [math3d.h — Header-Only 3D Math](#math3dh--header-only-3d-math)
+6. [Shader Reference](#6-shader-reference)
+7. [Universe Data Format](#7-universe-data-format)
+8. [Physics Deep Dive](#8-physics-deep-dive)
+9. [Rendering Pipeline](#9-rendering-pipeline)
+10. [File Dependency Graph](#10-file-dependency-graph)
+11. [Adding New Features — Where to Edit](#11-adding-new-features--where-to-edit)
+
+---
+
+## 1. Project Overview
+
+OpenVerse is a physically accurate solar system simulator:
+
+- **Language:** C99
+- **Windowing & Input:** SDL2
+- **Rendering:** OpenGL 3.3 Core Profile (GLSL 330)
+- **Text Rendering:** SDL2_ttf
+- **Physics:** 2R-RESPA hierarchical N-body integrator
+- **Orbital Mechanics:** Keplerian elements (JPL J2000 tables)
+- **Data Source:** `assets/universe.json` — single flat JSON file defining all bodies
+
+**Coordinate System:**
+- Simulation: SI units (metres, m/s)
+- Rendering: AU (Astronomical Units), 1 AU = 1.496 × 10¹¹ m
+- Conversion factor `RS = 1/AU` (metres → GL units) defined in `common.h`
+
+**Scale range the renderer handles:** sub-kilometre (spacecraft, rings) to light-years (interstellar) via a logarithmic depth buffer.
+
+---
+
+## 2. Repository Layout
+
+```
+OpenVerse/
+├── Makefile
+├── src/
+│   ├── main.c             Entry point, event loop, physics orchestration
+│   ├── body.c / body.h    Body struct, Keplerian mechanics
+│   ├── physics.c / .h     N-body RESPA gravity integrator
+│   ├── universe.c / .h    JSON universe loader, runtime body creation
+│   ├── render.c / .h      Scene renderer (delegates to sub-renderers)
+│   ├── trails.c / .h      Orbital trail rendering
+│   ├── labels.c / .h      Body name labels (SDL_ttf + OpenGL)
+│   ├── starfield.c / .h   Procedural background starfield
+│   ├── rings.c / .h       Keplerian ring particle system
+│   ├── asteroids.c / .h   Gravity-integrated asteroid belts
+│   ├── collision.c / .h   Solid-body impacts and merges
+│   ├── build.c / .h       Runtime body placement (sandbox mode)
+│   ├── ui.c / ui.h        2D HUD overlay
+│   ├── camera.c / .h      Free-look camera state
+│   ├── json.c / json.h    Minimal recursive-descent JSON parser
+│   ├── gl_utils.c / .h    OpenGL shader/buffer utilities
+│   ├── common.h           Shared constants and macros
+│   └── math3d.h           Header-only 3D math (Mat4, Vec3)
+└── assets/
+    ├── universe.json          All bodies, rings, and asteroid belts
+    └── shaders/
+        ├── phong.vert/frag        Planet sphere (ray-sphere intersection)
+        ├── atm.vert/frag          Atmospheric limb glow
+        ├── solid.vert/frag        Orbital trail lines
+        ├── color.vert/frag        Starfield GL_POINTS
+        ├── ring.vert              Keplerian ring particles
+        ├── ring_sprite.vert/frag  Saturn-specific sprite rings
+        ├── ring_sprite_generic.frag  Generic sprite rings (Uranus/Neptune)
+        ├── asteroid_particle.vert Asteroid belt GL_POINTS
+        ├── impact_particle.vert/frag  Collision debris
+        ├── label.vert/frag        Body name billboard quads
+        ├── star_glare.vert/frag   Star halo glow
+        ├── build_line.vert/frag   Build mode preview lines
+        └── ui.vert/frag           2D screen-space HUD
+```
+
+---
+
+## 3. Build System
+
+**File:** `Makefile`
+
+The Makefile auto-detects the platform (Linux / macOS / Windows MSYS2 MinGW64) and sets include paths and linker flags accordingly.
+
+**Dependencies:**
+- SDL2 (windowing, input, OpenGL context)
+- SDL2_ttf (font rendering for labels and HUD)
+- GLEW (OpenGL extension loading)
+- OpenGL 3.3+
+- OpenMP (parallelises multi-star-system warmup)
+
+**Build on Windows (MSYS2 MinGW64 shell):**
+```bash
+cd OpenVerse
+mingw32-make
+```
+
+**Build on Linux/macOS:**
+```bash
+cd OpenVerse
+make
+```
+
+**Key compiler flags:** `-O2 -std=c99 -Wall -Wextra -fopenmp`
+
+**Clean:**
+```bash
+make clean   # removes .o files and the executable
+```
+
+---
+
+## 4. Core Data Structures
+
+### `Body` — `src/body.h`
+
+The fundamental simulation unit. Every star, planet, moon, and test particle is a `Body`.
+
+```c
+typedef struct {
+    char   name[32];       // Display name ("Earth", "Luna", ...)
+    double mass;           // kg
+    double radius;         // metres (physical)
+
+    // World-frame simulation state (SI units)
+    double pos[3];         // metres, origin = solar system barycenter
+    double vel[3];         // m/s
+    double acc[3];         // m/s² — recomputed each physics step
+    double fast_acc[3];    // dominant parent force, used by RESPA inner loop
+
+    // Rendering
+    float  col[3];         // RGB [0..1]
+    int    is_star;        // 1 = star, 0 = planet/moon
+
+    // Lifecycle
+    int    alive;          // 0 = removed/absorbed; index is never reused
+    int    parent;         // index into g_bodies; -1 for stars
+
+    // Adaptive timestep hints (computed by physics_refresh_timestep_model)
+    double dyn_period;     // estimated orbital period (seconds)
+    double dyn_dt_outer;   // recommended slow-force timestep
+    double dyn_dt_inner;   // recommended fast-force timestep
+    int    dyn_bucket;     // 0 (slow) .. 3 (very fast)
+
+    // Rotation
+    double obliquity;      // axial tilt in degrees
+    double rotation_rate;  // rad/s
+    double rotation_angle; // current phase [0, 2π]
+
+    // Atmosphere (zero values = no atmosphere)
+    float  atm_color[3];
+    float  atm_intensity;
+    float  atm_scale;      // outer radius as multiple of body radius
+
+    // Orbital trail (circular buffer, heap-allocated)
+    double trail_interval; // seconds between trail samples
+    double trail_accum;    // accumulator
+    int    trail_head;     // next write index
+    int    trail_count;    // valid samples [0, TRAIL_LEN]
+    double (*trail)[3];    // TRAIL_LEN × 3 doubles (AU-scale positions)
+} Body;
+```
+
+**Key invariants:**
+- `parent = -1` for stars; `parent >= 0` for everything else
+- `alive = 0` marks a dead body — its slot in `g_bodies[]` is never recycled
+- Positions are in **metres**; the renderer divides by `AU` before upload
+
+**Global state:**
+```c
+Body *g_bodies;      // dynamically allocated array (body.h)
+int   g_nbodies;     // live count
+int   g_bodies_cap;  // allocated capacity
+```
+
+---
+
+### `Camera` — `src/camera.h`
+
+```c
+typedef struct {
+    double pos[3];   // AU (double precision — needed at interstellar distances)
+    float  yaw;      // degrees, horizontal
+    float  pitch;    // degrees, vertical
+    float  speed;    // AU/s movement speed
+} Camera;
+
+extern Camera g_cam;
+extern int    g_warp;  // 1 if warp mode active
+```
+
+---
+
+### `ParticleDisc` — `src/rings.h`
+
+Represents one ring system. Particles are simulated Keplerianly: mean anomaly advances on the CPU each step; the GPU solves Kepler's equation per-vertex to get position.
+
+Each particle is stored as 8 floats:
+`[M, a, e, ω, h, r, g, b]`
+— mean anomaly (rad), semi-major axis (AU), eccentricity, argument of periapsis (rad), vertical offset (AU), RGB color.
+
+---
+
+### `CollisionSpot` — `src/collision.h`
+
+```c
+typedef struct {
+    float dir[3];          // body-local unit direction (impact location on surface)
+    float angular_radius;  // radians (extent of visual effect)
+    float heat;            // [0, 1] — cooled intensity (decreases over time)
+    float progress;        // [0, 1] — event lifecycle
+    int   kind;            // 1=crater, 2=major, 3=merge, 4=intersect
+} CollisionSpot;
+```
+
+Up to 16 spots per body, passed as uniform arrays to `phong.frag`.
+
+---
+
+### `BuildPreset` — `src/build.h`
+
+```c
+typedef struct {
+    const char *name;
+    double mass;
+    double radius;
+    float  col[3];
+    int    is_star;
+    int    wants_planet_parent;
+    int    wants_nonstar_parent;
+    float  atm_color[3];
+    float  atm_intensity;
+    float  atm_scale;
+} BuildPreset;
+```
+
+6 presets: Rocky, Gas Giant, Ice World, Moon, Dwarf Planet, Star.
+
+---
+
+### `JsonNode` — `src/json.h`
+
+```c
+typedef struct JsonNode {
+    JsonType    type;         // NULL, BOOL, NUMBER, STRING, ARRAY, OBJECT
+    char       *key;          // object member key (NULL for array elements)
+    double      number;
+    char       *string;
+    int         boolean;
+    JsonNode   *first_child;  // first child of OBJECT or ARRAY
+    JsonNode   *next;         // next sibling
+} JsonNode;
+```
+
+---
+
+## 5. Module Reference
+
+### `main.c` — Entry Point & Event Loop
+
+**Location:** `src/main.c` (~495 lines)
+
+The top-level orchestrator. Owns:
+- SDL2 / OpenGL initialisation and teardown
+- The main loop: event handling → physics → render → swap
+- Per-frame camera movement
+- Simulation speed control (`g_sim_speed`, `g_paused`)
+- RESPA physics scheduling (outer/inner step counts per system)
+- 2-year warmup pre-simulation before the loop starts
+
+**Key sections:**
+| Lines (approx.) | What happens |
+|---|---|
+| Startup | SDL/GL init, shader loading, `universe_load()`, `render_init()`, warmup |
+| `handle_events()` | Keyboard (WASD, +/-, B, T, Space, Escape), mouse look |
+| `camera_move()` | Apply camera velocity each frame |
+| Physics block | `physics_refresh_timestep_model()`, RESPA loops per system, `collision_step()`, `asteroids_step()`, `rings_tick()` |
+| Render block | Build matrices, call `render_frame()`, `ui_render()`, swap |
+
+**Simulation speed table** (days/real-second):
+```
+0.0, 0.1, 0.25, 0.5, 1.0, 2.0, 5.0, 10.0, 30.0, 60.0, 100.0, 365.0
+```
+Cycled with `+` / `-` keys.
+
+**Warp mode** (T key): clamps camera speed to [200, 63241] AU/s (~0.003–1 ly/s).
+
+---
+
+### `body.c` / `body.h` — Body Data & Keplerian Mechanics
+
+**Location:** `src/body.c` (~233 lines), `src/body.h` (~76 lines)
+
+Owns the global body array and provides orbital mechanics utilities.
+
+**Functions:**
+
+| Function | Signature | Purpose |
+|---|---|---|
+| `keplerian_to_state` | `(a, e, i, Omega, omega_tilde, L, gm, pos[], vel[])` | Heliocentric Keplerian elements → Cartesian state. Uses JPL J2000 element convention (longitude of perihelion `ω̃ = Ω + ω`, mean longitude `L = ω̃ + M`). Rotates from ecliptic to GL frame (Y↔Z swap). |
+| `moon_to_state` | `(a_km, e, i, Omega, omega, M0, gm, pos[], vel[])` | Planetocentric Keplerian elements → state (moons). Uses standard ω (argument of periapsis, not longitude). |
+| `nearest_star_idx` | `(void) → int` | Returns index of the star closest to `g_cam.pos`. Used for lighting direction. |
+| `body_root_star` | `(int i) → int` | Walks the parent chain upward, returns root star index. |
+| `body_world_to_local_surface_dir` | `(int idx, double world_dir[3], float out[3])` | Converts a world-frame direction into body-local frame (accounting for obliquity and rotation angle). Used to place collision spots on the correct surface location. |
+
+**Keplerian solver** (internal `solve_kepler`): Newton-Raphson, converges in 3–5 iterations for typical eccentricities, capped at 50 for robustness.
+
+---
+
+### `physics.c` / `physics.h` — N-Body RESPA Integrator
+
+**Location:** `src/physics.c` (~400 lines), `src/physics.h` (~52 lines)
+
+Implements a **2R-RESPA** (Reference System Propagator Algorithm) hierarchical integrator:
+
+- **Slow forces** (outer, ~1 day timestep): planet-planet interactions + non-parent perturbations on moons
+- **Fast forces** (inner, ~0.02 day timestep): dominant parent → satellite force
+
+This gives ~32× efficiency over uniform short-timestep integration.
+
+**Global state:**
+```c
+double g_sim_time;    // seconds elapsed since epoch
+double g_sim_speed;   // seconds of sim per real second
+int    g_paused;      // 1 = paused
+```
+
+**Public functions:**
+
+| Function | Purpose |
+|---|---|
+| `physics_respa_begin(dt_outer)` | Slow half-kick: `v += 0.5 * a_slow * dt` for all bodies |
+| `physics_respa_inner(dt_inner)` | Fast KDK step: compute parent force, half-kick, drift, half-kick |
+| `physics_respa_end(dt_outer)` | Slow half-kick (second half) + rotation advance |
+| `physics_respa_begin_system(root, dt)` | Per-star-system variant of begin |
+| `physics_respa_inner_system(root, dt)` | Per-star-system inner step |
+| `physics_respa_end_system(root, dt)` | Per-star-system end |
+| `physics_refresh_timestep_model()` | Recompute `dyn_period`, `dyn_dt_outer`, `dyn_dt_inner` for all bodies |
+| `physics_outer_dt_limit()` | Minimum outer dt across all systems |
+| `physics_inner_dt_limit()` | Minimum inner dt across all systems |
+| `physics_system_count()` | Number of independent star systems |
+| `physics_system_root(idx)` | Root star index of system `idx` |
+| `physics_system_outer_dt_limit(idx)` | Per-system outer dt limit |
+| `physics_system_inner_dt_limit(idx)` | Per-system inner dt limit |
+| `physics_advance_time(dt)` | Increment `g_sim_time` |
+| `physics_step(dt)` | Legacy single-step KDK (for compatibility) |
+
+**Internal helpers** (not exposed in header):
+- `is_satellite(i)` — body has a non-star parent
+- `has_fast_parent(i)` — body should use fast RESPA forces
+- `timestep_anchor(i)` — find the dominant gravitational body for timestep estimation
+- `estimate_period_about(i, anchor)` — estimate orbital period via Kepler's 3rd law
+- `solve_kepler(M, e)` — Newton-Raphson Kepler solver
+
+**Timestep model** (`physics_refresh_timestep_model`):
+1. For each body: find dynamical anchor (explicit parent or nearest massive body)
+2. Estimate period: `T = 2π√(r³/GM)`
+3. `dt_outer = T / 24`, clamped to [0.05 day, 1 day]
+4. `dt_inner = T / 96`, clamped to [60 s, 0.02 day]
+5. Per-system limit = minimum across all bodies in that system
+
+---
+
+### `universe.c` / `universe.h` — JSON Universe Loader
+
+**Location:** `src/universe.c` (~300 lines), `src/universe.h` (~44 lines)
+
+Parses `assets/universe.json` and populates `g_bodies`. Also provides the runtime body creation interface used by build mode and collision merges.
+
+**`BodyCreateSpec`** (universe.h): flat struct describing a body to create at runtime (name, mass, radius, pos, vel, col, is_star, parent, obliquity, rotation_rate, atmosphere params).
+
+**Functions:**
+
+| Function | Purpose |
+|---|---|
+| `universe_load(path)` | Parse JSON, create all bodies in 3 passes: 1) stars, 2) planets/dwarf planets, 3) moons. Applies centre-of-mass velocity correction per star system. |
+| `universe_add_body(spec)` | Add a single body at runtime (build mode, collision merge). Returns new body index. Allocates trail buffer. |
+| `universe_rebind_to_nearest_stars()` | Reassign orphaned planets to the nearest star (used after a star is added via build mode). |
+| `universe_shutdown()` | Free all trail buffers and `g_bodies`. |
+
+**Load order matters:** stars must exist before planets (parent lookup by name), planets before moons.
+
+---
+
+### `render.c` / `render.h` — Scene Renderer
+
+**Location:** `src/render.c` (~600 lines), `src/render.h` (~24 lines)
+
+The scene compositor. Owns sphere mesh geometry, all body-level GL programs, and delegates to sub-renderers (trails, labels, rings, asteroids, etc.).
+
+**Functions:**
+
+| Function | Purpose |
+|---|---|
+| `render_init()` | Compile all shaders (`phong`, `atm`, `solid`, `color`, `star_glare`, `impact_particle`, `label`, `build_line`). Generate sphere mesh VAO/VBO. |
+| `render_frame(view, proj, view_rot, dt)` | Draw one complete frame (see [Rendering Pipeline](#9-rendering-pipeline)). |
+| `render_shutdown()` | Release all GL resources. |
+
+**Internal render passes** (called inside `render_frame`):
+- `render_spheres()` — iterate `g_bodies`, draw one billboard quad per body via `phong.vert/frag`
+- `render_atmospheres()` — additive glow pass for bodies with `atm_intensity > 0`
+- `render_dots()` — GL_POINTS at body centres, plus star glare quads
+- `render_collision_particles()` — impact debris (max 768 particles via `collision_particles()`)
+- `render_build_preview()` — build mode ghost sphere and distance lines
+
+**Logarithmic depth:** All shaders write `gl_FragDepth = log2(eye_depth + 1) / log2(FAR + 1)` (FAR = 2000 AU). This prevents z-fighting across the 14+ orders of magnitude from cm to light-years.
+
+---
+
+### `trails.c` / `trails.h` — Orbital Trail Rendering
+
+**Location:** `src/trails.c` (~250 lines), `src/trails.h` (~23 lines)
+
+Renders the coloured polylines showing orbital paths.
+
+**Design decisions:**
+- Positions stored camera-relative (double precision CPU → float VBO) to avoid float precision loss at large distances
+- Sampling rate: `~T/400` where T is orbital period, so ~400 samples per orbit
+- Dirty tracking: VBO re-uploaded only when new samples added OR camera moved (avoids unnecessary GPU traffic)
+- Circular buffer of `TRAIL_LEN` (4096) samples per body
+
+**Functions:**
+
+| Function | Purpose |
+|---|---|
+| `trails_gl_init()` | Allocate VAOs/VBOs for all initial bodies |
+| `trails_add_body(idx)` | Create GL buffers for a newly added body (build mode) |
+| `trails_remove_body(idx)` | Delete GL resources for a removed body |
+| `trails_reset_body(idx)` | Re-seed trail after discontinuous position change (e.g., capture) |
+| `trails_render(vp[16])` | Upload dirty VBOs and draw all trails as `GL_LINE_STRIP` |
+
+Trails fade when camera distance > `SYS_TRAIL_FADE_END` (1200 AU, defined in `common.h`).
+
+---
+
+### `labels.c` / `labels.h` — Body Name Labels
+
+**Location:** `src/labels.c` (~300 lines), `src/labels.h` (~36 lines)
+
+Renders body name labels using SDL_ttf pre-rendered textures on billboard quads.
+
+**`BodyRenderInfo`** (labels.h):
+```c
+typedef struct {
+    float pos[3];  // GL/AU world position
+    float dr;      // visual radius (AU)
+    float dcam;    // camera distance (AU)
+    int   show;    // 1 if body is too small to see as disc
+} BodyRenderInfo;
+```
+
+**Overlap avoidance:** Greedy AABB sweep — labels are sorted by camera distance, then accepted left-to-right only if their bounding box does not overlap any already-placed label.
+
+**Hysteresis:** `SHOW_DELAY` / `HIDE_DELAY` timers prevent flickering when a body crosses the show/hide threshold.
+
+**Functions:**
+
+| Function | Purpose |
+|---|---|
+| `labels_init()` | Load font (SDL_ttf), pre-render name textures for all bodies |
+| `labels_add_body(idx)` | Create cached text texture for a new body |
+| `labels_remove_body(idx)` | Release label texture |
+| `labels_render(view, proj, vp, info, dt)` | Project each body to screen, run overlap avoidance, draw billboard quads |
+| `labels_shutdown()` | Cleanup |
+
+The Sun always renders at highest priority. Non-star labels are hidden past `MAX_LABEL_DIST` (55 AU).
+
+---
+
+### `starfield.c` / `starfield.h` — Background Stars
+
+**Location:** `src/starfield.c` (~105 lines), `src/starfield.h` (~12 lines)
+
+4000 procedurally generated background stars distributed on the unit sphere.
+
+**Spectral type color distribution:**
+| Type | Fraction | Color |
+|---|---|---|
+| O/B | 3% | Blue-white |
+| A | 10% | White |
+| F | 17% | Yellow-white |
+| G | 25% | Yellow |
+| K | 23% | Orange |
+| M | 22% | Red |
+
+**Functions:**
+
+| Function | Purpose |
+|---|---|
+| `starfield_init()` | Generate 4000 stars with realistic spectral colors (constant seed for reproducibility) |
+| `starfield_render(view_rot, proj)` | Draw as `GL_POINTS` using rotation-only VP matrix (stars stay fixed) |
+| `starfield_shutdown()` | Cleanup |
+
+Two LOD tiers: 1px points (most stars) and 2px points (last quarter of buffer).
+
+---
+
+### `rings.c` / `rings.h` — Planetary Ring System
+
+**Location:** `src/rings.c` (~400 lines), `src/rings.h` (~65 lines)
+
+Keplerian ring particle systems for Saturn, Uranus, and Neptune.
+
+**Physics model:** Each ring particle orbits independently. CPU advances mean anomaly `M += n·dt` each step; GPU solves Kepler's equation per-vertex to get 3D position.
+
+**LOD strategy** (camera distance to ring parent):
+| Distance | Mode |
+|---|---|
+| > 0.2 AU | Flat sprite quad (procedural texture, 1 draw call) |
+| 0.05–0.2 AU | Reduced Keplerian particles (`n_lod`) |
+| < 0.05 AU | Full Keplerian particles (`n_full`) |
+
+**Particle data layout** (8 floats per particle):
+`[M, a, e, ω, h, r, g, b]`
+
+**Functions:**
+
+| Function | Purpose |
+|---|---|
+| `rings_init(path)` | Parse ring zones from JSON, generate particle arrays, upload VBOs, compile shaders |
+| `rings_tick(dt)` | Advance mean anomalies: `M[i] += n[i] * dt` |
+| `rings_render(vp)` | LOD selection + draw (Keplerian particles or sprite quad) |
+| `rings_on_body_absorbed(target, impactor)` | Update parent index after a collision merge |
+| `rings_shutdown()` | Cleanup |
+
+Saturn uses a hardcoded Cassini-division-aware sprite shader (`ring_sprite.frag`). Other planets use a generic uniform-driven sprite (`ring_sprite_generic.frag`).
+
+---
+
+### `asteroids.c` / `asteroids.h` — Asteroid Belts
+
+**Location:** `src/asteroids.c` (~350 lines), `src/asteroids.h` (~7 lines)
+
+Gravity-integrated test particles for the Main Belt and Kuiper Belt.
+
+**Integration:** Symplectic Euler at the outer RESPA rate (~1 day). Particles are test particles (no back-reaction on planets).
+
+**Optimisations:**
+- Only loop over non-moon bodies (~14 vs 33 total) — saves ~2.5× pair evaluations
+- Cache major-body positions per outer step for CPU L1 hit rate
+- Upload positions camera-relative each frame
+- Additive blending to avoid saturation on dense regions
+
+**Functions:**
+
+| Function | Purpose |
+|---|---|
+| `asteroids_init(path)` | Parse belt configs from JSON, generate particles with Keplerian initial conditions |
+| `asteroids_step(dt)` | Gravity-integrate all belt particles one outer step |
+| `asteroids_render(vp_camrel)` | Upload camera-relative positions, draw as `GL_POINTS` (1–3 px) |
+| `asteroids_shutdown()` | Cleanup |
+
+LOD fade parameters (`fade_start_au`, `fade_end_au`) per belt, defined in `universe.json`.
+
+---
+
+### `collision.c` / `collision.h` — Impact & Merge System
+
+**Location:** `src/collision.c` (~700 lines), `src/collision.h` (~39 lines)
+
+Handles solid-body collisions: detection, merge physics, and visual effects.
+
+**Collision types** (`CollisionVisualKind`):
+| Kind | Name | Description |
+|---|---|---|
+| 1 | `COLLISION_VIS_CRATER` | Small impactor — local hot spot, cools over ~45 sim-days |
+| 2 | `COLLISION_VIS_MAJOR` | Large impactor — wide ash cloud + molten interior, cools over ~90 sim-days |
+| 3 | `COLLISION_VIS_MERGE` | Bodies sinking into each other (MERGE_PHASE_SECONDS ~8 sim-days) |
+| 4 | `COLLISION_VIS_INTERSECT` | Live sphere-sphere boundary — bright molten cap at overlap region |
+
+**Functions:**
+
+| Function | Purpose |
+|---|---|
+| `collision_step(dt)` | Broadphase sphere-sphere checks, initiate merges, update active collision spots |
+| `collision_spots_for_body(idx, spots[16])` | Return array of active `CollisionSpot` for a body (passed to phong.frag as uniforms) |
+| `collision_on_body_added(idx)` | Mark parent system for hot broadphase checks |
+| `collision_visual_radius(idx, physical_radius)` | Returns inflated visual radius during merge (bodies look larger while sinking) |
+| `collision_body_heat_glow(idx, col, intensity, scale)` | Returns atmospheric glow params driven by active impacts |
+| `collision_body_has_active_merge(idx)` | True if body is currently in merge phase |
+| `collision_particles(out, max, cam_pos)` | Fill array of up to 768 `CollisionParticle` for the impact debris renderer |
+
+When a merge completes, the smaller body is removed (`alive = 0`), and the larger body receives the combined mass and momentum. `trails`, `labels`, and `rings` are notified to clean up.
+
+---
+
+### `build.c` / `build.h` — Sandbox Body Placement
+
+**Location:** `src/build.c` (~400 lines), `src/build.h` (~37 lines)
+
+Interactive mode allowing the user to place new bodies into the simulation at runtime.
+
+**Global state:**
+```c
+int g_build_mode;      // 1 if build mode is active
+int g_build_tab_held;  // 1 if Tab is held (scroll wheel changes preset)
+```
+
+**Functions:**
+
+| Function | Purpose |
+|---|---|
+| `build_init()` | Initialise |
+| `build_toggle()` | Enter/exit build mode (pauses simulation while active) |
+| `build_set_tab_held(held)` | Track Tab key state |
+| `build_scroll(wheel_y)` | Adjust placement distance (or cycle presets if Tab held) |
+| `build_place_current()` | Place body at preview position; calls `universe_add_body()`, `trails_add_body()`, `labels_add_body()`, `collision_on_body_added()`; returns new body index |
+| `build_preset_count()` | 6 |
+| `build_selected_index()` | Current preset (0–5) |
+| `build_current_preset()` | Pointer to current `BuildPreset` |
+| `build_preset_at(idx)` | Preset at given index |
+| `build_preview_pos_au(out[3])` | Preview position in AU |
+| `build_preview_pos_m(out[3])` | Preview position in metres |
+| `build_nearest3(pos_m, out_idx[3], out_dist_au[3])` | Find the 3 nearest bodies to a given position |
+
+Placement velocity is computed to give the new body a circular orbit around the nearest parent (or zero if no suitable parent).
+
+---
+
+### `ui.c` / `ui.h` — 2D HUD Overlay
+
+**Location:** `src/ui.c` (~300 lines), `src/ui.h` (~10 lines)
+
+Renders a 2D screen-space HUD using `ui.vert` / `ui.frag` (orthographic projection).
+
+**HUD elements:**
+- **Speed bar** (top-left): log-normalised camera speed fill graphic
+- **Speed text**: movement speed (AU/s) and simulation speed (days/s)
+- **FPS counter**: exponential moving average
+- **Build mode info**: selected preset name and instructions (when active)
+
+**Functions:**
+
+| Function | Purpose |
+|---|---|
+| `ui_init()` | Load font, prepare text caches, compile `ui.vert/frag` |
+| `ui_render()` | Draw all HUD elements |
+| `ui_shutdown()` | Cleanup |
+
+---
+
+### `camera.c` / `camera.h` — Free-Look Camera
+
+**Location:** `src/camera.c` (~28 lines), `src/camera.h` (~22 lines)
+
+Minimal camera state. Movement and mouse look are handled in `main.c`; this module only owns the state and provides direction computation.
+
+**Functions:**
+
+| Function | Purpose |
+|---|---|
+| `cam_reset()` | Reset to default view (pos=[0,3,6] AU, looking at origin) |
+| `cam_get_dir(dx, dy, dz)` | Compute forward unit vector from `g_cam.yaw` and `g_cam.pitch` |
+
+---
+
+### `json.c` / `json.h` — JSON Parser
+
+**Location:** `src/json.c` (~400 lines), `src/json.h` (~59 lines)
+
+A minimal recursive-descent JSON parser with two extensions: `//` line comments and scientific notation (via `strtod`).
+
+**Functions:**
+
+| Function | Purpose |
+|---|---|
+| `json_parse_file(path)` | Read file and return root `JsonNode *` |
+| `json_parse(text)` | Parse NUL-terminated string |
+| `json_free(root)` | Recursively free tree |
+| `json_get(obj, key)` | Find object member by key |
+| `json_idx(arr, i)` | Get array element by index |
+| `json_num(node, default)` | Safe number accessor |
+| `json_str(node, default)` | Safe string accessor |
+| `json_bool(node, default)` | Safe boolean accessor |
+
+---
+
+### `gl_utils.c` / `gl_utils.h` — OpenGL Helpers
+
+**Location:** `src/gl_utils.c` (~90 lines), `src/gl_utils.h` (~31 lines)
+
+Thin wrappers for boilerplate OpenGL operations used across multiple modules.
+
+**Functions:**
+
+| Function | Purpose |
+|---|---|
+| `gl_shader_load(vert_path, frag_path)` | Read, compile, and link a GLSL program; prints errors; returns `GLuint` program ID |
+| `gl_vao_create()` | Create and bind a VAO |
+| `gl_vbo_create(bytes, data, usage)` | Create VBO and optionally upload data |
+| `gl_ebo_create(bytes, data)` | Create and upload an element index buffer |
+
+Every module that uses shaders or GPU buffers calls these helpers instead of raw GL.
+
+---
+
+### `common.h` — Shared Constants
+
+**Location:** `src/common.h` (~60 lines)
+
+Included by almost every file. Defines all physical and rendering constants:
+
+| Constant | Value | Meaning |
+|---|---|---|
+| `DEFAULT_WIN_W/H` | 1280 / 720 | Default window size |
+| `FOV` | 60° | Vertical field of view |
+| `PI` | 3.14159… | π |
+| `AU` | 1.496e11 | Metres per AU |
+| `DAY` | 86400 | Seconds per day |
+| `G_CONST` | 6.674e-11 | Gravitational constant |
+| `GM_SUN` | AU³/day² | Solar GM in simulation units |
+| `SOFTENING` | 1e5 m | Gravitational softening radius |
+| `GRAV_EPSILON` | 1e-14 m/s² | Minimum gravity threshold |
+| `MAX_BODIES` | 128 | Maximum body array capacity |
+| `TRAIL_LEN` | 4096 | Trail samples per body |
+| `NUM_STARS` | 4000 | Background star count |
+| `RS` | 1/AU | Metres → GL unit scale factor |
+| `SYS_TRAIL_FADE_START/END` | AU | Trail LOD fade range |
+| `SYS_DOT_FADE_START/END` | AU | Asteroid LOD fade range |
+
+Also declares `int g_win_w, g_win_h` as externals.
+
+---
+
+### `math3d.h` — Header-Only 3D Math
+
+**Location:** `src/math3d.h` (~125 lines)
+
+All matrix and vector operations. Header-only (all functions are `static inline`).
+
+**Types:**
+```c
+typedef float Mat4[16];   // column-major 4×4
+typedef float Vec3[3];
+typedef float Vec4[4];
+```
+
+**Functions:**
+- `vec3_set`, `vec3_copy`, `vec3_add`, `vec3_sub`, `vec3_scale`
+- `vec3_dot`, `vec3_len`, `vec3_normalize`, `vec3_cross`
+- `mat4_mul_vec4`, `mat4_identity`, `mat4_copy`, `mat4_mul`
+- `mat4_perspective(m, fov_y_deg, aspect, near, far)`
+- `mat4_lookAt(m, eye, center, up)`
+- `mat4_get_right`, `mat4_get_up`, `mat4_get_fwd`
+- `mat4_strip_translation` — removes translation (used for skybox VP)
+- `mat4_project` — world → screen NDC projection
+
+---
+
+## 6. Shader Reference
+
+All shaders live in `assets/shaders/`. They are loaded at startup by `render_init()` (and by `starfield_init()`, `trails_gl_init()`, etc.) via `gl_shader_load()`.
+
+### `phong.vert` / `phong.frag` — Planet Spheres
+
+**Technique:** Per-pixel ray-sphere intersection. The vertex shader constructs an oversized billboard quad; the fragment shader traces a ray from the camera through each pixel and intersects it with the sphere.
+
+**Key uniforms (frag):**
+- `u_center`, `u_oc`, `u_radius` — sphere geometry
+- `u_cam_right`, `u_cam_up`, `u_cam_fwd` — camera axes
+- `u_fov_tan`, `u_aspect`, `u_screen` — FOV parameters
+- `u_rotation`, `u_obliquity` — body rotation state
+- `u_planet_type` (0–9) — surface appearance:
+  - 0 = generic rocky, 1 = Earth, 2 = Mars, 3 = Venus, 4 = Jupiter, 5 = Saturn, 6 = ice giant, 7 = Io, 8 = Titan, 9 = Europa
+- `u_impact_count`, `u_impact_dir[16]`, `u_impact_radius[16]`, `u_impact_heat[16]`, `u_impact_progress[16]`, `u_impact_kind[16]` — collision visuals (up to 16 spots)
+- `u_sun_pos_world` — for Phong diffuse lighting
+- `u_emission` — > 0.5 for stars (self-luminous)
+
+**Surface texturing:** 3D FBM noise (`hash3` + `vnoise`) — no UV atlas, no texture files needed.
+
+**Logarithmic depth:** `gl_FragDepth = log2(eye_depth + 1) / log2(2001)` where `eye_depth = t * dot(ray_dir, u_cam_fwd)`.
+
+---
+
+### `atm.vert` / `atm.frag` — Atmospheric Limb Glow
+
+Renders additive atmospheric glow for bodies with `atm_intensity > 0`.
+
+**Technique:** Ray-shell intersection. Glow intensity: `(1 - norm)^3` where `norm` is the normalised closest-approach distance inside the shell. Lit-side boost: `0.15 + 0.85 * clamp(sun_dot, 0, 1)`.
+
+Uses the **back face** of the atmosphere sphere for depth so that glow renders correctly behind solid bodies during merges.
+
+---
+
+### `solid.vert` / `solid.frag` — Orbital Trail Lines
+
+Simple `GL_LINE_STRIP` renderer. Takes camera-relative float positions. Uses `u_count` trick: if `u_count = 0`, renders fully opaque (used for pole axis lines in earlier versions). Logarithmic depth.
+
+---
+
+### `ring.vert` — Keplerian Ring Particles
+
+Solves Kepler's equation on the GPU per vertex:
+1. Newton-Raphson: `M = E - e·sin(E)` → eccentric anomaly E
+2. True anomaly: `ν = 2·atan2(√(1+e)·sin(E/2), √(1-e)·cos(E/2))`
+3. Orbital radius: `r = a(1 - e·cos(E))`
+4. 3D position via ring-plane basis vectors `u_b1`, `u_b2`
+
+Input attributes: `M`, `a`, `e`, `ω`, `h` (vertical offset), `r/g/b`.
+
+---
+
+### `ring_sprite.frag` / `ring_sprite_generic.frag` — Ring Sprites
+
+Far-LOD ring rendering: a single quad textured procedurally.
+- `ring_sprite.frag`: Saturn-specific hardcoded Cassini-division zone map
+- `ring_sprite_generic.frag`: uniform-driven (`u_r_inner`, `u_r_outer`, `u_ring_color`, `u_alpha_max`) for Uranus/Neptune
+
+---
+
+### `asteroid_particle.vert` — Asteroid GL_POINTS
+
+Camera-relative GL_POINTS with size ramp (1→3 px) and distance-based fade driven by `u_fade_start` / `u_fade_end`. Additive blending.
+
+---
+
+### `impact_particle.vert` / `impact_particle.frag` — Collision Debris
+
+Per-particle size and RGBA. Fade over particle lifetime. Used for the debris cloud emitted on large impacts.
+
+---
+
+### `label.vert` / `label.frag` — Body Name Labels
+
+Billboard quad constructed in the vertex shader from `u_right` and `u_up` (camera basis). Fragment shader: texture lookup, transparent regions discarded. Font pre-rendered with SDL_ttf.
+
+---
+
+### `star_glare.vert` / `star_glare.frag` — Star Halos
+
+Extra-large quad centered on each star. Radial gradient fades to transparent. Fades in based on star's projected size on screen.
+
+---
+
+### `ui.vert` / `ui.frag` — 2D HUD
+
+Screen-space orthographic projection. `u_use_tex` selects solid colour (speed bar fill) or textured (text quads).
+
+---
+
+### `build_line.vert` / `build_line.frag` — Build Mode Preview
+
+Lines from placement preview position to the 3 nearest bodies. White = acceptable distance, red = too close.
+
+---
+
+## 7. Universe Data Format
+
+**File:** `assets/universe.json`
+
+The single source of truth for all simulation content. Supports `//` line comments.
+
+### Stars
+
+```json
+{
+  "name": "Sun",
+  "type": "star",
+  "pos_ly": [0.0, 0.0, 0.0],
+  "mass": 1.989e30,
+  "radius_km": 696000.0,
+  "color": [1.0, 0.92, 0.23],
+  "obliquity_deg": 7.25,
+  "rotation_period_days": 25.38
+}
+```
+
+### Planets (Keplerian elements, JPL J2000)
+
+```json
+{
+  "name": "Earth",
+  "type": "planet",
+  "parent": "Sun",
+  "mass": 5.972e24,
+  "radius_km": 6371.0,
+  "color": [0.29, 0.48, 0.78],
+  "obliquity_deg": 23.44,
+  "rotation_period_days": 0.9973,
+  "atmosphere": { "color": [0.4, 0.6, 1.0], "intensity": 0.55, "scale": 1.03 },
+  "keplerian": {
+    "a_au": 1.00000261,
+    "e": 0.01671123,
+    "i_deg": -0.00001531,
+    "Omega_deg": 0.0,
+    "omega_tilde_deg": 102.93768193,
+    "L_deg": 100.46457166,
+    "epoch_jd": 2451545.0
+  }
+}
+```
+
+### Moons (planetocentric Keplerian)
+
+```json
+{
+  "name": "Luna",
+  "type": "moon",
+  "parent": "Earth",
+  "mass": 7.342e22,
+  "radius_km": 1737.4,
+  "color": [0.72, 0.72, 0.68],
+  "moon_keplerian": {
+    "a_km": 384400.0,
+    "e": 0.0549,
+    "i_deg": 5.16,
+    "Omega_deg": 125.08,
+    "omega_deg": 318.15,
+    "M0_deg": 115.3654
+  }
+}
+```
+
+### Rings
+
+```json
+{
+  "parent": "Saturn",
+  "n_full": 4096,
+  "n_lod": 512,
+  "zones": [
+    { "r_min_km": 66900.0, "r_max_km": 74500.0, "density": 0.15, "color": [0.85, 0.82, 0.70] }
+  ]
+}
+```
+
+### Asteroid Belts
+
+```json
+{
+  "name": "Main Belt",
+  "parent": "Sun",
+  "a_au": 2.87,
+  "e": 0.15,
+  "i_deg": 1.86,
+  "Omega_deg": 73.0,
+  "omega_deg": 100.0,
+  "count": 10000,
+  "color": [0.6, 0.6, 0.55],
+  "fade_start_au": 10.0,
+  "fade_end_au": 50.0
+}
+```
+
+---
+
+## 8. Physics Deep Dive
+
+### RESPA Force Split
+
+Forces are split into:
+- **Slow:** All body-body gravitational pairs *except* the dominant parent-satellite pair (~O(N²) for N primaries, updated every outer step `dt_outer ~1 day`)
+- **Fast:** Dominant parent → satellite force only (updated every inner step `dt_inner ~0.02 day`)
+
+For a moon, the dominant parent force is ~10³× larger than tidal perturbations — so using a 50× shorter inner timestep on only that force pair is ~32× more efficient than stepping everything at inner rate.
+
+### One Outer Step
+
+```
+physics_respa_begin_system(root, dt_outer)
+    v[all] += 0.5 * a_slow[all] * dt_outer
+
+    for i in range(n_inner):
+        physics_respa_inner_system(root, dt_inner)
+            compute fast_acc[satellites] = gravity from parent only
+            v[all]   += 0.5 * fast_acc * dt_inner
+            pos[all] += v[all] * dt_inner
+            v[all]   += 0.5 * fast_acc * dt_inner
+
+physics_respa_end_system(root, dt_outer)
+    v[all] += 0.5 * a_slow[all] * dt_outer   // second slow half-kick
+    rotation_angle[i] += rotation_rate[i] * dt_outer
+    g_sim_time += dt_outer
+```
+
+### Warmup (Pre-Simulation)
+
+Before the render loop, the simulation runs forward 2 years (`WARMUP_DT = 2 * 365 * DAY`) to populate the orbital trail buffers. Multiple star systems are warmed up in parallel via `#pragma omp parallel for schedule(dynamic)`.
+
+### Kepler Solver
+
+```c
+// Newton-Raphson: M = E - e*sin(E)
+double E = M;
+for (int k = 0; k < 50; k++) {
+    double dE = (M - E + e*sin(E)) / (1.0 - e*cos(E));
+    E += dE;
+    if (fabs(dE) < 1e-12) break;
+}
+```
+
+Converges in 3–5 iterations for `e < 0.3`; 50-iteration cap handles near-parabolic orbits.
+
+---
+
+## 9. Rendering Pipeline
+
+Full sequence inside `render_frame()`:
+
+| Step | Function / Shader | Notes |
+|---|---|---|
+| 1 | `starfield_render()` / `color.vert/frag` | Rotation-only VP, GL_POINTS |
+| 2 | `render_spheres()` / `phong.vert/frag` | Billboard quads, ray-sphere intersection |
+| 3 | `render_atmospheres()` / `atm.vert/frag` | Additive blend, GL_SRC_ALPHA / GL_ONE |
+| 4 | `render_dots()` / `color.vert/frag` + `star_glare` | GL_POINTS + halos |
+| 5 | `trails_render()` / `solid.vert/frag` | Camera-relative polylines |
+| 6 | `rings_render()` / `ring.vert` or sprite shaders | LOD: particles ↔ sprite |
+| 7 | `asteroids_render()` / `asteroid_particle.vert` | GL_POINTS, additive |
+| 8 | `render_collision_particles()` / `impact_particle.vert/frag` | Additive debris |
+| 9 | `labels_render()` / `label.vert/frag` | Billboard text quads |
+| 10 | `render_build_preview()` / `build_line.vert/frag` | Build mode only |
+| 11 | `ui_render()` / `ui.vert/frag` | Screen-space HUD |
+| 12 | `SDL_GL_SwapWindow()` | Present |
+
+**Blending modes:**
+| Pass | `glBlendFunc` |
+|---|---|
+| Opaque geometry | `GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA` |
+| Atmospheres, asteroids, collision particles, ring additive | `GL_SRC_ALPHA, GL_ONE` |
+
+---
+
+## 10. File Dependency Graph
+
+```
+main.c
+├── body.h, physics.h, camera.h, universe.h
+├── render.h, trails.h, labels.h, starfield.h
+├── rings.h, asteroids.h, collision.h, build.h, ui.h
+└── common.h
+
+body.c       → body.h, camera.h, math3d.h
+physics.c    → physics.h, body.h, common.h
+universe.c   → universe.h, body.h, json.h, common.h
+render.c     → render.h, body.h, camera.h, math3d.h, gl_utils.h
+             → starfield.h, trails.h, labels.h, rings.h
+             → asteroids.h, collision.h, build.h
+
+trails.c     → trails.h, body.h, camera.h, gl_utils.h, math3d.h, common.h
+labels.c     → labels.h, body.h, camera.h, gl_utils.h, math3d.h
+starfield.c  → starfield.h, gl_utils.h, common.h
+rings.c      → rings.h, body.h, json.h, gl_utils.h, math3d.h, common.h
+asteroids.c  → asteroids.h, body.h, json.h, gl_utils.h, common.h
+collision.c  → collision.h, body.h, labels.h, rings.h, trails.h, common.h
+build.c      → build.h, body.h, camera.h, physics.h, universe.h
+             → trails.h, labels.h, collision.h
+ui.c         → ui.h, camera.h, physics.h, build.h, body.h, gl_utils.h
+
+json.c       → json.h                    (standalone)
+gl_utils.c   → gl_utils.h, common.h     (standalone)
+camera.c     → camera.h                 (minimal, mostly state)
+```
+
+---
+
+## 11. Adding New Features — Where to Edit
+
+### Add a new planet or moon
+→ Edit `assets/universe.json`. Add a JSON object under `"bodies"` with `"type": "planet"` or `"type": "moon"`, a `"parent"` name, and either `"keplerian"` (planet) or `"moon_keplerian"` (moon) elements. No code changes required.
+
+### Add a planet surface appearance
+→ Edit `assets/shaders/phong.frag`. Add a new `case` in the `u_planet_type` switch. Increment the type counter and assign the new index when constructing the body in `render.c` (search for `u_planet_type` uniform upload).
+
+### Add a new ring system
+→ Edit `assets/universe.json`. Add an entry to the `"rings"` array with `"parent"`, `"n_full"`, `"n_lod"`, and `"zones"`. If the planet needs a custom sprite shader, add it in `rings.c::rings_init()`.
+
+### Add a new asteroid belt
+→ Edit `assets/universe.json`. Add an entry to `"asteroid_belts"` with `"parent"`, `"a_au"`, `"e"`, `"i_deg"`, `"count"`, etc.
+
+### Add a new body type / build preset
+→ Edit `build.c`. Add a new `BuildPreset` to the `presets[]` array. No header change needed unless the preset count is hard-coded elsewhere.
+
+### Add a new rendering effect per body
+→ Add uniforms to `phong.frag`. Upload them in the sphere-draw loop in `render.c::render_spheres()`. Follow the pattern of how `u_impact_*` uniforms are set.
+
+### Add a new HUD element
+→ Edit `ui.c::ui_render()`. Use `gl_vbo_create()` for geometry and the `ui.vert/frag` shader. For text, pre-render with SDL_ttf in `ui_init()`.
+
+### Add a new physics force
+→ Edit `physics.c`. Add force computation to the appropriate section of `physics_respa_inner_system()` (fast forces, inner loop) or `physics_respa_begin/end_system()` (slow forces, outer loop). Update `physics_refresh_timestep_model()` if the new force affects timestep selection.
+
+### Change the simulation initial state
+→ Edit `assets/universe.json`. The Keplerian element format follows the JPL Horizons/Solar System Dynamics table 1 convention (a, e, i, Ω, ω̃, L at J2000 epoch).
+
+### Add support for textures
+→ The rotation angle is already tracked in `Body.rotation_angle` (updated in `physics_respa_end_system`). The obliquity is in `Body.obliquity`. Add a texture sampler to `phong.frag`, compute UV from the surface normal rotated by these values, and sample accordingly.
+
+---
+
+*This document reflects the codebase as of April 2025. When in doubt, the source files are the authoritative reference.*

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,1117 @@
+# Contributing to OpenVerse — Codebase Reference
+
+This document is the definitive architectural reference for the **OpenVerse** solar system simulator — a real-time N-body gravity simulator with OpenGL rendering, written in C99. It is intended for both human contributors and LLM assistants to quickly understand where everything lives and how the pieces fit together.
+
+---
+
+## Table of Contents
+
+1. [Project Overview](#1-project-overview)
+2. [Repository Layout](#2-repository-layout)
+3. [Build System](#3-build-system)
+4. [Core Data Structures](#4-core-data-structures)
+5. [Module Reference](#5-module-reference)
+   - [main.c — Entry Point & Event Loop](#maincentry-point--event-loop)
+   - [body.c / body.h — Body Data & Keplerian Mechanics](#bodycbodyh--body-data--keplerian-mechanics)
+   - [physics.c / physics.h — N-Body RESPA Integrator](#physicscphysicsh--n-body-respa-integrator)
+   - [universe.c / universe.h — JSON Universe Loader](#universecuniverseh--json-universe-loader)
+   - [render.c / render.h — Scene Renderer](#rendercrenderh--scene-renderer)
+   - [trails.c / trails.h — Orbital Trail Rendering](#trailsctrailsh--orbital-trail-rendering)
+   - [labels.c / labels.h — Body Name Labels](#labelaclabelsh--body-name-labels)
+   - [starfield.c / starfield.h — Background Stars](#starfieldcstarfieldh--background-stars)
+   - [rings.c / rings.h — Planetary Ring System](#ringscringsh--planetary-ring-system)
+   - [asteroids.c / asteroids.h — Asteroid Belts](#asteroidscasteroidsh--asteroid-belts)
+   - [collision.c / collision.h — Impact & Merge System](#collisioncollisionh--impact--merge-system)
+   - [build.c / build.h — Sandbox Body Placement](#buildcbuildh--sandbox-body-placement)
+   - [ui.c / ui.h — 2D HUD Overlay](#uicuih--2d-hud-overlay)
+   - [camera.c / camera.h — Free-Look Camera](#cameraccamerah--free-look-camera)
+   - [json.c / json.h — JSON Parser](#jsoncjsonh--json-parser)
+   - [gl_utils.c / gl_utils.h — OpenGL Helpers](#gl_utilscgl_utilsh--opengl-helpers)
+   - [common.h — Shared Constants](#commonh--shared-constants)
+   - [math3d.h — Header-Only 3D Math](#math3dh--header-only-3d-math)
+6. [Shader Reference](#6-shader-reference)
+7. [Universe Data Format](#7-universe-data-format)
+8. [Physics Deep Dive](#8-physics-deep-dive)
+9. [Rendering Pipeline](#9-rendering-pipeline)
+10. [File Dependency Graph](#10-file-dependency-graph)
+11. [Adding New Features — Where to Edit](#11-adding-new-features--where-to-edit)
+
+---
+
+## 1. Project Overview
+
+OpenVerse is a physically accurate solar system simulator:
+
+- **Language:** C99
+- **Windowing & Input:** SDL2
+- **Rendering:** OpenGL 3.3 Core Profile (GLSL 330)
+- **Text Rendering:** SDL2_ttf
+- **Physics:** 2R-RESPA hierarchical N-body integrator
+- **Orbital Mechanics:** Keplerian elements (JPL J2000 tables)
+- **Data Source:** `assets/universe.json` — single flat JSON file defining all bodies
+
+**Coordinate System:**
+- Simulation: SI units (metres, m/s)
+- Rendering: AU (Astronomical Units), 1 AU = 1.496 × 10¹¹ m
+- Conversion factor `RS = 1/AU` (metres → GL units) defined in `common.h`
+
+**Scale range the renderer handles:** sub-kilometre (spacecraft, rings) to light-years (interstellar) via a logarithmic depth buffer.
+
+---
+
+## 2. Repository Layout
+
+```
+OpenVerse/
+├── Makefile
+├── src/
+│   ├── main.c             Entry point, event loop, physics orchestration
+│   ├── body.c / body.h    Body struct, Keplerian mechanics
+│   ├── physics.c / .h     N-body RESPA gravity integrator
+│   ├── universe.c / .h    JSON universe loader, runtime body creation
+│   ├── render.c / .h      Scene renderer (delegates to sub-renderers)
+│   ├── trails.c / .h      Orbital trail rendering
+│   ├── labels.c / .h      Body name labels (SDL_ttf + OpenGL)
+│   ├── starfield.c / .h   Procedural background starfield
+│   ├── rings.c / .h       Keplerian ring particle system
+│   ├── asteroids.c / .h   Gravity-integrated asteroid belts
+│   ├── collision.c / .h   Solid-body impacts and merges
+│   ├── build.c / .h       Runtime body placement (sandbox mode)
+│   ├── ui.c / ui.h        2D HUD overlay
+│   ├── camera.c / .h      Free-look camera state
+│   ├── json.c / json.h    Minimal recursive-descent JSON parser
+│   ├── gl_utils.c / .h    OpenGL shader/buffer utilities
+│   ├── common.h           Shared constants and macros
+│   └── math3d.h           Header-only 3D math (Mat4, Vec3)
+└── assets/
+    ├── universe.json          All bodies, rings, and asteroid belts
+    └── shaders/
+        ├── phong.vert/frag        Planet sphere (ray-sphere intersection)
+        ├── atm.vert/frag          Atmospheric limb glow
+        ├── solid.vert/frag        Orbital trail lines
+        ├── color.vert/frag        Starfield GL_POINTS
+        ├── ring.vert              Keplerian ring particles
+        ├── ring_sprite.vert/frag  Saturn-specific sprite rings
+        ├── ring_sprite_generic.frag  Generic sprite rings (Uranus/Neptune)
+        ├── asteroid_particle.vert Asteroid belt GL_POINTS
+        ├── impact_particle.vert/frag  Collision debris
+        ├── label.vert/frag        Body name billboard quads
+        ├── star_glare.vert/frag   Star halo glow
+        ├── build_line.vert/frag   Build mode preview lines
+        └── ui.vert/frag           2D screen-space HUD
+```
+
+---
+
+## 3. Build System
+
+**File:** `Makefile`
+
+The Makefile auto-detects the platform (Linux / macOS / Windows MSYS2 MinGW64) and sets include paths and linker flags accordingly.
+
+**Dependencies:**
+- SDL2 (windowing, input, OpenGL context)
+- SDL2_ttf (font rendering for labels and HUD)
+- GLEW (OpenGL extension loading)
+- OpenGL 3.3+
+- OpenMP (parallelises multi-star-system warmup)
+
+**Build on Windows (MSYS2 MinGW64 shell):**
+```bash
+cd OpenVerse
+mingw32-make
+```
+
+**Build on Linux/macOS:**
+```bash
+cd OpenVerse
+make
+```
+
+**Key compiler flags:** `-O2 -std=c99 -Wall -Wextra -fopenmp`
+
+**Clean:**
+```bash
+make clean   # removes .o files and the executable
+```
+
+---
+
+## 4. Core Data Structures
+
+### `Body` — `src/body.h`
+
+The fundamental simulation unit. Every star, planet, moon, and test particle is a `Body`.
+
+```c
+typedef struct {
+    char   name[32];       // Display name ("Earth", "Luna", ...)
+    double mass;           // kg
+    double radius;         // metres (physical)
+
+    // World-frame simulation state (SI units)
+    double pos[3];         // metres, origin = solar system barycenter
+    double vel[3];         // m/s
+    double acc[3];         // m/s² — recomputed each physics step
+    double fast_acc[3];    // dominant parent force, used by RESPA inner loop
+
+    // Rendering
+    float  col[3];         // RGB [0..1]
+    int    is_star;        // 1 = star, 0 = planet/moon
+
+    // Lifecycle
+    int    alive;          // 0 = removed/absorbed; index is never reused
+    int    parent;         // index into g_bodies; -1 for stars
+
+    // Adaptive timestep hints (computed by physics_refresh_timestep_model)
+    double dyn_period;     // estimated orbital period (seconds)
+    double dyn_dt_outer;   // recommended slow-force timestep
+    double dyn_dt_inner;   // recommended fast-force timestep
+    int    dyn_bucket;     // 0 (slow) .. 3 (very fast)
+
+    // Rotation
+    double obliquity;      // axial tilt in degrees
+    double rotation_rate;  // rad/s
+    double rotation_angle; // current phase [0, 2π]
+
+    // Atmosphere (zero values = no atmosphere)
+    float  atm_color[3];
+    float  atm_intensity;
+    float  atm_scale;      // outer radius as multiple of body radius
+
+    // Orbital trail (circular buffer, heap-allocated)
+    double trail_interval; // seconds between trail samples
+    double trail_accum;    // accumulator
+    int    trail_head;     // next write index
+    int    trail_count;    // valid samples [0, TRAIL_LEN]
+    double (*trail)[3];    // TRAIL_LEN × 3 doubles (AU-scale positions)
+} Body;
+```
+
+**Key invariants:**
+- `parent = -1` for stars; `parent >= 0` for everything else
+- `alive = 0` marks a dead body — its slot in `g_bodies[]` is never recycled
+- Positions are in **metres**; the renderer divides by `AU` before upload
+
+**Global state:**
+```c
+Body *g_bodies;      // dynamically allocated array (body.h)
+int   g_nbodies;     // live count
+int   g_bodies_cap;  // allocated capacity
+```
+
+---
+
+### `Camera` — `src/camera.h`
+
+```c
+typedef struct {
+    double pos[3];   // AU (double precision — needed at interstellar distances)
+    float  yaw;      // degrees, horizontal
+    float  pitch;    // degrees, vertical
+    float  speed;    // AU/s movement speed
+} Camera;
+
+extern Camera g_cam;
+extern int    g_warp;  // 1 if warp mode active
+```
+
+---
+
+### `ParticleDisc` — `src/rings.h`
+
+Represents one ring system. Particles are simulated Keplerianly: mean anomaly advances on the CPU each step; the GPU solves Kepler's equation per-vertex to get position.
+
+Each particle is stored as 8 floats:
+`[M, a, e, ω, h, r, g, b]`
+— mean anomaly (rad), semi-major axis (AU), eccentricity, argument of periapsis (rad), vertical offset (AU), RGB color.
+
+---
+
+### `CollisionSpot` — `src/collision.h`
+
+```c
+typedef struct {
+    float dir[3];          // body-local unit direction (impact location on surface)
+    float angular_radius;  // radians (extent of visual effect)
+    float heat;            // [0, 1] — cooled intensity (decreases over time)
+    float progress;        // [0, 1] — event lifecycle
+    int   kind;            // 1=crater, 2=major, 3=merge, 4=intersect
+} CollisionSpot;
+```
+
+Up to 16 spots per body, passed as uniform arrays to `phong.frag`.
+
+---
+
+### `BuildPreset` — `src/build.h`
+
+```c
+typedef struct {
+    const char *name;
+    double mass;
+    double radius;
+    float  col[3];
+    int    is_star;
+    int    wants_planet_parent;
+    int    wants_nonstar_parent;
+    float  atm_color[3];
+    float  atm_intensity;
+    float  atm_scale;
+} BuildPreset;
+```
+
+6 presets: Rocky, Gas Giant, Ice World, Moon, Dwarf Planet, Star.
+
+---
+
+### `JsonNode` — `src/json.h`
+
+```c
+typedef struct JsonNode {
+    JsonType    type;         // NULL, BOOL, NUMBER, STRING, ARRAY, OBJECT
+    char       *key;          // object member key (NULL for array elements)
+    double      number;
+    char       *string;
+    int         boolean;
+    JsonNode   *first_child;  // first child of OBJECT or ARRAY
+    JsonNode   *next;         // next sibling
+} JsonNode;
+```
+
+---
+
+## 5. Module Reference
+
+### `main.c` — Entry Point & Event Loop
+
+**Location:** `src/main.c` (~495 lines)
+
+The top-level orchestrator. Owns:
+- SDL2 / OpenGL initialisation and teardown
+- The main loop: event handling → physics → render → swap
+- Per-frame camera movement
+- Simulation speed control (`g_sim_speed`, `g_paused`)
+- RESPA physics scheduling (outer/inner step counts per system)
+- 2-year warmup pre-simulation before the loop starts
+
+**Key sections:**
+| Lines (approx.) | What happens |
+|---|---|
+| Startup | SDL/GL init, shader loading, `universe_load()`, `render_init()`, warmup |
+| `handle_events()` | Keyboard (WASD, +/-, B, T, Space, Escape), mouse look |
+| `camera_move()` | Apply camera velocity each frame |
+| Physics block | `physics_refresh_timestep_model()`, RESPA loops per system, `collision_step()`, `asteroids_step()`, `rings_tick()` |
+| Render block | Build matrices, call `render_frame()`, `ui_render()`, swap |
+
+**Simulation speed table** (days/real-second):
+```
+0.0, 0.1, 0.25, 0.5, 1.0, 2.0, 5.0, 10.0, 30.0, 60.0, 100.0, 365.0
+```
+Cycled with `+` / `-` keys.
+
+**Warp mode** (T key): clamps camera speed to [200, 63241] AU/s (~0.003–1 ly/s).
+
+---
+
+### `body.c` / `body.h` — Body Data & Keplerian Mechanics
+
+**Location:** `src/body.c` (~233 lines), `src/body.h` (~76 lines)
+
+Owns the global body array and provides orbital mechanics utilities.
+
+**Functions:**
+
+| Function | Signature | Purpose |
+|---|---|---|
+| `keplerian_to_state` | `(a, e, i, Omega, omega_tilde, L, gm, pos[], vel[])` | Heliocentric Keplerian elements → Cartesian state. Uses JPL J2000 element convention (longitude of perihelion `ω̃ = Ω + ω`, mean longitude `L = ω̃ + M`). Rotates from ecliptic to GL frame (Y↔Z swap). |
+| `moon_to_state` | `(a_km, e, i, Omega, omega, M0, gm, pos[], vel[])` | Planetocentric Keplerian elements → state (moons). Uses standard ω (argument of periapsis, not longitude). |
+| `nearest_star_idx` | `(void) → int` | Returns index of the star closest to `g_cam.pos`. Used for lighting direction. |
+| `body_root_star` | `(int i) → int` | Walks the parent chain upward, returns root star index. |
+| `body_world_to_local_surface_dir` | `(int idx, double world_dir[3], float out[3])` | Converts a world-frame direction into body-local frame (accounting for obliquity and rotation angle). Used to place collision spots on the correct surface location. |
+
+**Keplerian solver** (internal `solve_kepler`): Newton-Raphson, converges in 3–5 iterations for typical eccentricities, capped at 50 for robustness.
+
+---
+
+### `physics.c` / `physics.h` — N-Body RESPA Integrator
+
+**Location:** `src/physics.c` (~400 lines), `src/physics.h` (~52 lines)
+
+Implements a **2R-RESPA** (Reference System Propagator Algorithm) hierarchical integrator:
+
+- **Slow forces** (outer, ~1 day timestep): planet-planet interactions + non-parent perturbations on moons
+- **Fast forces** (inner, ~0.02 day timestep): dominant parent → satellite force
+
+This gives ~32× efficiency over uniform short-timestep integration.
+
+**Global state:**
+```c
+double g_sim_time;    // seconds elapsed since epoch
+double g_sim_speed;   // seconds of sim per real second
+int    g_paused;      // 1 = paused
+```
+
+**Public functions:**
+
+| Function | Purpose |
+|---|---|
+| `physics_respa_begin(dt_outer)` | Slow half-kick: `v += 0.5 * a_slow * dt` for all bodies |
+| `physics_respa_inner(dt_inner)` | Fast KDK step: compute parent force, half-kick, drift, half-kick |
+| `physics_respa_end(dt_outer)` | Slow half-kick (second half) + rotation advance |
+| `physics_respa_begin_system(root, dt)` | Per-star-system variant of begin |
+| `physics_respa_inner_system(root, dt)` | Per-star-system inner step |
+| `physics_respa_end_system(root, dt)` | Per-star-system end |
+| `physics_refresh_timestep_model()` | Recompute `dyn_period`, `dyn_dt_outer`, `dyn_dt_inner` for all bodies |
+| `physics_outer_dt_limit()` | Minimum outer dt across all systems |
+| `physics_inner_dt_limit()` | Minimum inner dt across all systems |
+| `physics_system_count()` | Number of independent star systems |
+| `physics_system_root(idx)` | Root star index of system `idx` |
+| `physics_system_outer_dt_limit(idx)` | Per-system outer dt limit |
+| `physics_system_inner_dt_limit(idx)` | Per-system inner dt limit |
+| `physics_advance_time(dt)` | Increment `g_sim_time` |
+| `physics_step(dt)` | Legacy single-step KDK (for compatibility) |
+
+**Internal helpers** (not exposed in header):
+- `is_satellite(i)` — body has a non-star parent
+- `has_fast_parent(i)` — body should use fast RESPA forces
+- `timestep_anchor(i)` — find the dominant gravitational body for timestep estimation
+- `estimate_period_about(i, anchor)` — estimate orbital period via Kepler's 3rd law
+- `solve_kepler(M, e)` — Newton-Raphson Kepler solver
+
+**Timestep model** (`physics_refresh_timestep_model`):
+1. For each body: find dynamical anchor (explicit parent or nearest massive body)
+2. Estimate period: `T = 2π√(r³/GM)`
+3. `dt_outer = T / 24`, clamped to [0.05 day, 1 day]
+4. `dt_inner = T / 96`, clamped to [60 s, 0.02 day]
+5. Per-system limit = minimum across all bodies in that system
+
+---
+
+### `universe.c` / `universe.h` — JSON Universe Loader
+
+**Location:** `src/universe.c` (~300 lines), `src/universe.h` (~44 lines)
+
+Parses `assets/universe.json` and populates `g_bodies`. Also provides the runtime body creation interface used by build mode and collision merges.
+
+**`BodyCreateSpec`** (universe.h): flat struct describing a body to create at runtime (name, mass, radius, pos, vel, col, is_star, parent, obliquity, rotation_rate, atmosphere params).
+
+**Functions:**
+
+| Function | Purpose |
+|---|---|
+| `universe_load(path)` | Parse JSON, create all bodies in 3 passes: 1) stars, 2) planets/dwarf planets, 3) moons. Applies centre-of-mass velocity correction per star system. |
+| `universe_add_body(spec)` | Add a single body at runtime (build mode, collision merge). Returns new body index. Allocates trail buffer. |
+| `universe_rebind_to_nearest_stars()` | Reassign orphaned planets to the nearest star (used after a star is added via build mode). |
+| `universe_shutdown()` | Free all trail buffers and `g_bodies`. |
+
+**Load order matters:** stars must exist before planets (parent lookup by name), planets before moons.
+
+---
+
+### `render.c` / `render.h` — Scene Renderer
+
+**Location:** `src/render.c` (~600 lines), `src/render.h` (~24 lines)
+
+The scene compositor. Owns sphere mesh geometry, all body-level GL programs, and delegates to sub-renderers (trails, labels, rings, asteroids, etc.).
+
+**Functions:**
+
+| Function | Purpose |
+|---|---|
+| `render_init()` | Compile all shaders (`phong`, `atm`, `solid`, `color`, `star_glare`, `impact_particle`, `label`, `build_line`). Generate sphere mesh VAO/VBO. |
+| `render_frame(view, proj, view_rot, dt)` | Draw one complete frame (see [Rendering Pipeline](#9-rendering-pipeline)). |
+| `render_shutdown()` | Release all GL resources. |
+
+**Internal render passes** (called inside `render_frame`):
+- `render_spheres()` — iterate `g_bodies`, draw one billboard quad per body via `phong.vert/frag`
+- `render_atmospheres()` — additive glow pass for bodies with `atm_intensity > 0`
+- `render_dots()` — GL_POINTS at body centres, plus star glare quads
+- `render_collision_particles()` — impact debris (max 768 particles via `collision_particles()`)
+- `render_build_preview()` — build mode ghost sphere and distance lines
+
+**Logarithmic depth:** All shaders write `gl_FragDepth = log2(eye_depth + 1) / log2(FAR + 1)` (FAR = 2000 AU). This prevents z-fighting across the 14+ orders of magnitude from cm to light-years.
+
+---
+
+### `trails.c` / `trails.h` — Orbital Trail Rendering
+
+**Location:** `src/trails.c` (~250 lines), `src/trails.h` (~23 lines)
+
+Renders the coloured polylines showing orbital paths.
+
+**Design decisions:**
+- Positions stored camera-relative (double precision CPU → float VBO) to avoid float precision loss at large distances
+- Sampling rate: `~T/400` where T is orbital period, so ~400 samples per orbit
+- Dirty tracking: VBO re-uploaded only when new samples added OR camera moved (avoids unnecessary GPU traffic)
+- Circular buffer of `TRAIL_LEN` (4096) samples per body
+
+**Functions:**
+
+| Function | Purpose |
+|---|---|
+| `trails_gl_init()` | Allocate VAOs/VBOs for all initial bodies |
+| `trails_add_body(idx)` | Create GL buffers for a newly added body (build mode) |
+| `trails_remove_body(idx)` | Delete GL resources for a removed body |
+| `trails_reset_body(idx)` | Re-seed trail after discontinuous position change (e.g., capture) |
+| `trails_render(vp[16])` | Upload dirty VBOs and draw all trails as `GL_LINE_STRIP` |
+
+Trails fade when camera distance > `SYS_TRAIL_FADE_END` (1200 AU, defined in `common.h`).
+
+---
+
+### `labels.c` / `labels.h` — Body Name Labels
+
+**Location:** `src/labels.c` (~300 lines), `src/labels.h` (~36 lines)
+
+Renders body name labels using SDL_ttf pre-rendered textures on billboard quads.
+
+**`BodyRenderInfo`** (labels.h):
+```c
+typedef struct {
+    float pos[3];  // GL/AU world position
+    float dr;      // visual radius (AU)
+    float dcam;    // camera distance (AU)
+    int   show;    // 1 if body is too small to see as disc
+} BodyRenderInfo;
+```
+
+**Overlap avoidance:** Greedy AABB sweep — labels are sorted by camera distance, then accepted left-to-right only if their bounding box does not overlap any already-placed label.
+
+**Hysteresis:** `SHOW_DELAY` / `HIDE_DELAY` timers prevent flickering when a body crosses the show/hide threshold.
+
+**Functions:**
+
+| Function | Purpose |
+|---|---|
+| `labels_init()` | Load font (SDL_ttf), pre-render name textures for all bodies |
+| `labels_add_body(idx)` | Create cached text texture for a new body |
+| `labels_remove_body(idx)` | Release label texture |
+| `labels_render(view, proj, vp, info, dt)` | Project each body to screen, run overlap avoidance, draw billboard quads |
+| `labels_shutdown()` | Cleanup |
+
+The Sun always renders at highest priority. Non-star labels are hidden past `MAX_LABEL_DIST` (55 AU).
+
+---
+
+### `starfield.c` / `starfield.h` — Background Stars
+
+**Location:** `src/starfield.c` (~105 lines), `src/starfield.h` (~12 lines)
+
+4000 procedurally generated background stars distributed on the unit sphere.
+
+**Spectral type color distribution:**
+| Type | Fraction | Color |
+|---|---|---|
+| O/B | 3% | Blue-white |
+| A | 10% | White |
+| F | 17% | Yellow-white |
+| G | 25% | Yellow |
+| K | 23% | Orange |
+| M | 22% | Red |
+
+**Functions:**
+
+| Function | Purpose |
+|---|---|
+| `starfield_init()` | Generate 4000 stars with realistic spectral colors (constant seed for reproducibility) |
+| `starfield_render(view_rot, proj)` | Draw as `GL_POINTS` using rotation-only VP matrix (stars stay fixed) |
+| `starfield_shutdown()` | Cleanup |
+
+Two LOD tiers: 1px points (most stars) and 2px points (last quarter of buffer).
+
+---
+
+### `rings.c` / `rings.h` — Planetary Ring System
+
+**Location:** `src/rings.c` (~400 lines), `src/rings.h` (~65 lines)
+
+Keplerian ring particle systems for Saturn, Uranus, and Neptune.
+
+**Physics model:** Each ring particle orbits independently. CPU advances mean anomaly `M += n·dt` each step; GPU solves Kepler's equation per-vertex to get 3D position.
+
+**LOD strategy** (camera distance to ring parent):
+| Distance | Mode |
+|---|---|
+| > 0.2 AU | Flat sprite quad (procedural texture, 1 draw call) |
+| 0.05–0.2 AU | Reduced Keplerian particles (`n_lod`) |
+| < 0.05 AU | Full Keplerian particles (`n_full`) |
+
+**Particle data layout** (8 floats per particle):
+`[M, a, e, ω, h, r, g, b]`
+
+**Functions:**
+
+| Function | Purpose |
+|---|---|
+| `rings_init(path)` | Parse ring zones from JSON, generate particle arrays, upload VBOs, compile shaders |
+| `rings_tick(dt)` | Advance mean anomalies: `M[i] += n[i] * dt` |
+| `rings_render(vp)` | LOD selection + draw (Keplerian particles or sprite quad) |
+| `rings_on_body_absorbed(target, impactor)` | Update parent index after a collision merge |
+| `rings_shutdown()` | Cleanup |
+
+Saturn uses a hardcoded Cassini-division-aware sprite shader (`ring_sprite.frag`). Other planets use a generic uniform-driven sprite (`ring_sprite_generic.frag`).
+
+---
+
+### `asteroids.c` / `asteroids.h` — Asteroid Belts
+
+**Location:** `src/asteroids.c` (~350 lines), `src/asteroids.h` (~7 lines)
+
+Gravity-integrated test particles for the Main Belt and Kuiper Belt.
+
+**Integration:** Symplectic Euler at the outer RESPA rate (~1 day). Particles are test particles (no back-reaction on planets).
+
+**Optimisations:**
+- Only loop over non-moon bodies (~14 vs 33 total) — saves ~2.5× pair evaluations
+- Cache major-body positions per outer step for CPU L1 hit rate
+- Upload positions camera-relative each frame
+- Additive blending to avoid saturation on dense regions
+
+**Functions:**
+
+| Function | Purpose |
+|---|---|
+| `asteroids_init(path)` | Parse belt configs from JSON, generate particles with Keplerian initial conditions |
+| `asteroids_step(dt)` | Gravity-integrate all belt particles one outer step |
+| `asteroids_render(vp_camrel)` | Upload camera-relative positions, draw as `GL_POINTS` (1–3 px) |
+| `asteroids_shutdown()` | Cleanup |
+
+LOD fade parameters (`fade_start_au`, `fade_end_au`) per belt, defined in `universe.json`.
+
+---
+
+### `collision.c` / `collision.h` — Impact & Merge System
+
+**Location:** `src/collision.c` (~700 lines), `src/collision.h` (~39 lines)
+
+Handles solid-body collisions: detection, merge physics, and visual effects.
+
+**Collision types** (`CollisionVisualKind`):
+| Kind | Name | Description |
+|---|---|---|
+| 1 | `COLLISION_VIS_CRATER` | Small impactor — local hot spot, cools over ~45 sim-days |
+| 2 | `COLLISION_VIS_MAJOR` | Large impactor — wide ash cloud + molten interior, cools over ~90 sim-days |
+| 3 | `COLLISION_VIS_MERGE` | Bodies sinking into each other (MERGE_PHASE_SECONDS ~8 sim-days) |
+| 4 | `COLLISION_VIS_INTERSECT` | Live sphere-sphere boundary — bright molten cap at overlap region |
+
+**Functions:**
+
+| Function | Purpose |
+|---|---|
+| `collision_step(dt)` | Broadphase sphere-sphere checks, initiate merges, update active collision spots |
+| `collision_spots_for_body(idx, spots[16])` | Return array of active `CollisionSpot` for a body (passed to phong.frag as uniforms) |
+| `collision_on_body_added(idx)` | Mark parent system for hot broadphase checks |
+| `collision_visual_radius(idx, physical_radius)` | Returns inflated visual radius during merge (bodies look larger while sinking) |
+| `collision_body_heat_glow(idx, col, intensity, scale)` | Returns atmospheric glow params driven by active impacts |
+| `collision_body_has_active_merge(idx)` | True if body is currently in merge phase |
+| `collision_particles(out, max, cam_pos)` | Fill array of up to 768 `CollisionParticle` for the impact debris renderer |
+
+When a merge completes, the smaller body is removed (`alive = 0`), and the larger body receives the combined mass and momentum. `trails`, `labels`, and `rings` are notified to clean up.
+
+---
+
+### `build.c` / `build.h` — Sandbox Body Placement
+
+**Location:** `src/build.c` (~400 lines), `src/build.h` (~37 lines)
+
+Interactive mode allowing the user to place new bodies into the simulation at runtime.
+
+**Global state:**
+```c
+int g_build_mode;      // 1 if build mode is active
+int g_build_tab_held;  // 1 if Tab is held (scroll wheel changes preset)
+```
+
+**Functions:**
+
+| Function | Purpose |
+|---|---|
+| `build_init()` | Initialise |
+| `build_toggle()` | Enter/exit build mode (pauses simulation while active) |
+| `build_set_tab_held(held)` | Track Tab key state |
+| `build_scroll(wheel_y)` | Adjust placement distance (or cycle presets if Tab held) |
+| `build_place_current()` | Place body at preview position; calls `universe_add_body()`, `trails_add_body()`, `labels_add_body()`, `collision_on_body_added()`; returns new body index |
+| `build_preset_count()` | 6 |
+| `build_selected_index()` | Current preset (0–5) |
+| `build_current_preset()` | Pointer to current `BuildPreset` |
+| `build_preset_at(idx)` | Preset at given index |
+| `build_preview_pos_au(out[3])` | Preview position in AU |
+| `build_preview_pos_m(out[3])` | Preview position in metres |
+| `build_nearest3(pos_m, out_idx[3], out_dist_au[3])` | Find the 3 nearest bodies to a given position |
+
+Placement velocity is computed to give the new body a circular orbit around the nearest parent (or zero if no suitable parent).
+
+---
+
+### `ui.c` / `ui.h` — 2D HUD Overlay
+
+**Location:** `src/ui.c` (~300 lines), `src/ui.h` (~10 lines)
+
+Renders a 2D screen-space HUD using `ui.vert` / `ui.frag` (orthographic projection).
+
+**HUD elements:**
+- **Speed bar** (top-left): log-normalised camera speed fill graphic
+- **Speed text**: movement speed (AU/s) and simulation speed (days/s)
+- **FPS counter**: exponential moving average
+- **Build mode info**: selected preset name and instructions (when active)
+
+**Functions:**
+
+| Function | Purpose |
+|---|---|
+| `ui_init()` | Load font, prepare text caches, compile `ui.vert/frag` |
+| `ui_render()` | Draw all HUD elements |
+| `ui_shutdown()` | Cleanup |
+
+---
+
+### `camera.c` / `camera.h` — Free-Look Camera
+
+**Location:** `src/camera.c` (~28 lines), `src/camera.h` (~22 lines)
+
+Minimal camera state. Movement and mouse look are handled in `main.c`; this module only owns the state and provides direction computation.
+
+**Functions:**
+
+| Function | Purpose |
+|---|---|
+| `cam_reset()` | Reset to default view (pos=[0,3,6] AU, looking at origin) |
+| `cam_get_dir(dx, dy, dz)` | Compute forward unit vector from `g_cam.yaw` and `g_cam.pitch` |
+
+---
+
+### `json.c` / `json.h` — JSON Parser
+
+**Location:** `src/json.c` (~400 lines), `src/json.h` (~59 lines)
+
+A minimal recursive-descent JSON parser with two extensions: `//` line comments and scientific notation (via `strtod`).
+
+**Functions:**
+
+| Function | Purpose |
+|---|---|
+| `json_parse_file(path)` | Read file and return root `JsonNode *` |
+| `json_parse(text)` | Parse NUL-terminated string |
+| `json_free(root)` | Recursively free tree |
+| `json_get(obj, key)` | Find object member by key |
+| `json_idx(arr, i)` | Get array element by index |
+| `json_num(node, default)` | Safe number accessor |
+| `json_str(node, default)` | Safe string accessor |
+| `json_bool(node, default)` | Safe boolean accessor |
+
+---
+
+### `gl_utils.c` / `gl_utils.h` — OpenGL Helpers
+
+**Location:** `src/gl_utils.c` (~90 lines), `src/gl_utils.h` (~31 lines)
+
+Thin wrappers for boilerplate OpenGL operations used across multiple modules.
+
+**Functions:**
+
+| Function | Purpose |
+|---|---|
+| `gl_shader_load(vert_path, frag_path)` | Read, compile, and link a GLSL program; prints errors; returns `GLuint` program ID |
+| `gl_vao_create()` | Create and bind a VAO |
+| `gl_vbo_create(bytes, data, usage)` | Create VBO and optionally upload data |
+| `gl_ebo_create(bytes, data)` | Create and upload an element index buffer |
+
+Every module that uses shaders or GPU buffers calls these helpers instead of raw GL.
+
+---
+
+### `common.h` — Shared Constants
+
+**Location:** `src/common.h` (~60 lines)
+
+Included by almost every file. Defines all physical and rendering constants:
+
+| Constant | Value | Meaning |
+|---|---|---|
+| `DEFAULT_WIN_W/H` | 1280 / 720 | Default window size |
+| `FOV` | 60° | Vertical field of view |
+| `PI` | 3.14159… | π |
+| `AU` | 1.496e11 | Metres per AU |
+| `DAY` | 86400 | Seconds per day |
+| `G_CONST` | 6.674e-11 | Gravitational constant |
+| `GM_SUN` | AU³/day² | Solar GM in simulation units |
+| `SOFTENING` | 1e5 m | Gravitational softening radius |
+| `GRAV_EPSILON` | 1e-14 m/s² | Minimum gravity threshold |
+| `MAX_BODIES` | 128 | Maximum body array capacity |
+| `TRAIL_LEN` | 4096 | Trail samples per body |
+| `NUM_STARS` | 4000 | Background star count |
+| `RS` | 1/AU | Metres → GL unit scale factor |
+| `SYS_TRAIL_FADE_START/END` | AU | Trail LOD fade range |
+| `SYS_DOT_FADE_START/END` | AU | Asteroid LOD fade range |
+
+Also declares `int g_win_w, g_win_h` as externals.
+
+---
+
+### `math3d.h` — Header-Only 3D Math
+
+**Location:** `src/math3d.h` (~125 lines)
+
+All matrix and vector operations. Header-only (all functions are `static inline`).
+
+**Types:**
+```c
+typedef float Mat4[16];   // column-major 4×4
+typedef float Vec3[3];
+typedef float Vec4[4];
+```
+
+**Functions:**
+- `vec3_set`, `vec3_copy`, `vec3_add`, `vec3_sub`, `vec3_scale`
+- `vec3_dot`, `vec3_len`, `vec3_normalize`, `vec3_cross`
+- `mat4_mul_vec4`, `mat4_identity`, `mat4_copy`, `mat4_mul`
+- `mat4_perspective(m, fov_y_deg, aspect, near, far)`
+- `mat4_lookAt(m, eye, center, up)`
+- `mat4_get_right`, `mat4_get_up`, `mat4_get_fwd`
+- `mat4_strip_translation` — removes translation (used for skybox VP)
+- `mat4_project` — world → screen NDC projection
+
+---
+
+## 6. Shader Reference
+
+All shaders live in `assets/shaders/`. They are loaded at startup by `render_init()` (and by `starfield_init()`, `trails_gl_init()`, etc.) via `gl_shader_load()`.
+
+### `phong.vert` / `phong.frag` — Planet Spheres
+
+**Technique:** Per-pixel ray-sphere intersection. The vertex shader constructs an oversized billboard quad; the fragment shader traces a ray from the camera through each pixel and intersects it with the sphere.
+
+**Key uniforms (frag):**
+- `u_center`, `u_oc`, `u_radius` — sphere geometry
+- `u_cam_right`, `u_cam_up`, `u_cam_fwd` — camera axes
+- `u_fov_tan`, `u_aspect`, `u_screen` — FOV parameters
+- `u_rotation`, `u_obliquity` — body rotation state
+- `u_planet_type` (0–9) — surface appearance:
+  - 0 = generic rocky, 1 = Earth, 2 = Mars, 3 = Venus, 4 = Jupiter, 5 = Saturn, 6 = ice giant, 7 = Io, 8 = Titan, 9 = Europa
+- `u_impact_count`, `u_impact_dir[16]`, `u_impact_radius[16]`, `u_impact_heat[16]`, `u_impact_progress[16]`, `u_impact_kind[16]` — collision visuals (up to 16 spots)
+- `u_sun_pos_world` — for Phong diffuse lighting
+- `u_emission` — > 0.5 for stars (self-luminous)
+
+**Surface texturing:** 3D FBM noise (`hash3` + `vnoise`) — no UV atlas, no texture files needed.
+
+**Logarithmic depth:** `gl_FragDepth = log2(eye_depth + 1) / log2(2001)` where `eye_depth = t * dot(ray_dir, u_cam_fwd)`.
+
+---
+
+### `atm.vert` / `atm.frag` — Atmospheric Limb Glow
+
+Renders additive atmospheric glow for bodies with `atm_intensity > 0`.
+
+**Technique:** Ray-shell intersection. Glow intensity: `(1 - norm)^3` where `norm` is the normalised closest-approach distance inside the shell. Lit-side boost: `0.15 + 0.85 * clamp(sun_dot, 0, 1)`.
+
+Uses the **back face** of the atmosphere sphere for depth so that glow renders correctly behind solid bodies during merges.
+
+---
+
+### `solid.vert` / `solid.frag` — Orbital Trail Lines
+
+Simple `GL_LINE_STRIP` renderer. Takes camera-relative float positions. Uses `u_count` trick: if `u_count = 0`, renders fully opaque (used for pole axis lines in earlier versions). Logarithmic depth.
+
+---
+
+### `ring.vert` — Keplerian Ring Particles
+
+Solves Kepler's equation on the GPU per vertex:
+1. Newton-Raphson: `M = E - e·sin(E)` → eccentric anomaly E
+2. True anomaly: `ν = 2·atan2(√(1+e)·sin(E/2), √(1-e)·cos(E/2))`
+3. Orbital radius: `r = a(1 - e·cos(E))`
+4. 3D position via ring-plane basis vectors `u_b1`, `u_b2`
+
+Input attributes: `M`, `a`, `e`, `ω`, `h` (vertical offset), `r/g/b`.
+
+---
+
+### `ring_sprite.frag` / `ring_sprite_generic.frag` — Ring Sprites
+
+Far-LOD ring rendering: a single quad textured procedurally.
+- `ring_sprite.frag`: Saturn-specific hardcoded Cassini-division zone map
+- `ring_sprite_generic.frag`: uniform-driven (`u_r_inner`, `u_r_outer`, `u_ring_color`, `u_alpha_max`) for Uranus/Neptune
+
+---
+
+### `asteroid_particle.vert` — Asteroid GL_POINTS
+
+Camera-relative GL_POINTS with size ramp (1→3 px) and distance-based fade driven by `u_fade_start` / `u_fade_end`. Additive blending.
+
+---
+
+### `impact_particle.vert` / `impact_particle.frag` — Collision Debris
+
+Per-particle size and RGBA. Fade over particle lifetime. Used for the debris cloud emitted on large impacts.
+
+---
+
+### `label.vert` / `label.frag` — Body Name Labels
+
+Billboard quad constructed in the vertex shader from `u_right` and `u_up` (camera basis). Fragment shader: texture lookup, transparent regions discarded. Font pre-rendered with SDL_ttf.
+
+---
+
+### `star_glare.vert` / `star_glare.frag` — Star Halos
+
+Extra-large quad centered on each star. Radial gradient fades to transparent. Fades in based on star's projected size on screen.
+
+---
+
+### `ui.vert` / `ui.frag` — 2D HUD
+
+Screen-space orthographic projection. `u_use_tex` selects solid colour (speed bar fill) or textured (text quads).
+
+---
+
+### `build_line.vert` / `build_line.frag` — Build Mode Preview
+
+Lines from placement preview position to the 3 nearest bodies. White = acceptable distance, red = too close.
+
+---
+
+## 7. Universe Data Format
+
+**File:** `assets/universe.json`
+
+The single source of truth for all simulation content. Supports `//` line comments.
+
+### Stars
+
+```json
+{
+  "name": "Sun",
+  "type": "star",
+  "pos_ly": [0.0, 0.0, 0.0],
+  "mass": 1.989e30,
+  "radius_km": 696000.0,
+  "color": [1.0, 0.92, 0.23],
+  "obliquity_deg": 7.25,
+  "rotation_period_days": 25.38
+}
+```
+
+### Planets (Keplerian elements, JPL J2000)
+
+```json
+{
+  "name": "Earth",
+  "type": "planet",
+  "parent": "Sun",
+  "mass": 5.972e24,
+  "radius_km": 6371.0,
+  "color": [0.29, 0.48, 0.78],
+  "obliquity_deg": 23.44,
+  "rotation_period_days": 0.9973,
+  "atmosphere": { "color": [0.4, 0.6, 1.0], "intensity": 0.55, "scale": 1.03 },
+  "keplerian": {
+    "a_au": 1.00000261,
+    "e": 0.01671123,
+    "i_deg": -0.00001531,
+    "Omega_deg": 0.0,
+    "omega_tilde_deg": 102.93768193,
+    "L_deg": 100.46457166,
+    "epoch_jd": 2451545.0
+  }
+}
+```
+
+### Moons (planetocentric Keplerian)
+
+```json
+{
+  "name": "Luna",
+  "type": "moon",
+  "parent": "Earth",
+  "mass": 7.342e22,
+  "radius_km": 1737.4,
+  "color": [0.72, 0.72, 0.68],
+  "moon_keplerian": {
+    "a_km": 384400.0,
+    "e": 0.0549,
+    "i_deg": 5.16,
+    "Omega_deg": 125.08,
+    "omega_deg": 318.15,
+    "M0_deg": 115.3654
+  }
+}
+```
+
+### Rings
+
+```json
+{
+  "parent": "Saturn",
+  "n_full": 4096,
+  "n_lod": 512,
+  "zones": [
+    { "r_min_km": 66900.0, "r_max_km": 74500.0, "density": 0.15, "color": [0.85, 0.82, 0.70] }
+  ]
+}
+```
+
+### Asteroid Belts
+
+```json
+{
+  "name": "Main Belt",
+  "parent": "Sun",
+  "a_au": 2.87,
+  "e": 0.15,
+  "i_deg": 1.86,
+  "Omega_deg": 73.0,
+  "omega_deg": 100.0,
+  "count": 10000,
+  "color": [0.6, 0.6, 0.55],
+  "fade_start_au": 10.0,
+  "fade_end_au": 50.0
+}
+```
+
+---
+
+## 8. Physics Deep Dive
+
+### RESPA Force Split
+
+Forces are split into:
+- **Slow:** All body-body gravitational pairs *except* the dominant parent-satellite pair (~O(N²) for N primaries, updated every outer step `dt_outer ~1 day`)
+- **Fast:** Dominant parent → satellite force only (updated every inner step `dt_inner ~0.02 day`)
+
+For a moon, the dominant parent force is ~10³× larger than tidal perturbations — so using a 50× shorter inner timestep on only that force pair is ~32× more efficient than stepping everything at inner rate.
+
+### One Outer Step
+
+```
+physics_respa_begin_system(root, dt_outer)
+    v[all] += 0.5 * a_slow[all] * dt_outer
+
+    for i in range(n_inner):
+        physics_respa_inner_system(root, dt_inner)
+            compute fast_acc[satellites] = gravity from parent only
+            v[all]   += 0.5 * fast_acc * dt_inner
+            pos[all] += v[all] * dt_inner
+            v[all]   += 0.5 * fast_acc * dt_inner
+
+physics_respa_end_system(root, dt_outer)
+    v[all] += 0.5 * a_slow[all] * dt_outer   // second slow half-kick
+    rotation_angle[i] += rotation_rate[i] * dt_outer
+    g_sim_time += dt_outer
+```
+
+### Warmup (Pre-Simulation)
+
+Before the render loop, the simulation runs forward 2 years (`WARMUP_DT = 2 * 365 * DAY`) to populate the orbital trail buffers. Multiple star systems are warmed up in parallel via `#pragma omp parallel for schedule(dynamic)`.
+
+### Kepler Solver
+
+```c
+// Newton-Raphson: M = E - e*sin(E)
+double E = M;
+for (int k = 0; k < 50; k++) {
+    double dE = (M - E + e*sin(E)) / (1.0 - e*cos(E));
+    E += dE;
+    if (fabs(dE) < 1e-12) break;
+}
+```
+
+Converges in 3–5 iterations for `e < 0.3`; 50-iteration cap handles near-parabolic orbits.
+
+---
+
+## 9. Rendering Pipeline
+
+Full sequence inside `render_frame()`:
+
+| Step | Function / Shader | Notes |
+|---|---|---|
+| 1 | `starfield_render()` / `color.vert/frag` | Rotation-only VP, GL_POINTS |
+| 2 | `render_spheres()` / `phong.vert/frag` | Billboard quads, ray-sphere intersection |
+| 3 | `render_atmospheres()` / `atm.vert/frag` | Additive blend, GL_SRC_ALPHA / GL_ONE |
+| 4 | `render_dots()` / `color.vert/frag` + `star_glare` | GL_POINTS + halos |
+| 5 | `trails_render()` / `solid.vert/frag` | Camera-relative polylines |
+| 6 | `rings_render()` / `ring.vert` or sprite shaders | LOD: particles ↔ sprite |
+| 7 | `asteroids_render()` / `asteroid_particle.vert` | GL_POINTS, additive |
+| 8 | `render_collision_particles()` / `impact_particle.vert/frag` | Additive debris |
+| 9 | `labels_render()` / `label.vert/frag` | Billboard text quads |
+| 10 | `render_build_preview()` / `build_line.vert/frag` | Build mode only |
+| 11 | `ui_render()` / `ui.vert/frag` | Screen-space HUD |
+| 12 | `SDL_GL_SwapWindow()` | Present |
+
+**Blending modes:**
+| Pass | `glBlendFunc` |
+|---|---|
+| Opaque geometry | `GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA` |
+| Atmospheres, asteroids, collision particles, ring additive | `GL_SRC_ALPHA, GL_ONE` |
+
+---
+
+## 10. File Dependency Graph
+
+```
+main.c
+├── body.h, physics.h, camera.h, universe.h
+├── render.h, trails.h, labels.h, starfield.h
+├── rings.h, asteroids.h, collision.h, build.h, ui.h
+└── common.h
+
+body.c       → body.h, camera.h, math3d.h
+physics.c    → physics.h, body.h, common.h
+universe.c   → universe.h, body.h, json.h, common.h
+render.c     → render.h, body.h, camera.h, math3d.h, gl_utils.h
+             → starfield.h, trails.h, labels.h, rings.h
+             → asteroids.h, collision.h, build.h
+
+trails.c     → trails.h, body.h, camera.h, gl_utils.h, math3d.h, common.h
+labels.c     → labels.h, body.h, camera.h, gl_utils.h, math3d.h
+starfield.c  → starfield.h, gl_utils.h, common.h
+rings.c      → rings.h, body.h, json.h, gl_utils.h, math3d.h, common.h
+asteroids.c  → asteroids.h, body.h, json.h, gl_utils.h, common.h
+collision.c  → collision.h, body.h, labels.h, rings.h, trails.h, common.h
+build.c      → build.h, body.h, camera.h, physics.h, universe.h
+             → trails.h, labels.h, collision.h
+ui.c         → ui.h, camera.h, physics.h, build.h, body.h, gl_utils.h
+
+json.c       → json.h                    (standalone)
+gl_utils.c   → gl_utils.h, common.h     (standalone)
+camera.c     → camera.h                 (minimal, mostly state)
+```
+
+---
+
+## 11. Adding New Features — Where to Edit
+
+### Add a new planet or moon
+→ Edit `assets/universe.json`. Add a JSON object under `"bodies"` with `"type": "planet"` or `"type": "moon"`, a `"parent"` name, and either `"keplerian"` (planet) or `"moon_keplerian"` (moon) elements. No code changes required.
+
+### Add a planet surface appearance
+→ Edit `assets/shaders/phong.frag`. Add a new `case` in the `u_planet_type` switch. Increment the type counter and assign the new index when constructing the body in `render.c` (search for `u_planet_type` uniform upload).
+
+### Add a new ring system
+→ Edit `assets/universe.json`. Add an entry to the `"rings"` array with `"parent"`, `"n_full"`, `"n_lod"`, and `"zones"`. If the planet needs a custom sprite shader, add it in `rings.c::rings_init()`.
+
+### Add a new asteroid belt
+→ Edit `assets/universe.json`. Add an entry to `"asteroid_belts"` with `"parent"`, `"a_au"`, `"e"`, `"i_deg"`, `"count"`, etc.
+
+### Add a new body type / build preset
+→ Edit `build.c`. Add a new `BuildPreset` to the `presets[]` array. No header change needed unless the preset count is hard-coded elsewhere.
+
+### Add a new rendering effect per body
+→ Add uniforms to `phong.frag`. Upload them in the sphere-draw loop in `render.c::render_spheres()`. Follow the pattern of how `u_impact_*` uniforms are set.
+
+### Add a new HUD element
+→ Edit `ui.c::ui_render()`. Use `gl_vbo_create()` for geometry and the `ui.vert/frag` shader. For text, pre-render with SDL_ttf in `ui_init()`.
+
+### Add a new physics force
+→ Edit `physics.c`. Add force computation to the appropriate section of `physics_respa_inner_system()` (fast forces, inner loop) or `physics_respa_begin/end_system()` (slow forces, outer loop). Update `physics_refresh_timestep_model()` if the new force affects timestep selection.
+
+### Change the simulation initial state
+→ Edit `assets/universe.json`. The Keplerian element format follows the JPL Horizons/Solar System Dynamics table 1 convention (a, e, i, Ω, ω̃, L at J2000 epoch).
+
+### Add support for textures
+→ The rotation angle is already tracked in `Body.rotation_angle` (updated in `physics_respa_end_system`). The obliquity is in `Body.obliquity`. Add a texture sampler to `phong.frag`, compute UV from the surface normal rotated by these values, and sample accordingly.
+
+---
+
+*This document reflects the codebase as of April 2025. When in doubt, the source files are the authoritative reference.*

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,1117 +1,156 @@
-# Contributing to OpenVerse — Codebase Reference
+# Contributing to OpenVerse
 
-This document is the definitive architectural reference for the **OpenVerse** solar system simulator — a real-time N-body gravity simulator with OpenGL rendering, written in C99. It is intended for both human contributors and LLM assistants to quickly understand where everything lives and how the pieces fit together.
+Thanks for your interest in contributing! This document explains the process for reporting bugs, proposing features, and submitting code.
+
+> **Note:** OpenVerse is in early development and we are not strict about following every guideline to the letter — contribute in whatever way works for you. That said, following the conventions below makes reviewing and integrating changes much easier, and it is genuinely appreciated.
+
+For a full technical reference of the codebase (modules, data structures, rendering pipeline, physics), see [ARCHITECTURE.md](ARCHITECTURE.md).
 
 ---
 
 ## Table of Contents
 
-1. [Project Overview](#1-project-overview)
-2. [Repository Layout](#2-repository-layout)
-3. [Build System](#3-build-system)
-4. [Core Data Structures](#4-core-data-structures)
-5. [Module Reference](#5-module-reference)
-   - [main.c — Entry Point & Event Loop](#maincentry-point--event-loop)
-   - [body.c / body.h — Body Data & Keplerian Mechanics](#bodycbodyh--body-data--keplerian-mechanics)
-   - [physics.c / physics.h — N-Body RESPA Integrator](#physicscphysicsh--n-body-respa-integrator)
-   - [universe.c / universe.h — JSON Universe Loader](#universecuniverseh--json-universe-loader)
-   - [render.c / render.h — Scene Renderer](#rendercrenderh--scene-renderer)
-   - [trails.c / trails.h — Orbital Trail Rendering](#trailsctrailsh--orbital-trail-rendering)
-   - [labels.c / labels.h — Body Name Labels](#labelaclabelsh--body-name-labels)
-   - [starfield.c / starfield.h — Background Stars](#starfieldcstarfieldh--background-stars)
-   - [rings.c / rings.h — Planetary Ring System](#ringscringsh--planetary-ring-system)
-   - [asteroids.c / asteroids.h — Asteroid Belts](#asteroidscasteroidsh--asteroid-belts)
-   - [collision.c / collision.h — Impact & Merge System](#collisioncollisionh--impact--merge-system)
-   - [build.c / build.h — Sandbox Body Placement](#buildcbuildh--sandbox-body-placement)
-   - [ui.c / ui.h — 2D HUD Overlay](#uicuih--2d-hud-overlay)
-   - [camera.c / camera.h — Free-Look Camera](#cameraccamerah--free-look-camera)
-   - [json.c / json.h — JSON Parser](#jsoncjsonh--json-parser)
-   - [gl_utils.c / gl_utils.h — OpenGL Helpers](#gl_utilscgl_utilsh--opengl-helpers)
-   - [common.h — Shared Constants](#commonh--shared-constants)
-   - [math3d.h — Header-Only 3D Math](#math3dh--header-only-3d-math)
-6. [Shader Reference](#6-shader-reference)
-7. [Universe Data Format](#7-universe-data-format)
-8. [Physics Deep Dive](#8-physics-deep-dive)
-9. [Rendering Pipeline](#9-rendering-pipeline)
-10. [File Dependency Graph](#10-file-dependency-graph)
-11. [Adding New Features — Where to Edit](#11-adding-new-features--where-to-edit)
+1. [Code of Conduct](#1-code-of-conduct)
+2. [Reporting Bugs](#2-reporting-bugs)
+3. [Requesting Features](#3-requesting-features)
+4. [Branching Strategy](#4-branching-strategy)
+5. [Submitting a Pull Request](#5-submitting-a-pull-request)
+6. [Code Review Process](#6-code-review-process)
+7. [Labels](#7-labels)
 
 ---
 
-## 1. Project Overview
+## 1. Code of Conduct
 
-OpenVerse is a physically accurate solar system simulator:
-
-- **Language:** C99
-- **Windowing & Input:** SDL2
-- **Rendering:** OpenGL 3.3 Core Profile (GLSL 330)
-- **Text Rendering:** SDL2_ttf
-- **Physics:** 2R-RESPA hierarchical N-body integrator
-- **Orbital Mechanics:** Keplerian elements (JPL J2000 tables)
-- **Data Source:** `assets/universe.json` — single flat JSON file defining all bodies
-
-**Coordinate System:**
-- Simulation: SI units (metres, m/s)
-- Rendering: AU (Astronomical Units), 1 AU = 1.496 × 10¹¹ m
-- Conversion factor `RS = 1/AU` (metres → GL units) defined in `common.h`
-
-**Scale range the renderer handles:** sub-kilometre (spacecraft, rings) to light-years (interstellar) via a logarithmic depth buffer.
+This project follows the [Contributor Covenant Code of Conduct](CODE_OF_CONDUCT.md). By participating you agree to uphold it.
 
 ---
 
-## 2. Repository Layout
+## 2. Reporting Bugs
+
+Open an **Issue** and apply the `bug` label. Please include:
+
+**Title:** Short and specific — e.g. `Saturn rings disappear when camera is inside the ring plane` not `rings broken`.
+
+**Body:**
 
 ```
-OpenVerse/
-├── Makefile
-├── src/
-│   ├── main.c             Entry point, event loop, physics orchestration
-│   ├── body.c / body.h    Body struct, Keplerian mechanics
-│   ├── physics.c / .h     N-body RESPA gravity integrator
-│   ├── universe.c / .h    JSON universe loader, runtime body creation
-│   ├── render.c / .h      Scene renderer (delegates to sub-renderers)
-│   ├── trails.c / .h      Orbital trail rendering
-│   ├── labels.c / .h      Body name labels (SDL_ttf + OpenGL)
-│   ├── starfield.c / .h   Procedural background starfield
-│   ├── rings.c / .h       Keplerian ring particle system
-│   ├── asteroids.c / .h   Gravity-integrated asteroid belts
-│   ├── collision.c / .h   Solid-body impacts and merges
-│   ├── build.c / .h       Runtime body placement (sandbox mode)
-│   ├── ui.c / ui.h        2D HUD overlay
-│   ├── camera.c / .h      Free-look camera state
-│   ├── json.c / json.h    Minimal recursive-descent JSON parser
-│   ├── gl_utils.c / .h    OpenGL shader/buffer utilities
-│   ├── common.h           Shared constants and macros
-│   └── math3d.h           Header-only 3D math (Mat4, Vec3)
-└── assets/
-    ├── universe.json          All bodies, rings, and asteroid belts
-    └── shaders/
-        ├── phong.vert/frag        Planet sphere (ray-sphere intersection)
-        ├── atm.vert/frag          Atmospheric limb glow
-        ├── solid.vert/frag        Orbital trail lines
-        ├── color.vert/frag        Starfield GL_POINTS
-        ├── ring.vert              Keplerian ring particles
-        ├── ring_sprite.vert/frag  Saturn-specific sprite rings
-        ├── ring_sprite_generic.frag  Generic sprite rings (Uranus/Neptune)
-        ├── asteroid_particle.vert Asteroid belt GL_POINTS
-        ├── impact_particle.vert/frag  Collision debris
-        ├── label.vert/frag        Body name billboard quads
-        ├── star_glare.vert/frag   Star halo glow
-        ├── build_line.vert/frag   Build mode preview lines
-        └── ui.vert/frag           2D screen-space HUD
+### Description
+What went wrong?
+
+### Steps to Reproduce
+1. ...
+2. ...
+
+### Expected Behaviour
+What should have happened?
+
+### Actual Behaviour
+What happened instead?
+
+### Environment
+- OS:
+- GPU / Driver:
+- Build type (Debug / Release):
+
+### Additional Context
+Screenshots, logs, or anything else relevant.
 ```
 
 ---
 
-## 3. Build System
+## 3. Requesting Features
 
-**File:** `Makefile`
+Open an **Issue** and apply the `enhancement` label.
 
-The Makefile auto-detects the platform (Linux / macOS / Windows MSYS2 MinGW64) and sets include paths and linker flags accordingly.
-
-**Dependencies:**
-- SDL2 (windowing, input, OpenGL context)
-- SDL2_ttf (font rendering for labels and HUD)
-- GLEW (OpenGL extension loading)
-- OpenGL 3.3+
-- OpenMP (parallelises multi-star-system warmup)
-
-**Build on Windows (MSYS2 MinGW64 shell):**
-```bash
-cd OpenVerse
-mingw32-make
 ```
+### Summary
+One-sentence description of the feature.
 
-**Build on Linux/macOS:**
-```bash
-cd OpenVerse
-make
-```
+### Motivation
+Why is this useful? What problem does it solve?
 
-**Key compiler flags:** `-O2 -std=c99 -Wall -Wextra -fopenmp`
+### Proposed Approach
+How might it be implemented? Reference relevant files from ARCHITECTURE.md if applicable.
 
-**Clean:**
-```bash
-make clean   # removes .o files and the executable
+### Alternatives Considered
+Other approaches you thought about and why you ruled them out.
 ```
 
 ---
 
-## 4. Core Data Structures
+## 4. Branching Strategy
 
-### `Body` — `src/body.h`
-
-The fundamental simulation unit. Every star, planet, moon, and test particle is a `Body`.
-
-```c
-typedef struct {
-    char   name[32];       // Display name ("Earth", "Luna", ...)
-    double mass;           // kg
-    double radius;         // metres (physical)
-
-    // World-frame simulation state (SI units)
-    double pos[3];         // metres, origin = solar system barycenter
-    double vel[3];         // m/s
-    double acc[3];         // m/s² — recomputed each physics step
-    double fast_acc[3];    // dominant parent force, used by RESPA inner loop
-
-    // Rendering
-    float  col[3];         // RGB [0..1]
-    int    is_star;        // 1 = star, 0 = planet/moon
-
-    // Lifecycle
-    int    alive;          // 0 = removed/absorbed; index is never reused
-    int    parent;         // index into g_bodies; -1 for stars
-
-    // Adaptive timestep hints (computed by physics_refresh_timestep_model)
-    double dyn_period;     // estimated orbital period (seconds)
-    double dyn_dt_outer;   // recommended slow-force timestep
-    double dyn_dt_inner;   // recommended fast-force timestep
-    int    dyn_bucket;     // 0 (slow) .. 3 (very fast)
-
-    // Rotation
-    double obliquity;      // axial tilt in degrees
-    double rotation_rate;  // rad/s
-    double rotation_angle; // current phase [0, 2π]
-
-    // Atmosphere (zero values = no atmosphere)
-    float  atm_color[3];
-    float  atm_intensity;
-    float  atm_scale;      // outer radius as multiple of body radius
-
-    // Orbital trail (circular buffer, heap-allocated)
-    double trail_interval; // seconds between trail samples
-    double trail_accum;    // accumulator
-    int    trail_head;     // next write index
-    int    trail_count;    // valid samples [0, TRAIL_LEN]
-    double (*trail)[3];    // TRAIL_LEN × 3 doubles (AU-scale positions)
-} Body;
-```
-
-**Key invariants:**
-- `parent = -1` for stars; `parent >= 0` for everything else
-- `alive = 0` marks a dead body — its slot in `g_bodies[]` is never recycled
-- Positions are in **metres**; the renderer divides by `AU` before upload
-
-**Global state:**
-```c
-Body *g_bodies;      // dynamically allocated array (body.h)
-int   g_nbodies;     // live count
-int   g_bodies_cap;  // allocated capacity
-```
-
----
-
-### `Camera` — `src/camera.h`
-
-```c
-typedef struct {
-    double pos[3];   // AU (double precision — needed at interstellar distances)
-    float  yaw;      // degrees, horizontal
-    float  pitch;    // degrees, vertical
-    float  speed;    // AU/s movement speed
-} Camera;
-
-extern Camera g_cam;
-extern int    g_warp;  // 1 if warp mode active
-```
-
----
-
-### `ParticleDisc` — `src/rings.h`
-
-Represents one ring system. Particles are simulated Keplerianly: mean anomaly advances on the CPU each step; the GPU solves Kepler's equation per-vertex to get position.
-
-Each particle is stored as 8 floats:
-`[M, a, e, ω, h, r, g, b]`
-— mean anomaly (rad), semi-major axis (AU), eccentricity, argument of periapsis (rad), vertical offset (AU), RGB color.
-
----
-
-### `CollisionSpot` — `src/collision.h`
-
-```c
-typedef struct {
-    float dir[3];          // body-local unit direction (impact location on surface)
-    float angular_radius;  // radians (extent of visual effect)
-    float heat;            // [0, 1] — cooled intensity (decreases over time)
-    float progress;        // [0, 1] — event lifecycle
-    int   kind;            // 1=crater, 2=major, 3=merge, 4=intersect
-} CollisionSpot;
-```
-
-Up to 16 spots per body, passed as uniform arrays to `phong.frag`.
-
----
-
-### `BuildPreset` — `src/build.h`
-
-```c
-typedef struct {
-    const char *name;
-    double mass;
-    double radius;
-    float  col[3];
-    int    is_star;
-    int    wants_planet_parent;
-    int    wants_nonstar_parent;
-    float  atm_color[3];
-    float  atm_intensity;
-    float  atm_scale;
-} BuildPreset;
-```
-
-6 presets: Rocky, Gas Giant, Ice World, Moon, Dwarf Planet, Star.
-
----
-
-### `JsonNode` — `src/json.h`
-
-```c
-typedef struct JsonNode {
-    JsonType    type;         // NULL, BOOL, NUMBER, STRING, ARRAY, OBJECT
-    char       *key;          // object member key (NULL for array elements)
-    double      number;
-    char       *string;
-    int         boolean;
-    JsonNode   *first_child;  // first child of OBJECT or ARRAY
-    JsonNode   *next;         // next sibling
-} JsonNode;
-```
-
----
-
-## 5. Module Reference
-
-### `main.c` — Entry Point & Event Loop
-
-**Location:** `src/main.c` (~495 lines)
-
-The top-level orchestrator. Owns:
-- SDL2 / OpenGL initialisation and teardown
-- The main loop: event handling → physics → render → swap
-- Per-frame camera movement
-- Simulation speed control (`g_sim_speed`, `g_paused`)
-- RESPA physics scheduling (outer/inner step counts per system)
-- 2-year warmup pre-simulation before the loop starts
-
-**Key sections:**
-| Lines (approx.) | What happens |
+| Branch | Purpose |
 |---|---|
-| Startup | SDL/GL init, shader loading, `universe_load()`, `render_init()`, warmup |
-| `handle_events()` | Keyboard (WASD, +/-, B, T, Space, Escape), mouse look |
-| `camera_move()` | Apply camera velocity each frame |
-| Physics block | `physics_refresh_timestep_model()`, RESPA loops per system, `collision_step()`, `asteroids_step()`, `rings_tick()` |
-| Render block | Build matrices, call `render_frame()`, `ui_render()`, swap |
+| `main` | Always stable and buildable. Direct commits are not allowed. |
+| `feat/<name>` | New features (e.g. `feat/jupiter-moons`) |
+| `fix/<name>` | Bug fixes (e.g. `fix/ring-lod-flicker`) |
+| `docs/<name>` | Documentation only (e.g. `docs/architecture-update`) |
+| `refactor/<name>` | Refactoring without behaviour change |
 
-**Simulation speed table** (days/real-second):
+**Rules:**
+- Branch off `main`, merge back into `main` via PR.
+- Keep branches focused — one feature or fix per branch.
+- Delete the branch after the PR is merged.
+
+---
+
+## 5. Submitting a Pull Request
+
+1. Make sure the project builds without warnings (`-Wall -Wextra`).
+2. Test the change at multiple simulation speeds and zoom levels.
+3. Open a PR against `main` with the following format:
+
+**Title:** `[type] Short description` — e.g. `[feat] Add Galilean moons for Jupiter`
+
+**Body:**
+
 ```
-0.0, 0.1, 0.25, 0.5, 1.0, 2.0, 5.0, 10.0, 30.0, 60.0, 100.0, 365.0
-```
-Cycled with `+` / `-` keys.
+### What does this PR do?
+Short summary of the change.
 
-**Warp mode** (T key): clamps camera speed to [200, 63241] AU/s (~0.003–1 ly/s).
+### Related Issue
+Closes #<issue number> (if applicable)
 
----
+### Changes
+- file.c: what changed and why
+- shader.frag: what changed and why
 
-### `body.c` / `body.h` — Body Data & Keplerian Mechanics
+### Testing
+How did you verify the change? What did you check for regressions?
 
-**Location:** `src/body.c` (~233 lines), `src/body.h` (~76 lines)
-
-Owns the global body array and provides orbital mechanics utilities.
-
-**Functions:**
-
-| Function | Signature | Purpose |
-|---|---|---|
-| `keplerian_to_state` | `(a, e, i, Omega, omega_tilde, L, gm, pos[], vel[])` | Heliocentric Keplerian elements → Cartesian state. Uses JPL J2000 element convention (longitude of perihelion `ω̃ = Ω + ω`, mean longitude `L = ω̃ + M`). Rotates from ecliptic to GL frame (Y↔Z swap). |
-| `moon_to_state` | `(a_km, e, i, Omega, omega, M0, gm, pos[], vel[])` | Planetocentric Keplerian elements → state (moons). Uses standard ω (argument of periapsis, not longitude). |
-| `nearest_star_idx` | `(void) → int` | Returns index of the star closest to `g_cam.pos`. Used for lighting direction. |
-| `body_root_star` | `(int i) → int` | Walks the parent chain upward, returns root star index. |
-| `body_world_to_local_surface_dir` | `(int idx, double world_dir[3], float out[3])` | Converts a world-frame direction into body-local frame (accounting for obliquity and rotation angle). Used to place collision spots on the correct surface location. |
-
-**Keplerian solver** (internal `solve_kepler`): Newton-Raphson, converges in 3–5 iterations for typical eccentricities, capped at 50 for robustness.
-
----
-
-### `physics.c` / `physics.h` — N-Body RESPA Integrator
-
-**Location:** `src/physics.c` (~400 lines), `src/physics.h` (~52 lines)
-
-Implements a **2R-RESPA** (Reference System Propagator Algorithm) hierarchical integrator:
-
-- **Slow forces** (outer, ~1 day timestep): planet-planet interactions + non-parent perturbations on moons
-- **Fast forces** (inner, ~0.02 day timestep): dominant parent → satellite force
-
-This gives ~32× efficiency over uniform short-timestep integration.
-
-**Global state:**
-```c
-double g_sim_time;    // seconds elapsed since epoch
-double g_sim_speed;   // seconds of sim per real second
-int    g_paused;      // 1 = paused
-```
-
-**Public functions:**
-
-| Function | Purpose |
-|---|---|
-| `physics_respa_begin(dt_outer)` | Slow half-kick: `v += 0.5 * a_slow * dt` for all bodies |
-| `physics_respa_inner(dt_inner)` | Fast KDK step: compute parent force, half-kick, drift, half-kick |
-| `physics_respa_end(dt_outer)` | Slow half-kick (second half) + rotation advance |
-| `physics_respa_begin_system(root, dt)` | Per-star-system variant of begin |
-| `physics_respa_inner_system(root, dt)` | Per-star-system inner step |
-| `physics_respa_end_system(root, dt)` | Per-star-system end |
-| `physics_refresh_timestep_model()` | Recompute `dyn_period`, `dyn_dt_outer`, `dyn_dt_inner` for all bodies |
-| `physics_outer_dt_limit()` | Minimum outer dt across all systems |
-| `physics_inner_dt_limit()` | Minimum inner dt across all systems |
-| `physics_system_count()` | Number of independent star systems |
-| `physics_system_root(idx)` | Root star index of system `idx` |
-| `physics_system_outer_dt_limit(idx)` | Per-system outer dt limit |
-| `physics_system_inner_dt_limit(idx)` | Per-system inner dt limit |
-| `physics_advance_time(dt)` | Increment `g_sim_time` |
-| `physics_step(dt)` | Legacy single-step KDK (for compatibility) |
-
-**Internal helpers** (not exposed in header):
-- `is_satellite(i)` — body has a non-star parent
-- `has_fast_parent(i)` — body should use fast RESPA forces
-- `timestep_anchor(i)` — find the dominant gravitational body for timestep estimation
-- `estimate_period_about(i, anchor)` — estimate orbital period via Kepler's 3rd law
-- `solve_kepler(M, e)` — Newton-Raphson Kepler solver
-
-**Timestep model** (`physics_refresh_timestep_model`):
-1. For each body: find dynamical anchor (explicit parent or nearest massive body)
-2. Estimate period: `T = 2π√(r³/GM)`
-3. `dt_outer = T / 24`, clamped to [0.05 day, 1 day]
-4. `dt_inner = T / 96`, clamped to [60 s, 0.02 day]
-5. Per-system limit = minimum across all bodies in that system
-
----
-
-### `universe.c` / `universe.h` — JSON Universe Loader
-
-**Location:** `src/universe.c` (~300 lines), `src/universe.h` (~44 lines)
-
-Parses `assets/universe.json` and populates `g_bodies`. Also provides the runtime body creation interface used by build mode and collision merges.
-
-**`BodyCreateSpec`** (universe.h): flat struct describing a body to create at runtime (name, mass, radius, pos, vel, col, is_star, parent, obliquity, rotation_rate, atmosphere params).
-
-**Functions:**
-
-| Function | Purpose |
-|---|---|
-| `universe_load(path)` | Parse JSON, create all bodies in 3 passes: 1) stars, 2) planets/dwarf planets, 3) moons. Applies centre-of-mass velocity correction per star system. |
-| `universe_add_body(spec)` | Add a single body at runtime (build mode, collision merge). Returns new body index. Allocates trail buffer. |
-| `universe_rebind_to_nearest_stars()` | Reassign orphaned planets to the nearest star (used after a star is added via build mode). |
-| `universe_shutdown()` | Free all trail buffers and `g_bodies`. |
-
-**Load order matters:** stars must exist before planets (parent lookup by name), planets before moons.
-
----
-
-### `render.c` / `render.h` — Scene Renderer
-
-**Location:** `src/render.c` (~600 lines), `src/render.h` (~24 lines)
-
-The scene compositor. Owns sphere mesh geometry, all body-level GL programs, and delegates to sub-renderers (trails, labels, rings, asteroids, etc.).
-
-**Functions:**
-
-| Function | Purpose |
-|---|---|
-| `render_init()` | Compile all shaders (`phong`, `atm`, `solid`, `color`, `star_glare`, `impact_particle`, `label`, `build_line`). Generate sphere mesh VAO/VBO. |
-| `render_frame(view, proj, view_rot, dt)` | Draw one complete frame (see [Rendering Pipeline](#9-rendering-pipeline)). |
-| `render_shutdown()` | Release all GL resources. |
-
-**Internal render passes** (called inside `render_frame`):
-- `render_spheres()` — iterate `g_bodies`, draw one billboard quad per body via `phong.vert/frag`
-- `render_atmospheres()` — additive glow pass for bodies with `atm_intensity > 0`
-- `render_dots()` — GL_POINTS at body centres, plus star glare quads
-- `render_collision_particles()` — impact debris (max 768 particles via `collision_particles()`)
-- `render_build_preview()` — build mode ghost sphere and distance lines
-
-**Logarithmic depth:** All shaders write `gl_FragDepth = log2(eye_depth + 1) / log2(FAR + 1)` (FAR = 2000 AU). This prevents z-fighting across the 14+ orders of magnitude from cm to light-years.
-
----
-
-### `trails.c` / `trails.h` — Orbital Trail Rendering
-
-**Location:** `src/trails.c` (~250 lines), `src/trails.h` (~23 lines)
-
-Renders the coloured polylines showing orbital paths.
-
-**Design decisions:**
-- Positions stored camera-relative (double precision CPU → float VBO) to avoid float precision loss at large distances
-- Sampling rate: `~T/400` where T is orbital period, so ~400 samples per orbit
-- Dirty tracking: VBO re-uploaded only when new samples added OR camera moved (avoids unnecessary GPU traffic)
-- Circular buffer of `TRAIL_LEN` (4096) samples per body
-
-**Functions:**
-
-| Function | Purpose |
-|---|---|
-| `trails_gl_init()` | Allocate VAOs/VBOs for all initial bodies |
-| `trails_add_body(idx)` | Create GL buffers for a newly added body (build mode) |
-| `trails_remove_body(idx)` | Delete GL resources for a removed body |
-| `trails_reset_body(idx)` | Re-seed trail after discontinuous position change (e.g., capture) |
-| `trails_render(vp[16])` | Upload dirty VBOs and draw all trails as `GL_LINE_STRIP` |
-
-Trails fade when camera distance > `SYS_TRAIL_FADE_END` (1200 AU, defined in `common.h`).
-
----
-
-### `labels.c` / `labels.h` — Body Name Labels
-
-**Location:** `src/labels.c` (~300 lines), `src/labels.h` (~36 lines)
-
-Renders body name labels using SDL_ttf pre-rendered textures on billboard quads.
-
-**`BodyRenderInfo`** (labels.h):
-```c
-typedef struct {
-    float pos[3];  // GL/AU world position
-    float dr;      // visual radius (AU)
-    float dcam;    // camera distance (AU)
-    int   show;    // 1 if body is too small to see as disc
-} BodyRenderInfo;
-```
-
-**Overlap avoidance:** Greedy AABB sweep — labels are sorted by camera distance, then accepted left-to-right only if their bounding box does not overlap any already-placed label.
-
-**Hysteresis:** `SHOW_DELAY` / `HIDE_DELAY` timers prevent flickering when a body crosses the show/hide threshold.
-
-**Functions:**
-
-| Function | Purpose |
-|---|---|
-| `labels_init()` | Load font (SDL_ttf), pre-render name textures for all bodies |
-| `labels_add_body(idx)` | Create cached text texture for a new body |
-| `labels_remove_body(idx)` | Release label texture |
-| `labels_render(view, proj, vp, info, dt)` | Project each body to screen, run overlap avoidance, draw billboard quads |
-| `labels_shutdown()` | Cleanup |
-
-The Sun always renders at highest priority. Non-star labels are hidden past `MAX_LABEL_DIST` (55 AU).
-
----
-
-### `starfield.c` / `starfield.h` — Background Stars
-
-**Location:** `src/starfield.c` (~105 lines), `src/starfield.h` (~12 lines)
-
-4000 procedurally generated background stars distributed on the unit sphere.
-
-**Spectral type color distribution:**
-| Type | Fraction | Color |
-|---|---|---|
-| O/B | 3% | Blue-white |
-| A | 10% | White |
-| F | 17% | Yellow-white |
-| G | 25% | Yellow |
-| K | 23% | Orange |
-| M | 22% | Red |
-
-**Functions:**
-
-| Function | Purpose |
-|---|---|
-| `starfield_init()` | Generate 4000 stars with realistic spectral colors (constant seed for reproducibility) |
-| `starfield_render(view_rot, proj)` | Draw as `GL_POINTS` using rotation-only VP matrix (stars stay fixed) |
-| `starfield_shutdown()` | Cleanup |
-
-Two LOD tiers: 1px points (most stars) and 2px points (last quarter of buffer).
-
----
-
-### `rings.c` / `rings.h` — Planetary Ring System
-
-**Location:** `src/rings.c` (~400 lines), `src/rings.h` (~65 lines)
-
-Keplerian ring particle systems for Saturn, Uranus, and Neptune.
-
-**Physics model:** Each ring particle orbits independently. CPU advances mean anomaly `M += n·dt` each step; GPU solves Kepler's equation per-vertex to get 3D position.
-
-**LOD strategy** (camera distance to ring parent):
-| Distance | Mode |
-|---|---|
-| > 0.2 AU | Flat sprite quad (procedural texture, 1 draw call) |
-| 0.05–0.2 AU | Reduced Keplerian particles (`n_lod`) |
-| < 0.05 AU | Full Keplerian particles (`n_full`) |
-
-**Particle data layout** (8 floats per particle):
-`[M, a, e, ω, h, r, g, b]`
-
-**Functions:**
-
-| Function | Purpose |
-|---|---|
-| `rings_init(path)` | Parse ring zones from JSON, generate particle arrays, upload VBOs, compile shaders |
-| `rings_tick(dt)` | Advance mean anomalies: `M[i] += n[i] * dt` |
-| `rings_render(vp)` | LOD selection + draw (Keplerian particles or sprite quad) |
-| `rings_on_body_absorbed(target, impactor)` | Update parent index after a collision merge |
-| `rings_shutdown()` | Cleanup |
-
-Saturn uses a hardcoded Cassini-division-aware sprite shader (`ring_sprite.frag`). Other planets use a generic uniform-driven sprite (`ring_sprite_generic.frag`).
-
----
-
-### `asteroids.c` / `asteroids.h` — Asteroid Belts
-
-**Location:** `src/asteroids.c` (~350 lines), `src/asteroids.h` (~7 lines)
-
-Gravity-integrated test particles for the Main Belt and Kuiper Belt.
-
-**Integration:** Symplectic Euler at the outer RESPA rate (~1 day). Particles are test particles (no back-reaction on planets).
-
-**Optimisations:**
-- Only loop over non-moon bodies (~14 vs 33 total) — saves ~2.5× pair evaluations
-- Cache major-body positions per outer step for CPU L1 hit rate
-- Upload positions camera-relative each frame
-- Additive blending to avoid saturation on dense regions
-
-**Functions:**
-
-| Function | Purpose |
-|---|---|
-| `asteroids_init(path)` | Parse belt configs from JSON, generate particles with Keplerian initial conditions |
-| `asteroids_step(dt)` | Gravity-integrate all belt particles one outer step |
-| `asteroids_render(vp_camrel)` | Upload camera-relative positions, draw as `GL_POINTS` (1–3 px) |
-| `asteroids_shutdown()` | Cleanup |
-
-LOD fade parameters (`fade_start_au`, `fade_end_au`) per belt, defined in `universe.json`.
-
----
-
-### `collision.c` / `collision.h` — Impact & Merge System
-
-**Location:** `src/collision.c` (~700 lines), `src/collision.h` (~39 lines)
-
-Handles solid-body collisions: detection, merge physics, and visual effects.
-
-**Collision types** (`CollisionVisualKind`):
-| Kind | Name | Description |
-|---|---|---|
-| 1 | `COLLISION_VIS_CRATER` | Small impactor — local hot spot, cools over ~45 sim-days |
-| 2 | `COLLISION_VIS_MAJOR` | Large impactor — wide ash cloud + molten interior, cools over ~90 sim-days |
-| 3 | `COLLISION_VIS_MERGE` | Bodies sinking into each other (MERGE_PHASE_SECONDS ~8 sim-days) |
-| 4 | `COLLISION_VIS_INTERSECT` | Live sphere-sphere boundary — bright molten cap at overlap region |
-
-**Functions:**
-
-| Function | Purpose |
-|---|---|
-| `collision_step(dt)` | Broadphase sphere-sphere checks, initiate merges, update active collision spots |
-| `collision_spots_for_body(idx, spots[16])` | Return array of active `CollisionSpot` for a body (passed to phong.frag as uniforms) |
-| `collision_on_body_added(idx)` | Mark parent system for hot broadphase checks |
-| `collision_visual_radius(idx, physical_radius)` | Returns inflated visual radius during merge (bodies look larger while sinking) |
-| `collision_body_heat_glow(idx, col, intensity, scale)` | Returns atmospheric glow params driven by active impacts |
-| `collision_body_has_active_merge(idx)` | True if body is currently in merge phase |
-| `collision_particles(out, max, cam_pos)` | Fill array of up to 768 `CollisionParticle` for the impact debris renderer |
-
-When a merge completes, the smaller body is removed (`alive = 0`), and the larger body receives the combined mass and momentum. `trails`, `labels`, and `rings` are notified to clean up.
-
----
-
-### `build.c` / `build.h` — Sandbox Body Placement
-
-**Location:** `src/build.c` (~400 lines), `src/build.h` (~37 lines)
-
-Interactive mode allowing the user to place new bodies into the simulation at runtime.
-
-**Global state:**
-```c
-int g_build_mode;      // 1 if build mode is active
-int g_build_tab_held;  // 1 if Tab is held (scroll wheel changes preset)
-```
-
-**Functions:**
-
-| Function | Purpose |
-|---|---|
-| `build_init()` | Initialise |
-| `build_toggle()` | Enter/exit build mode (pauses simulation while active) |
-| `build_set_tab_held(held)` | Track Tab key state |
-| `build_scroll(wheel_y)` | Adjust placement distance (or cycle presets if Tab held) |
-| `build_place_current()` | Place body at preview position; calls `universe_add_body()`, `trails_add_body()`, `labels_add_body()`, `collision_on_body_added()`; returns new body index |
-| `build_preset_count()` | 6 |
-| `build_selected_index()` | Current preset (0–5) |
-| `build_current_preset()` | Pointer to current `BuildPreset` |
-| `build_preset_at(idx)` | Preset at given index |
-| `build_preview_pos_au(out[3])` | Preview position in AU |
-| `build_preview_pos_m(out[3])` | Preview position in metres |
-| `build_nearest3(pos_m, out_idx[3], out_dist_au[3])` | Find the 3 nearest bodies to a given position |
-
-Placement velocity is computed to give the new body a circular orbit around the nearest parent (or zero if no suitable parent).
-
----
-
-### `ui.c` / `ui.h` — 2D HUD Overlay
-
-**Location:** `src/ui.c` (~300 lines), `src/ui.h` (~10 lines)
-
-Renders a 2D screen-space HUD using `ui.vert` / `ui.frag` (orthographic projection).
-
-**HUD elements:**
-- **Speed bar** (top-left): log-normalised camera speed fill graphic
-- **Speed text**: movement speed (AU/s) and simulation speed (days/s)
-- **FPS counter**: exponential moving average
-- **Build mode info**: selected preset name and instructions (when active)
-
-**Functions:**
-
-| Function | Purpose |
-|---|---|
-| `ui_init()` | Load font, prepare text caches, compile `ui.vert/frag` |
-| `ui_render()` | Draw all HUD elements |
-| `ui_shutdown()` | Cleanup |
-
----
-
-### `camera.c` / `camera.h` — Free-Look Camera
-
-**Location:** `src/camera.c` (~28 lines), `src/camera.h` (~22 lines)
-
-Minimal camera state. Movement and mouse look are handled in `main.c`; this module only owns the state and provides direction computation.
-
-**Functions:**
-
-| Function | Purpose |
-|---|---|
-| `cam_reset()` | Reset to default view (pos=[0,3,6] AU, looking at origin) |
-| `cam_get_dir(dx, dy, dz)` | Compute forward unit vector from `g_cam.yaw` and `g_cam.pitch` |
-
----
-
-### `json.c` / `json.h` — JSON Parser
-
-**Location:** `src/json.c` (~400 lines), `src/json.h` (~59 lines)
-
-A minimal recursive-descent JSON parser with two extensions: `//` line comments and scientific notation (via `strtod`).
-
-**Functions:**
-
-| Function | Purpose |
-|---|---|
-| `json_parse_file(path)` | Read file and return root `JsonNode *` |
-| `json_parse(text)` | Parse NUL-terminated string |
-| `json_free(root)` | Recursively free tree |
-| `json_get(obj, key)` | Find object member by key |
-| `json_idx(arr, i)` | Get array element by index |
-| `json_num(node, default)` | Safe number accessor |
-| `json_str(node, default)` | Safe string accessor |
-| `json_bool(node, default)` | Safe boolean accessor |
-
----
-
-### `gl_utils.c` / `gl_utils.h` — OpenGL Helpers
-
-**Location:** `src/gl_utils.c` (~90 lines), `src/gl_utils.h` (~31 lines)
-
-Thin wrappers for boilerplate OpenGL operations used across multiple modules.
-
-**Functions:**
-
-| Function | Purpose |
-|---|---|
-| `gl_shader_load(vert_path, frag_path)` | Read, compile, and link a GLSL program; prints errors; returns `GLuint` program ID |
-| `gl_vao_create()` | Create and bind a VAO |
-| `gl_vbo_create(bytes, data, usage)` | Create VBO and optionally upload data |
-| `gl_ebo_create(bytes, data)` | Create and upload an element index buffer |
-
-Every module that uses shaders or GPU buffers calls these helpers instead of raw GL.
-
----
-
-### `common.h` — Shared Constants
-
-**Location:** `src/common.h` (~60 lines)
-
-Included by almost every file. Defines all physical and rendering constants:
-
-| Constant | Value | Meaning |
-|---|---|---|
-| `DEFAULT_WIN_W/H` | 1280 / 720 | Default window size |
-| `FOV` | 60° | Vertical field of view |
-| `PI` | 3.14159… | π |
-| `AU` | 1.496e11 | Metres per AU |
-| `DAY` | 86400 | Seconds per day |
-| `G_CONST` | 6.674e-11 | Gravitational constant |
-| `GM_SUN` | AU³/day² | Solar GM in simulation units |
-| `SOFTENING` | 1e5 m | Gravitational softening radius |
-| `GRAV_EPSILON` | 1e-14 m/s² | Minimum gravity threshold |
-| `MAX_BODIES` | 128 | Maximum body array capacity |
-| `TRAIL_LEN` | 4096 | Trail samples per body |
-| `NUM_STARS` | 4000 | Background star count |
-| `RS` | 1/AU | Metres → GL unit scale factor |
-| `SYS_TRAIL_FADE_START/END` | AU | Trail LOD fade range |
-| `SYS_DOT_FADE_START/END` | AU | Asteroid LOD fade range |
-
-Also declares `int g_win_w, g_win_h` as externals.
-
----
-
-### `math3d.h` — Header-Only 3D Math
-
-**Location:** `src/math3d.h` (~125 lines)
-
-All matrix and vector operations. Header-only (all functions are `static inline`).
-
-**Types:**
-```c
-typedef float Mat4[16];   // column-major 4×4
-typedef float Vec3[3];
-typedef float Vec4[4];
-```
-
-**Functions:**
-- `vec3_set`, `vec3_copy`, `vec3_add`, `vec3_sub`, `vec3_scale`
-- `vec3_dot`, `vec3_len`, `vec3_normalize`, `vec3_cross`
-- `mat4_mul_vec4`, `mat4_identity`, `mat4_copy`, `mat4_mul`
-- `mat4_perspective(m, fov_y_deg, aspect, near, far)`
-- `mat4_lookAt(m, eye, center, up)`
-- `mat4_get_right`, `mat4_get_up`, `mat4_get_fwd`
-- `mat4_strip_translation` — removes translation (used for skybox VP)
-- `mat4_project` — world → screen NDC projection
-
----
-
-## 6. Shader Reference
-
-All shaders live in `assets/shaders/`. They are loaded at startup by `render_init()` (and by `starfield_init()`, `trails_gl_init()`, etc.) via `gl_shader_load()`.
-
-### `phong.vert` / `phong.frag` — Planet Spheres
-
-**Technique:** Per-pixel ray-sphere intersection. The vertex shader constructs an oversized billboard quad; the fragment shader traces a ray from the camera through each pixel and intersects it with the sphere.
-
-**Key uniforms (frag):**
-- `u_center`, `u_oc`, `u_radius` — sphere geometry
-- `u_cam_right`, `u_cam_up`, `u_cam_fwd` — camera axes
-- `u_fov_tan`, `u_aspect`, `u_screen` — FOV parameters
-- `u_rotation`, `u_obliquity` — body rotation state
-- `u_planet_type` (0–9) — surface appearance:
-  - 0 = generic rocky, 1 = Earth, 2 = Mars, 3 = Venus, 4 = Jupiter, 5 = Saturn, 6 = ice giant, 7 = Io, 8 = Titan, 9 = Europa
-- `u_impact_count`, `u_impact_dir[16]`, `u_impact_radius[16]`, `u_impact_heat[16]`, `u_impact_progress[16]`, `u_impact_kind[16]` — collision visuals (up to 16 spots)
-- `u_sun_pos_world` — for Phong diffuse lighting
-- `u_emission` — > 0.5 for stars (self-luminous)
-
-**Surface texturing:** 3D FBM noise (`hash3` + `vnoise`) — no UV atlas, no texture files needed.
-
-**Logarithmic depth:** `gl_FragDepth = log2(eye_depth + 1) / log2(2001)` where `eye_depth = t * dot(ray_dir, u_cam_fwd)`.
-
----
-
-### `atm.vert` / `atm.frag` — Atmospheric Limb Glow
-
-Renders additive atmospheric glow for bodies with `atm_intensity > 0`.
-
-**Technique:** Ray-shell intersection. Glow intensity: `(1 - norm)^3` where `norm` is the normalised closest-approach distance inside the shell. Lit-side boost: `0.15 + 0.85 * clamp(sun_dot, 0, 1)`.
-
-Uses the **back face** of the atmosphere sphere for depth so that glow renders correctly behind solid bodies during merges.
-
----
-
-### `solid.vert` / `solid.frag` — Orbital Trail Lines
-
-Simple `GL_LINE_STRIP` renderer. Takes camera-relative float positions. Uses `u_count` trick: if `u_count = 0`, renders fully opaque (used for pole axis lines in earlier versions). Logarithmic depth.
-
----
-
-### `ring.vert` — Keplerian Ring Particles
-
-Solves Kepler's equation on the GPU per vertex:
-1. Newton-Raphson: `M = E - e·sin(E)` → eccentric anomaly E
-2. True anomaly: `ν = 2·atan2(√(1+e)·sin(E/2), √(1-e)·cos(E/2))`
-3. Orbital radius: `r = a(1 - e·cos(E))`
-4. 3D position via ring-plane basis vectors `u_b1`, `u_b2`
-
-Input attributes: `M`, `a`, `e`, `ω`, `h` (vertical offset), `r/g/b`.
-
----
-
-### `ring_sprite.frag` / `ring_sprite_generic.frag` — Ring Sprites
-
-Far-LOD ring rendering: a single quad textured procedurally.
-- `ring_sprite.frag`: Saturn-specific hardcoded Cassini-division zone map
-- `ring_sprite_generic.frag`: uniform-driven (`u_r_inner`, `u_r_outer`, `u_ring_color`, `u_alpha_max`) for Uranus/Neptune
-
----
-
-### `asteroid_particle.vert` — Asteroid GL_POINTS
-
-Camera-relative GL_POINTS with size ramp (1→3 px) and distance-based fade driven by `u_fade_start` / `u_fade_end`. Additive blending.
-
----
-
-### `impact_particle.vert` / `impact_particle.frag` — Collision Debris
-
-Per-particle size and RGBA. Fade over particle lifetime. Used for the debris cloud emitted on large impacts.
-
----
-
-### `label.vert` / `label.frag` — Body Name Labels
-
-Billboard quad constructed in the vertex shader from `u_right` and `u_up` (camera basis). Fragment shader: texture lookup, transparent regions discarded. Font pre-rendered with SDL_ttf.
-
----
-
-### `star_glare.vert` / `star_glare.frag` — Star Halos
-
-Extra-large quad centered on each star. Radial gradient fades to transparent. Fades in based on star's projected size on screen.
-
----
-
-### `ui.vert` / `ui.frag` — 2D HUD
-
-Screen-space orthographic projection. `u_use_tex` selects solid colour (speed bar fill) or textured (text quads).
-
----
-
-### `build_line.vert` / `build_line.frag` — Build Mode Preview
-
-Lines from placement preview position to the 3 nearest bodies. White = acceptable distance, red = too close.
-
----
-
-## 7. Universe Data Format
-
-**File:** `assets/universe.json`
-
-The single source of truth for all simulation content. Supports `//` line comments.
-
-### Stars
-
-```json
-{
-  "name": "Sun",
-  "type": "star",
-  "pos_ly": [0.0, 0.0, 0.0],
-  "mass": 1.989e30,
-  "radius_km": 696000.0,
-  "color": [1.0, 0.92, 0.23],
-  "obliquity_deg": 7.25,
-  "rotation_period_days": 25.38
-}
-```
-
-### Planets (Keplerian elements, JPL J2000)
-
-```json
-{
-  "name": "Earth",
-  "type": "planet",
-  "parent": "Sun",
-  "mass": 5.972e24,
-  "radius_km": 6371.0,
-  "color": [0.29, 0.48, 0.78],
-  "obliquity_deg": 23.44,
-  "rotation_period_days": 0.9973,
-  "atmosphere": { "color": [0.4, 0.6, 1.0], "intensity": 0.55, "scale": 1.03 },
-  "keplerian": {
-    "a_au": 1.00000261,
-    "e": 0.01671123,
-    "i_deg": -0.00001531,
-    "Omega_deg": 0.0,
-    "omega_tilde_deg": 102.93768193,
-    "L_deg": 100.46457166,
-    "epoch_jd": 2451545.0
-  }
-}
-```
-
-### Moons (planetocentric Keplerian)
-
-```json
-{
-  "name": "Luna",
-  "type": "moon",
-  "parent": "Earth",
-  "mass": 7.342e22,
-  "radius_km": 1737.4,
-  "color": [0.72, 0.72, 0.68],
-  "moon_keplerian": {
-    "a_km": 384400.0,
-    "e": 0.0549,
-    "i_deg": 5.16,
-    "Omega_deg": 125.08,
-    "omega_deg": 318.15,
-    "M0_deg": 115.3654
-  }
-}
-```
-
-### Rings
-
-```json
-{
-  "parent": "Saturn",
-  "n_full": 4096,
-  "n_lod": 512,
-  "zones": [
-    { "r_min_km": 66900.0, "r_max_km": 74500.0, "density": 0.15, "color": [0.85, 0.82, 0.70] }
-  ]
-}
-```
-
-### Asteroid Belts
-
-```json
-{
-  "name": "Main Belt",
-  "parent": "Sun",
-  "a_au": 2.87,
-  "e": 0.15,
-  "i_deg": 1.86,
-  "Omega_deg": 73.0,
-  "omega_deg": 100.0,
-  "count": 10000,
-  "color": [0.6, 0.6, 0.55],
-  "fade_start_au": 10.0,
-  "fade_end_au": 50.0
-}
+### Screenshots / Videos
+(For visual changes — before/after if possible)
 ```
 
 ---
 
-## 8. Physics Deep Dive
+## 6. Code Review Process
 
-### RESPA Force Split
+- Every PR needs **at least one approving review** before merge.
+- The reviewer aims to respond within **7 days**. If there is no response after a week, feel free to ping in the PR comments.
+- Address all review comments before requesting a re-review.
+- The author merges after approval (not the reviewer).
 
-Forces are split into:
-- **Slow:** All body-body gravitational pairs *except* the dominant parent-satellite pair (~O(N²) for N primaries, updated every outer step `dt_outer ~1 day`)
-- **Fast:** Dominant parent → satellite force only (updated every inner step `dt_inner ~0.02 day`)
-
-For a moon, the dominant parent force is ~10³× larger than tidal perturbations — so using a 50× shorter inner timestep on only that force pair is ~32× more efficient than stepping everything at inner rate.
-
-### One Outer Step
-
-```
-physics_respa_begin_system(root, dt_outer)
-    v[all] += 0.5 * a_slow[all] * dt_outer
-
-    for i in range(n_inner):
-        physics_respa_inner_system(root, dt_inner)
-            compute fast_acc[satellites] = gravity from parent only
-            v[all]   += 0.5 * fast_acc * dt_inner
-            pos[all] += v[all] * dt_inner
-            v[all]   += 0.5 * fast_acc * dt_inner
-
-physics_respa_end_system(root, dt_outer)
-    v[all] += 0.5 * a_slow[all] * dt_outer   // second slow half-kick
-    rotation_angle[i] += rotation_rate[i] * dt_outer
-    g_sim_time += dt_outer
-```
-
-### Warmup (Pre-Simulation)
-
-Before the render loop, the simulation runs forward 2 years (`WARMUP_DT = 2 * 365 * DAY`) to populate the orbital trail buffers. Multiple star systems are warmed up in parallel via `#pragma omp parallel for schedule(dynamic)`.
-
-### Kepler Solver
-
-```c
-// Newton-Raphson: M = E - e*sin(E)
-double E = M;
-for (int k = 0; k < 50; k++) {
-    double dE = (M - E + e*sin(E)) / (1.0 - e*cos(E));
-    E += dE;
-    if (fabs(dE) < 1e-12) break;
-}
-```
-
-Converges in 3–5 iterations for `e < 0.3`; 50-iteration cap handles near-parabolic orbits.
+**What reviewers check:**
+- Does it build cleanly?
+- Are the physics/rendering changes correct?
+- Does it follow the existing code style (snake_case, `g_` globals, C99)?
+- Are new bodies/data added to `assets/universe.json` rather than hardcoded?
+- Does it handle the `alive = 0` body lifecycle correctly?
 
 ---
 
-## 9. Rendering Pipeline
+## 7. Labels
 
-Full sequence inside `render_frame()`:
-
-| Step | Function / Shader | Notes |
-|---|---|---|
-| 1 | `starfield_render()` / `color.vert/frag` | Rotation-only VP, GL_POINTS |
-| 2 | `render_spheres()` / `phong.vert/frag` | Billboard quads, ray-sphere intersection |
-| 3 | `render_atmospheres()` / `atm.vert/frag` | Additive blend, GL_SRC_ALPHA / GL_ONE |
-| 4 | `render_dots()` / `color.vert/frag` + `star_glare` | GL_POINTS + halos |
-| 5 | `trails_render()` / `solid.vert/frag` | Camera-relative polylines |
-| 6 | `rings_render()` / `ring.vert` or sprite shaders | LOD: particles ↔ sprite |
-| 7 | `asteroids_render()` / `asteroid_particle.vert` | GL_POINTS, additive |
-| 8 | `render_collision_particles()` / `impact_particle.vert/frag` | Additive debris |
-| 9 | `labels_render()` / `label.vert/frag` | Billboard text quads |
-| 10 | `render_build_preview()` / `build_line.vert/frag` | Build mode only |
-| 11 | `ui_render()` / `ui.vert/frag` | Screen-space HUD |
-| 12 | `SDL_GL_SwapWindow()` | Present |
-
-**Blending modes:**
-| Pass | `glBlendFunc` |
+| Label | Meaning |
 |---|---|
-| Opaque geometry | `GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA` |
-| Atmospheres, asteroids, collision particles, ring additive | `GL_SRC_ALPHA, GL_ONE` |
-
----
-
-## 10. File Dependency Graph
-
-```
-main.c
-├── body.h, physics.h, camera.h, universe.h
-├── render.h, trails.h, labels.h, starfield.h
-├── rings.h, asteroids.h, collision.h, build.h, ui.h
-└── common.h
-
-body.c       → body.h, camera.h, math3d.h
-physics.c    → physics.h, body.h, common.h
-universe.c   → universe.h, body.h, json.h, common.h
-render.c     → render.h, body.h, camera.h, math3d.h, gl_utils.h
-             → starfield.h, trails.h, labels.h, rings.h
-             → asteroids.h, collision.h, build.h
-
-trails.c     → trails.h, body.h, camera.h, gl_utils.h, math3d.h, common.h
-labels.c     → labels.h, body.h, camera.h, gl_utils.h, math3d.h
-starfield.c  → starfield.h, gl_utils.h, common.h
-rings.c      → rings.h, body.h, json.h, gl_utils.h, math3d.h, common.h
-asteroids.c  → asteroids.h, body.h, json.h, gl_utils.h, common.h
-collision.c  → collision.h, body.h, labels.h, rings.h, trails.h, common.h
-build.c      → build.h, body.h, camera.h, physics.h, universe.h
-             → trails.h, labels.h, collision.h
-ui.c         → ui.h, camera.h, physics.h, build.h, body.h, gl_utils.h
-
-json.c       → json.h                    (standalone)
-gl_utils.c   → gl_utils.h, common.h     (standalone)
-camera.c     → camera.h                 (minimal, mostly state)
-```
-
----
-
-## 11. Adding New Features — Where to Edit
-
-### Add a new planet or moon
-→ Edit `assets/universe.json`. Add a JSON object under `"bodies"` with `"type": "planet"` or `"type": "moon"`, a `"parent"` name, and either `"keplerian"` (planet) or `"moon_keplerian"` (moon) elements. No code changes required.
-
-### Add a planet surface appearance
-→ Edit `assets/shaders/phong.frag`. Add a new `case` in the `u_planet_type` switch. Increment the type counter and assign the new index when constructing the body in `render.c` (search for `u_planet_type` uniform upload).
-
-### Add a new ring system
-→ Edit `assets/universe.json`. Add an entry to the `"rings"` array with `"parent"`, `"n_full"`, `"n_lod"`, and `"zones"`. If the planet needs a custom sprite shader, add it in `rings.c::rings_init()`.
-
-### Add a new asteroid belt
-→ Edit `assets/universe.json`. Add an entry to `"asteroid_belts"` with `"parent"`, `"a_au"`, `"e"`, `"i_deg"`, `"count"`, etc.
-
-### Add a new body type / build preset
-→ Edit `build.c`. Add a new `BuildPreset` to the `presets[]` array. No header change needed unless the preset count is hard-coded elsewhere.
-
-### Add a new rendering effect per body
-→ Add uniforms to `phong.frag`. Upload them in the sphere-draw loop in `render.c::render_spheres()`. Follow the pattern of how `u_impact_*` uniforms are set.
-
-### Add a new HUD element
-→ Edit `ui.c::ui_render()`. Use `gl_vbo_create()` for geometry and the `ui.vert/frag` shader. For text, pre-render with SDL_ttf in `ui_init()`.
-
-### Add a new physics force
-→ Edit `physics.c`. Add force computation to the appropriate section of `physics_respa_inner_system()` (fast forces, inner loop) or `physics_respa_begin/end_system()` (slow forces, outer loop). Update `physics_refresh_timestep_model()` if the new force affects timestep selection.
-
-### Change the simulation initial state
-→ Edit `assets/universe.json`. The Keplerian element format follows the JPL Horizons/Solar System Dynamics table 1 convention (a, e, i, Ω, ω̃, L at J2000 epoch).
-
-### Add support for textures
-→ The rotation angle is already tracked in `Body.rotation_angle` (updated in `physics_respa_end_system`). The obliquity is in `Body.obliquity`. Add a texture sampler to `phong.frag`, compute UV from the surface normal rotated by these values, and sample accordingly.
-
----
-
-*This document reflects the codebase as of April 2025. When in doubt, the source files are the authoritative reference.*
+| `bug` | Something is broken |
+| `enhancement` | New feature or improvement |
+| `physics` | Relates to the integrator, orbital mechanics, or collision system |
+| `rendering` | Relates to shaders, the render pipeline, or visual effects |
+| `data` | Relates to `universe.json` or body definitions |
+| `docs` | Documentation only |
+| `good first issue` | Self-contained, well-scoped — good entry point for new contributors |
+| `wontfix` | Out of scope or intentionally not addressed |

--- a/Makefile
+++ b/Makefile
@@ -11,20 +11,20 @@ SRCDIR  = src
 SRCS    = $(wildcard $(SRCDIR)/*.c)
 OBJS    = $(SRCS:.c=.o)
 
-CFLAGS  = -Wall -Wextra -O2 -std=c99 -I$(SRCDIR)
+CFLAGS  = -Wall -Wextra -O2 -std=c99 -I$(SRCDIR) -fopenmp
 
 # Auto-detect platform
 UNAME := $(shell uname -s 2>/dev/null || echo Windows)
 
 ifeq ($(UNAME), Linux)
     CFLAGS  += $(shell sdl2-config --cflags)
-    LDFLAGS  = $(shell sdl2-config --libs) -lSDL2_ttf -lGL -lGLEW -lm
+    LDFLAGS  = $(shell sdl2-config --libs) -lSDL2_ttf -lGL -lGLEW -lm -fopenmp
     EXT      =
 
 else ifeq ($(UNAME), Darwin)
     CFLAGS  += $(shell sdl2-config --cflags)
     LDFLAGS  = $(shell sdl2-config --libs) -lSDL2_ttf -lGLEW \
-               -framework OpenGL -lm
+               -framework OpenGL -lm -fopenmp
     EXT      =
 
 else
@@ -37,7 +37,7 @@ else
                -lSDL2 -lSDL2_ttf \
                -lglew32 \
                -lopengl32 -lglu32 \
-               -lm
+               -lm -fopenmp
     EXT      = .exe
 endif
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ make
 | Key / Input | Action |
 |---|---|
 | Left-click | Enter free-look (captures mouse) |
-| Escape | Exit free-look |
+| Escape | Open system menu / release mouse from free-look |
 | W / S | Move forward / backward |
 | A / D | Strafe left / right |
 | Q / E | Move down / up |

--- a/assets/shaders/atm.frag
+++ b/assets/shaders/atm.frag
@@ -86,10 +86,18 @@ void main() {
     float alpha = glow * u_atm_intensity * lit;
     if (alpha < 0.003) discard;
 
-    /* Logarithmic depth — view-direction depth, consistent with phong.frag
-     * and solid.frag / color.frag (all use eye_depth = 1/gl_FragCoord.w). */
+    /* Logarithmic depth — use the BACK face of the atmosphere sphere.
+     *
+     * Using the front face (t_atm) causes the glow of body A to render
+     * additively over body B whenever A's atmosphere front face sits in
+     * front of B's solid surface — which happens during merges because the
+     * target's atmosphere shell extends past the impactor's sphere.  The
+     * back face (t_atm_back) is always behind any solid object that sits
+     * inside the atmosphere shell, so the depth test correctly rejects the
+     * glow at pixels occupied by a closer solid body.                    */
     const float FAR = 2000.0;
-    float eye_depth  = t_atm * dot(ray_dir, u_cam_fwd);
+    float t_atm_back = -b + sqrt(max(0.0, R_atm * R_atm - p2));
+    float eye_depth  = t_atm_back * dot(ray_dir, u_cam_fwd);
     gl_FragDepth = log2(eye_depth + 1.0) / log2(FAR + 1.0);
 
     frag_color = vec4(u_atm_color * alpha, alpha);

--- a/assets/shaders/atm.frag
+++ b/assets/shaders/atm.frag
@@ -21,8 +21,6 @@
  * gl_FragDepth keeps it correctly depth-sorted against opaque geometry.
  */
 
-in vec2 v_uv;            /* [−1, +1] → outer atmosphere edge  */
-
 uniform vec3  u_oc;              /* cam − centre  (camera-relative, AU) */
 uniform float u_planet_radius;   /* inner sphere radius  (AU)           */
 uniform float u_radius;          /* outer atmosphere radius (AU)        */
@@ -40,9 +38,6 @@ uniform float u_atm_intensity;
 out vec4 frag_color;
 
 void main() {
-    /* Fast discard: billboard is square, glow disc is circular */
-    if (dot(v_uv, v_uv) > 1.0) discard;
-
     /* Per-pixel ray direction — identical formula to phong.frag */
     vec2 ndc     = (gl_FragCoord.xy / (u_screen * 0.5)) - 1.0;
     vec3 ray_dir = normalize(u_cam_fwd

--- a/assets/shaders/atm.vert
+++ b/assets/shaders/atm.vert
@@ -2,9 +2,8 @@
 /*
  * atm.vert — atmospheric glow billboard
  *
- * Sizes the quad to the outer atmosphere radius (planet_r × scale).
- * v_uv ∈ [−1, +1] maps to the outer atmosphere edge, used in atm.frag
- * only for the fast corner-discard (billboard is square, glow is circular).
+ * Sizes the quad to an oversized outer-atmosphere billboard so off-axis
+ * planets do not have their atmosphere clipped by the quad bounds.
  */
 
 layout(location = 0) in vec2 a_uv;
@@ -15,13 +14,12 @@ uniform float u_radius;      /* outer atmosphere radius (AU)  */
 uniform vec3  u_cam_right;
 uniform vec3  u_cam_up;
 
-out vec2 v_uv;
+const float BILL_SCALE = 2.0;
 
 void main() {
     vec2 off    = a_uv * 2.0 - 1.0;          /* −1 .. +1 */
     vec3 pos    = u_center
-                + u_cam_right * (off.x * u_radius)
-                + u_cam_up    * (off.y * u_radius);
-    v_uv        = off;
+                + u_cam_right * (off.x * u_radius * BILL_SCALE)
+                + u_cam_up    * (off.y * u_radius * BILL_SCALE);
     gl_Position = u_vp * vec4(pos, 1.0);
 }

--- a/assets/shaders/impact_particle.frag
+++ b/assets/shaders/impact_particle.frag
@@ -1,0 +1,26 @@
+#version 330 core
+/*
+ * impact_particle.frag — soft glowing point sprite for impact debris
+ */
+
+in vec4 v_color;
+in float v_size;
+out vec4 frag_color;
+
+void main() {
+    const float FAR = 2000.0;
+    vec2 uv = gl_PointCoord * 2.0 - 1.0;
+    float r = length(uv);
+    if (r > 1.0) discard;
+
+    gl_FragDepth = log2(1.0 / gl_FragCoord.w + 1.0) / log2(FAR + 1.0);
+
+    float compact_r = r * max(v_size, 1.0);
+    float glow = exp(-compact_r * 4.6);
+    float core = 1.0 - smoothstep(0.0, 0.34, compact_r);
+    float alpha = max(glow * 0.85, core);
+
+    vec3 hot = vec3(1.15, 1.0, 0.82);
+    vec3 col = mix(v_color.rgb, hot, 0.35);
+    frag_color = vec4(col * alpha, v_color.a * alpha);
+}

--- a/assets/shaders/impact_particle.vert
+++ b/assets/shaders/impact_particle.vert
@@ -1,0 +1,25 @@
+#version 330 core
+/*
+ * impact_particle.vert — glowing impact debris point sprites
+ *
+ * Positions are uploaded camera-relative each frame.
+ * Point size scales with camera distance so particles appear larger when
+ * close and smaller when far away.
+ */
+
+layout(location = 0) in vec3 a_pos;
+layout(location = 1) in vec4 a_color;
+layout(location = 2) in float a_size;
+
+uniform mat4 u_vp;
+
+out vec4 v_color;
+out float v_size;
+
+void main() {
+    float dist = max(length(a_pos), 0.001);
+    gl_PointSize = clamp((0.22 * a_size) / dist, 4.0 * a_size, 16.0 * a_size);
+    v_color = a_color;
+    v_size = a_size;
+    gl_Position = u_vp * vec4(a_pos, 1.0);
+}

--- a/assets/shaders/phong.frag
+++ b/assets/shaders/phong.frag
@@ -41,11 +41,11 @@ uniform float u_rotation;     /* body rotation angle, radians           */
 uniform float u_obliquity;    /* axial tilt, radians (0 = upright)      */
 uniform int   u_planet_type;  /* 0-9, selects colour recipe             */
 uniform int   u_impact_count;
-uniform vec3  u_impact_dir[4];
-uniform float u_impact_radius[4];
-uniform float u_impact_heat[4];
-uniform float u_impact_progress[4];
-uniform int   u_impact_kind[4];
+uniform vec3  u_impact_dir[16];
+uniform float u_impact_radius[16];
+uniform float u_impact_heat[16];
+uniform float u_impact_progress[16];
+uniform int   u_impact_kind[16];
 
 out vec4 frag_color;
 
@@ -75,6 +75,26 @@ float vnoise(vec3 p) {
 float fbm(vec3 p) {
     return vnoise(p)               * 0.65
          + vnoise(p * 2.1 + vec3(7.3, 2.1, 5.8)) * 0.35;
+}
+
+vec3 lava_color(float heat)
+{
+    heat = clamp(heat, 0.0, 1.0);
+
+    if (heat < 0.33) {
+        float t = heat / 0.33;
+        return mix(vec3(0.10, 0.025, 0.02), vec3(0.42, 0.06, 0.02), t);
+    }
+    if (heat < 0.72) {
+        float t = (heat - 0.33) / 0.39;
+        return mix(vec3(0.42, 0.06, 0.02), vec3(0.88, 0.30, 0.06), t);
+    }
+    if (heat < 0.92) {
+        float t = (heat - 0.72) / 0.20;
+        return mix(vec3(0.88, 0.30, 0.06), vec3(0.98, 0.58, 0.14), t);
+    }
+
+    return mix(vec3(0.98, 0.58, 0.14), vec3(1.00, 0.80, 0.34), (heat - 0.92) / 0.08);
 }
 
 /* ======================================================================
@@ -251,7 +271,7 @@ void main() {
 
     vec3 surface = surface_color(NL);
     vec3 lava_emit = vec3(0.0);
-    for (int i = 0; i < 4; i++) {
+    for (int i = 0; i < 16; i++) {
         if (i >= u_impact_count) break;
         vec3 idir = normalize(u_impact_dir[i]);
         float ang = acos(clamp(dot(NL, idir), -1.0, 1.0));
@@ -265,10 +285,13 @@ void main() {
                    * (1.0 - smoothstep(rad * 0.72, rad * 1.02, ang));
         float outer = smoothstep(rad * 0.72, rad * 1.30, ang)
                     * (1.0 - smoothstep(rad * 1.30, rad * 1.85, ang));
-        vec3 lava_hot = vec3(1.0, 0.94, 0.62);
-        vec3 lava_molten = vec3(1.0, 0.42, 0.08);
-        vec3 lava_deep = vec3(0.48, 0.06, 0.02);
-        vec3 lava = mix(lava_deep, lava_hot, core * 0.75 + (1.0 - progress) * 0.25);
+        float lava_noise = fbm(NL * 10.5 + idir * 4.0 + vec3(progress * 5.0, progress * 2.2, progress * 3.7));
+        float lava_var = (lava_noise - 0.5) * 0.22;
+        vec3 lava_hot = lava_color(clamp(min(1.0, heat * 1.02 + 0.06) + lava_var * 0.55, 0.0, 1.0));
+        vec3 lava_molten = lava_color(clamp(min(1.0, heat * 0.82 + 0.08) + lava_var * 0.45, 0.0, 1.0));
+        vec3 lava_warm = lava_color(clamp(heat * 0.58 + lava_var * 0.30, 0.0, 1.0));
+        vec3 lava_deep = lava_color(clamp(heat * 0.34 + lava_var * 0.18, 0.0, 1.0));
+        vec3 lava = mix(lava_warm, lava_hot, core * 0.75 + (1.0 - progress) * 0.25);
 
         if (kind == 1) {
             float crater_floor = 1.0 - smoothstep(0.0, rad * 0.72, ang);
@@ -282,13 +305,28 @@ void main() {
             surface = mix(surface, surface * 0.18, ring * heat * 0.72 + ash);
             surface = mix(surface, mix(lava_deep, lava_hot, core), melt * heat * 0.88);
             lava_emit += lava * (core * 1.8 + melt * 0.9 + outer * 0.35) * heat;
-        } else {
+        } else if (kind == 3) {
             float flood = 1.0 - smoothstep(0.0, rad * 1.08, ang);
             float seam = ring * (0.55 + 0.35 * (1.0 - progress));
             surface = mix(surface, surface * 0.20, seam * 0.55);
-            surface = mix(surface, mix(lava_deep, lava_hot, flood), flood * (0.45 + heat * 0.55));
-            lava_emit += mix(lava_molten, lava_hot, flood) *
+            surface = mix(surface, mix(lava_deep, lava_molten, flood), flood * (0.45 + heat * 0.55));
+            lava_emit += mix(lava_warm, lava_molten, flood) *
                          (flood * 1.75 + seam * 0.65 + outer * 0.25) * heat;
+        } else if (kind == 4) {
+            /* Live sphere-sphere intersection boundary.
+             * rad = angular radius of the buried cap on this sphere.
+             * Render the cap as molten lava with a bright ring at the edge. */
+            float inside_cap  = 1.0 - smoothstep(rad * 0.80, rad * 1.05, ang);
+            float edge_ring   = smoothstep(rad * 0.68, rad * 0.92, ang)
+                              * (1.0 - smoothstep(rad * 0.92, rad * 1.20, ang));
+            float outer_fringe = smoothstep(rad * 0.98, rad * 1.30, ang)
+                               * (1.0 - smoothstep(rad * 1.30, rad * 1.95, ang));
+
+            surface = mix(surface, mix(lava_deep, lava_molten, inside_cap * 0.7),
+                          inside_cap * heat * 0.88);
+            lava_emit += mix(lava_warm, lava_molten, inside_cap) * inside_cap * heat * 1.65;
+            lava_emit += lava_molten * edge_ring * heat * 1.8;
+            lava_emit += lava_warm * outer_fringe * heat * 0.9;
         }
     }
 

--- a/assets/shaders/phong.frag
+++ b/assets/shaders/phong.frag
@@ -40,6 +40,12 @@ uniform vec2  u_screen;
 uniform float u_rotation;     /* body rotation angle, radians           */
 uniform float u_obliquity;    /* axial tilt, radians (0 = upright)      */
 uniform int   u_planet_type;  /* 0-9, selects colour recipe             */
+uniform int   u_impact_count;
+uniform vec3  u_impact_dir[4];
+uniform float u_impact_radius[4];
+uniform float u_impact_heat[4];
+uniform float u_impact_progress[4];
+uniform int   u_impact_kind[4];
 
 out vec4 frag_color;
 
@@ -244,11 +250,52 @@ void main() {
     }
 
     vec3 surface = surface_color(NL);
+    vec3 lava_emit = vec3(0.0);
+    for (int i = 0; i < 4; i++) {
+        if (i >= u_impact_count) break;
+        vec3 idir = normalize(u_impact_dir[i]);
+        float ang = acos(clamp(dot(NL, idir), -1.0, 1.0));
+        float rad = max(u_impact_radius[i], 0.001);
+        float heat = clamp(u_impact_heat[i], 0.0, 1.0);
+        float progress = clamp(u_impact_progress[i], 0.0, 1.0);
+        int kind = u_impact_kind[i];
+        float core = 1.0 - smoothstep(0.0, rad * 0.30, ang);
+        float melt = 1.0 - smoothstep(rad * 0.10, rad * 0.98, ang);
+        float ring = smoothstep(rad * 0.48, rad * 0.72, ang)
+                   * (1.0 - smoothstep(rad * 0.72, rad * 1.02, ang));
+        float outer = smoothstep(rad * 0.72, rad * 1.30, ang)
+                    * (1.0 - smoothstep(rad * 1.30, rad * 1.85, ang));
+        vec3 lava_hot = vec3(1.0, 0.94, 0.62);
+        vec3 lava_molten = vec3(1.0, 0.42, 0.08);
+        vec3 lava_deep = vec3(0.48, 0.06, 0.02);
+        vec3 lava = mix(lava_deep, lava_hot, core * 0.75 + (1.0 - progress) * 0.25);
+
+        if (kind == 1) {
+            float crater_floor = 1.0 - smoothstep(0.0, rad * 0.72, ang);
+            float hot_rim = ring * (1.0 - progress * 0.65);
+            surface = mix(surface, surface * 0.12, crater_floor * 0.58);
+            surface = mix(surface, mix(lava_deep, lava_molten, core), core * heat * 0.72);
+            surface = mix(surface, vec3(0.08, 0.05, 0.04), ring * 0.32);
+            lava_emit += lava_molten * (core * 1.5 + hot_rim * 0.9) * heat;
+        } else if (kind == 2) {
+            float ash = outer * 0.35;
+            surface = mix(surface, surface * 0.18, ring * heat * 0.72 + ash);
+            surface = mix(surface, mix(lava_deep, lava_hot, core), melt * heat * 0.88);
+            lava_emit += lava * (core * 1.8 + melt * 0.9 + outer * 0.35) * heat;
+        } else {
+            float flood = 1.0 - smoothstep(0.0, rad * 1.08, ang);
+            float seam = ring * (0.55 + 0.35 * (1.0 - progress));
+            surface = mix(surface, surface * 0.20, seam * 0.55);
+            surface = mix(surface, mix(lava_deep, lava_hot, flood), flood * (0.45 + heat * 0.55));
+            lava_emit += mix(lava_molten, lava_hot, flood) *
+                         (flood * 1.75 + seam * 0.65 + outer * 0.25) * heat;
+        }
+    }
 
     /* ---- Phong diffuse ------------------------------------------------ */
     vec3  L     = normalize(u_sun_rel - hit_rel);
     float diff  = max(dot(N, L), 0.0);
     float light = u_ambient + (1.0 - u_ambient) * diff;
 
-    frag_color = vec4(surface * light, 1.0);
+    frag_color = vec4(surface * light + lava_emit, 1.0);
 }

--- a/assets/shaders/phong.frag
+++ b/assets/shaders/phong.frag
@@ -41,12 +41,13 @@ uniform float u_rotation;     /* body rotation angle, radians           */
 uniform float u_obliquity;    /* axial tilt, radians (0 = upright)      */
 uniform int   u_planet_type;  /* 0-9, selects colour recipe             */
 uniform int   u_impact_count;
-uniform vec3  u_impact_dir[16];
-uniform vec3  u_impact_tangent1[16];
-uniform float u_impact_radius[16];
-uniform float u_impact_heat[16];
-uniform float u_impact_progress[16];
-uniform int   u_impact_kind[16];
+uniform vec3  u_impact_dir[32];
+uniform vec3  u_impact_tangent1[32];
+uniform float u_impact_radius[32];
+uniform float u_impact_heat[32];
+uniform float u_impact_progress[32];
+uniform float u_impact_seed[32];
+uniform int   u_impact_kind[32];
 
 out vec4 frag_color;
 
@@ -270,7 +271,8 @@ void main() {
                   tx * sr + tz * cr);
     }
 
-    vec3 surface = surface_color(NL);
+    vec3 base_surface = surface_color(NL);
+    vec3 surface = base_surface;
     vec3 lava_emit = vec3(0.0);
 
     /* Sun direction — computed once, reused for emission clamping inside the
@@ -279,13 +281,28 @@ void main() {
     vec3  L    = normalize(u_sun_rel - hit_rel);
     float diff = max(dot(N, L), 0.0);
 
-    for (int i = 0; i < 16; i++) {
+    /* Pre-pass: accumulate kind-4 (intersection) coverage so craters (kind 5)
+     * don't overwrite the live collision bloom regardless of slot order. */
+    float s_intersection = 0.0;
+    for (int i = 0; i < 32; i++) {
+        if (i >= u_impact_count) break;
+        if (u_impact_kind[i] != 4) continue;
+        vec3 jdir = normalize(u_impact_dir[i]);
+        float jrad = max(u_impact_radius[i], 0.001);
+        float jang = acos(clamp(dot(NL, jdir), -1.0, 1.0));
+        s_intersection = max(s_intersection,
+                             1.0 - smoothstep(jrad * 0.80, jrad * 1.55, jang));
+    }
+
+    for (int i = 0; i < 32; i++) {
         if (i >= u_impact_count) break;
         vec3 idir = normalize(u_impact_dir[i]);
+        vec3 it1 = normalize(u_impact_tangent1[i]);
         float ang = acos(clamp(dot(NL, idir), -1.0, 1.0));
         float rad = max(u_impact_radius[i], 0.001);
         float heat = clamp(u_impact_heat[i], 0.0, 1.0);
         float progress = clamp(u_impact_progress[i], 0.0, 1.0);
+        float seed = u_impact_seed[i];
         int kind = u_impact_kind[i];
         float core = 1.0 - smoothstep(0.0, rad * 0.30, ang);
         float melt = 1.0 - smoothstep(rad * 0.10, rad * 0.98, ang);
@@ -324,7 +341,7 @@ void main() {
             /* Live sphere-sphere intersection boundary.
              * rad = angular radius of the buried cap on this sphere.
              * Render the cap as molten lava with a bright ring at the edge. */
-            vec3 scar_t1 = normalize(u_impact_tangent1[i]);
+            vec3 scar_t1 = it1;
             vec3 scar_t2 = normalize(cross(idir, scar_t1));
             scar_t1 = normalize(cross(scar_t2, idir));
             vec3 scar_p = vec3(dot(NL, scar_t1),
@@ -363,6 +380,103 @@ void main() {
             float night_blend = 1.0 - diff * 0.80;
             lava_emit += seam_molten * edge_ring * heat * 1.8 * night_blend;
             lava_emit += seam_warm * outer_fringe * heat * 0.9 * night_blend;
+        } else if (kind == 5) {
+            vec3 scar_t1 = it1;
+            vec3 scar_t2 = normalize(cross(idir, scar_t1));
+            scar_t1 = normalize(cross(scar_t2, idir));
+            vec3 scar_p = vec3(dot(NL, scar_t1),
+                               dot(NL, scar_t2),
+                               dot(NL, idir) - cos(rad));
+            vec2 crater_uv = scar_p.xy / max(rad, 0.001);
+            float crater_r = length(crater_uv);
+            float crater_ang = atan(crater_uv.y, crater_uv.x);
+            float crater_scale = 5.4 / max(rad, 0.08);
+            vec3 crater_q = vec3(scar_p.xy * crater_scale + vec2(seed * 0.07, seed * 0.11),
+                                 scar_p.z * 5.6 + seed * 0.05);
+            float crater_coarse = vnoise(crater_q * 0.56 + vec3(1.7, 3.2, 4.4));
+            float crater_fine = fbm(crater_q * 1.45 + vec3(6.1, 2.4, 1.8));
+            float crater_rubble = vnoise(crater_q * 2.6 + vec3(2.8, 5.4, 1.3));
+            float crater_fracture = fbm(vec3(crater_ang * 2.1 + seed * 0.03,
+                                             crater_r * 3.6,
+                                             seed * 0.09));
+            float crater_chunks = fbm(crater_q * 3.4 + vec3(8.2, 1.6, 4.7));
+            float radial_rays = sin(crater_ang * 9.0 + seed * 0.21) * 0.5 + 0.5;
+            float radial_rays2 = sin(crater_ang * 5.0 - seed * 0.17) * 0.5 + 0.5;
+            float radial_rays3 = sin(crater_ang * 13.0 + seed * 0.29) * 0.5 + 0.5;
+            float crater_var = (crater_coarse - 0.5) * 0.38 + (crater_fine - 0.5) * 0.24;
+            float rubble_var = (crater_rubble - 0.5) * 0.28;
+            float chunk_var = (crater_chunks - 0.5) * 0.26;
+            float fracture_var = (crater_fracture - 0.5) * 0.32;
+            float ray_break = (radial_rays - 0.5) * 0.05 + (radial_rays2 - 0.5) * 0.03;
+            float rim_shift = crater_var * 0.05 + fracture_var * 0.08 + ray_break;
+            float bowl = 1.0 - smoothstep(0.0, 0.54 + crater_var * 0.05, crater_r);
+            float inner_slope = smoothstep(0.14 + crater_var * 0.03, 0.70 + crater_var * 0.05, crater_r);
+            float wall_band = smoothstep(0.30 + crater_var * 0.04, 0.78 + rim_shift, crater_r)
+                            * (1.0 - smoothstep(0.78 + rim_shift, 0.96 + rim_shift, crater_r));
+            float rim = smoothstep(0.74 + rim_shift, 0.88 + rim_shift, crater_r)
+                      * (1.0 - smoothstep(0.88 + rim_shift, 1.02 + rim_shift, crater_r));
+            float fractured_band = smoothstep(0.24 + crater_var * 0.03, 0.96 + rim_shift, crater_r)
+                                 * (1.0 - smoothstep(0.96 + rim_shift, 1.14 + rim_shift, crater_r));
+            float crater_mask = 1.0 - smoothstep(0.78 + crater_var * 0.04, 1.14 + rim_shift, crater_r);
+            float outer_fade = 1.0 - smoothstep(0.92 + crater_var * 0.03, 1.14 + rim_shift, crater_r);
+            float central_peak = 0.0; /* disabled */
+            /* terrace — concentric step at ~50 % radius */
+            float terrace = smoothstep(0.38 + crater_var * 0.03, 0.52 + crater_var * 0.04, crater_r)
+                          * (1.0 - smoothstep(0.52 + crater_var * 0.04, 0.66 + crater_var * 0.03, crater_r));
+            float radial_mix = radial_rays * 0.50 + radial_rays2 * 0.28 + radial_rays3 * 0.22;
+            float radial_fractures = smoothstep(0.58, 0.84, radial_mix)
+                                   * smoothstep(0.12, 0.56, crater_r)
+                                   * (1.0 - smoothstep(0.56, 0.80, crater_r));
+            /* ejecta streaks stay within the crater rim */
+            float ejecta_streaks = smoothstep(0.62, 0.90, radial_mix)
+                                 * smoothstep(0.68, 0.82, crater_r)
+                                 * (1.0 - smoothstep(0.82, 0.96, crater_r));
+            float depth = heat;
+            float earth_crater = u_planet_type == 1 ? 1.0 : 0.0;
+            float size_fade = smoothstep(0.006, 0.18, rad);
+            float crater_alpha = mix(0.58, 1.0, earth_crater) * mix(0.08, 1.0, size_fade)
+                               * (1.0 - s_intersection * 0.95);
+            vec3 warm_brown = mix(vec3(0.18, 0.14, 0.11), vec3(0.34, 0.26, 0.18), crater_coarse);
+            vec3 dusty_brown = mix(vec3(0.24, 0.19, 0.14), vec3(0.42, 0.33, 0.24), crater_fine);
+            vec3 ridge_brown = mix(vec3(0.32, 0.25, 0.18), vec3(0.50, 0.40, 0.30), crater_coarse * 0.65 + crater_fine * 0.35);
+            vec3 crater_dark = mix(base_surface * 0.28, warm_brown, earth_crater * 0.25 + 0.75);
+            vec3 crater_mid = mix(base_surface * 0.52, dusty_brown, earth_crater * 0.15 + 0.55);
+            vec3 crater_ridge = mix(base_surface * 0.74, ridge_brown, earth_crater * 0.10 + 0.45);
+            vec3 crater_floor_col = mix(crater_dark * 0.72, crater_mid * 0.84,
+                                        0.16 + crater_var * 0.18 + rubble_var * 0.20 + chunk_var * 0.18);
+            vec3 crater_wall_col = mix(crater_dark * 0.92, crater_mid,
+                                       0.48 + crater_var * 0.18 + rubble_var * 0.16 + chunk_var * 0.14);
+            vec3 crater_surface = mix(crater_floor_col, crater_wall_col, inner_slope);
+            vec3 crater_rim_col = mix(crater_surface, crater_ridge, 0.78 + crater_var * 0.12 + rubble_var * 0.12 + chunk_var * 0.10);
+            vec3 fractured_col = mix(crater_dark * 0.85, crater_ridge,
+                                     0.44 + crater_fine * 0.18 + rubble_var * 0.26 + chunk_var * 0.16);
+            vec3 chunk_col = mix(crater_dark * 0.90, crater_mid * 1.05, 0.42 + chunk_var * 0.28);
+            crater_surface = mix(crater_surface, chunk_col,
+                                 smoothstep(0.54, 0.82, crater_chunks)
+                                 * smoothstep(0.10, 0.88, crater_r)
+                                 * (1.0 - smoothstep(0.88, 1.02, crater_r))
+                                 * 0.34);
+            crater_surface = mix(crater_surface, fractured_col,
+                                 fractured_band * (0.30 + crater_rubble * 0.22 + max(fracture_var, 0.0) * 0.85));
+            crater_surface = mix(crater_surface, crater_dark * 0.62,
+                                 radial_fractures * (0.62 + max(fracture_var, 0.0) * 0.55));
+            crater_surface = mix(crater_surface, crater_wall_col * 0.68, bowl * (0.34 + depth * 0.22));
+            crater_surface = mix(crater_surface, crater_wall_col, wall_band * (0.58 + depth * 0.18));
+            crater_surface = mix(crater_surface, crater_rim_col, rim * (0.56 + max(fracture_var, 0.0) * 0.24));
+            /* terrace step — slightly lighter than wall, with rubble variation */
+            vec3 terrace_col = mix(crater_wall_col * 0.88, crater_ridge * 0.82,
+                                   0.45 + crater_var * 0.20 + rubble_var * 0.18);
+            crater_surface = mix(crater_surface, terrace_col,
+                                 terrace * (0.58 + max(fracture_var, 0.0) * 0.30));
+            /* central peak — bright rocky protrusion */
+            vec3 peak_col = mix(crater_mid * 1.06, crater_ridge * 0.92,
+                                crater_coarse * 0.55 + crater_fine * 0.45);
+            crater_surface = mix(crater_surface, peak_col, central_peak * 0.74);
+
+            surface = mix(surface, crater_surface, crater_alpha * crater_mask * outer_fade);
+            surface = mix(surface, crater_floor_col * 0.72, crater_alpha * bowl * (0.48 + depth * 0.26));
+            surface = mix(surface, crater_rim_col, crater_alpha * rim * (0.30 + depth * 0.14));
+            surface = mix(surface, crater_mid * 1.04, crater_alpha * ejecta_streaks * 0.34);
         }
     }
 

--- a/assets/shaders/phong.frag
+++ b/assets/shaders/phong.frag
@@ -271,6 +271,13 @@ void main() {
 
     vec3 surface = surface_color(NL);
     vec3 lava_emit = vec3(0.0);
+
+    /* Sun direction — computed once, reused for emission clamping inside the
+     * impact loop (kind 4 dampens edge/fringe emission on the lit hemisphere
+     * to avoid a transparent-looking orange halo when viewed from the sun). */
+    vec3  L    = normalize(u_sun_rel - hit_rel);
+    float diff = max(dot(N, L), 0.0);
+
     for (int i = 0; i < 16; i++) {
         if (i >= u_impact_count) break;
         vec3 idir = normalize(u_impact_dir[i]);
@@ -316,23 +323,26 @@ void main() {
             /* Live sphere-sphere intersection boundary.
              * rad = angular radius of the buried cap on this sphere.
              * Render the cap as molten lava with a bright ring at the edge. */
-            float inside_cap  = 1.0 - smoothstep(rad * 0.80, rad * 1.05, ang);
-            float edge_ring   = smoothstep(rad * 0.68, rad * 0.92, ang)
-                              * (1.0 - smoothstep(rad * 0.92, rad * 1.20, ang));
+            float inside_cap  = 1.0 - smoothstep(rad * 0.80, rad * 1.10, ang);
+            float edge_ring   = smoothstep(rad * 0.55, rad * 0.85, ang)
+                              * (1.0 - smoothstep(rad * 0.85, rad * 1.55, ang));
             float outer_fringe = smoothstep(rad * 0.98, rad * 1.30, ang)
                                * (1.0 - smoothstep(rad * 1.30, rad * 1.95, ang));
 
             surface = mix(surface, mix(lava_deep, lava_molten, inside_cap * 0.7),
                           inside_cap * heat * 0.88);
             lava_emit += mix(lava_warm, lava_molten, inside_cap) * inside_cap * heat * 1.65;
-            lava_emit += lava_molten * edge_ring * heat * 1.8;
-            lava_emit += lava_warm * outer_fringe * heat * 0.9;
+            /* Dampen edge/fringe glow on the lit side: viewing from the sun
+             * direction the ring at ang≈90° (the equatorial limb) would
+             * otherwise appear as a bright orange halo that looks transparent.
+             * Keep full intensity on the night side (diff≈0).              */
+            float night_blend = 1.0 - diff * 0.80;
+            lava_emit += lava_molten * edge_ring * heat * 1.8 * night_blend;
+            lava_emit += lava_warm * outer_fringe * heat * 0.9 * night_blend;
         }
     }
 
     /* ---- Phong diffuse ------------------------------------------------ */
-    vec3  L     = normalize(u_sun_rel - hit_rel);
-    float diff  = max(dot(N, L), 0.0);
     float light = u_ambient + (1.0 - u_ambient) * diff;
 
     frag_color = vec4(surface * light + lava_emit, 1.0);

--- a/assets/shaders/phong.frag
+++ b/assets/shaders/phong.frag
@@ -42,6 +42,7 @@ uniform float u_obliquity;    /* axial tilt, radians (0 = upright)      */
 uniform int   u_planet_type;  /* 0-9, selects colour recipe             */
 uniform int   u_impact_count;
 uniform vec3  u_impact_dir[16];
+uniform vec3  u_impact_tangent1[16];
 uniform float u_impact_radius[16];
 uniform float u_impact_heat[16];
 uniform float u_impact_progress[16];
@@ -323,22 +324,45 @@ void main() {
             /* Live sphere-sphere intersection boundary.
              * rad = angular radius of the buried cap on this sphere.
              * Render the cap as molten lava with a bright ring at the edge. */
+            vec3 scar_t1 = normalize(u_impact_tangent1[i]);
+            vec3 scar_t2 = normalize(cross(idir, scar_t1));
+            scar_t1 = normalize(cross(scar_t2, idir));
+            vec3 scar_p = vec3(dot(NL, scar_t1),
+                               dot(NL, scar_t2),
+                               dot(NL, idir) - cos(rad));
+            float scar_scale = 8.0 / max(rad, 0.08);
+            vec3 scar_q = vec3(scar_p.xy * (scar_scale * 1.18),
+                               scar_p.z * 4.8);
+            float seam_noise = fbm(scar_q);
+            float seam_var = (seam_noise - 0.5) * 0.22;
+            float seam_coarse = vnoise(scar_q * 0.58 + vec3(3.1, 1.7, 4.9));
+            float seam_coarse_var = (seam_coarse - 0.5) * 0.26;
+            float cool_phase = smoothstep(0.34, 0.88, progress);
             float inside_cap  = 1.0 - smoothstep(rad * 0.80, rad * 1.10, ang);
             float edge_ring   = smoothstep(rad * 0.55, rad * 0.85, ang)
                               * (1.0 - smoothstep(rad * 0.85, rad * 1.55, ang));
             float outer_fringe = smoothstep(rad * 0.98, rad * 1.30, ang)
                                * (1.0 - smoothstep(rad * 1.30, rad * 1.95, ang));
+            vec3 seam_hot = lava_color(clamp(min(1.0, heat * 1.02 + 0.06) + seam_var * 0.55, 0.0, 1.0));
+            vec3 seam_molten = lava_color(clamp(min(1.0, heat * 0.82 + 0.08)
+                                                + seam_var * 0.34
+                                                + seam_coarse_var * (0.10 + 0.18 * cool_phase), 0.0, 1.0));
+            vec3 seam_warm = lava_color(clamp(heat * 0.58 + seam_var * 0.18 + seam_coarse_var * 0.28, 0.0, 1.0));
+            vec3 seam_deep = lava_color(clamp(heat * 0.34 + seam_var * 0.08 + seam_coarse_var * 0.24, 0.0, 1.0));
+            vec3 seam_core = mix(seam_molten, seam_hot, inside_cap * 0.75 + (1.0 - progress) * 0.25);
+            seam_core = mix(seam_core, mix(seam_deep, seam_molten, 0.62 + seam_coarse * 0.18),
+                            cool_phase * (1.0 - inside_cap * 0.55));
 
-            surface = mix(surface, mix(lava_deep, lava_molten, inside_cap * 0.7),
+            surface = mix(surface, mix(seam_deep, seam_core, inside_cap * 0.7),
                           inside_cap * heat * 0.88);
-            lava_emit += mix(lava_warm, lava_molten, inside_cap) * inside_cap * heat * 1.65;
+            lava_emit += mix(seam_warm, seam_molten, inside_cap) * inside_cap * heat * 1.65;
             /* Dampen edge/fringe glow on the lit side: viewing from the sun
              * direction the ring at ang≈90° (the equatorial limb) would
              * otherwise appear as a bright orange halo that looks transparent.
              * Keep full intensity on the night side (diff≈0).              */
             float night_blend = 1.0 - diff * 0.80;
-            lava_emit += lava_molten * edge_ring * heat * 1.8 * night_blend;
-            lava_emit += lava_warm * outer_fringe * heat * 0.9 * night_blend;
+            lava_emit += seam_molten * edge_ring * heat * 1.8 * night_blend;
+            lava_emit += seam_warm * outer_fringe * heat * 0.9 * night_blend;
         }
     }
 

--- a/assets/shaders/phong.frag
+++ b/assets/shaders/phong.frag
@@ -17,6 +17,9 @@
  *   7  Io              (yellow-orange with dark volcanic spots)
  *   8  Titan           (orange haze)
  *   9  Europa          (icy white with rust cracks)
+ *   10 build rocky     (grey-brown terrestrial)
+ *   11 build gas giant (soft cloudy beige-brown giant)
+ *   12 build ice       (icy blue giant)
  */
 
 in vec2 v_uv;   /* unused for planets, kept for linker compatibility */
@@ -159,6 +162,43 @@ vec3 surface_color(vec3 NL) {
     if (u_planet_type == 6) {
         float band = sin(NL.y * 5.0 + (n - 0.5)) * 0.07 + 0.93;
         return u_color * (0.72 + 0.56 * n) * band;
+    }
+
+    /* ---- Build Rocky Planet ------------------------------------------- */
+    if (u_planet_type == 10) {
+        float n2 = fbm(NL * 6.2 + vec3(3.2, 5.4, 1.7));
+        vec3 dark = u_color * vec3(0.62, 0.60, 0.58);
+        vec3 mid  = u_color * vec3(0.95, 0.92, 0.88);
+        vec3 bright = u_color * vec3(1.18, 1.12, 1.04);
+        vec3 col = mix(dark, mid, n * 0.75 + n2 * 0.25);
+        col = mix(col, bright, smoothstep(0.70, 0.90, n2) * 0.35);
+        return col;
+    }
+
+    /* ---- Build Gas Giant ---------------------------------------------- */
+    if (u_planet_type == 11) {
+        float n2 = fbm(NL * 3.2 + vec3(4.4, 1.6, 7.2));
+        float n3 = fbm(NL * 6.8 + vec3(1.8, 6.2, 2.7));
+        float cloud = sin(NL.y * 11.5 + (n - 0.5) * 1.8 + (n2 - 0.5) * 1.0) * 0.5 + 0.5;
+        float haze  = sin(NL.y * 5.2 + (n3 - 0.5) * 1.4) * 0.5 + 0.5;
+        vec3 deep = u_color * vec3(0.78, 0.64, 0.48);
+        vec3 light = u_color * vec3(1.12, 1.04, 0.92);
+        vec3 warm = u_color * vec3(0.96, 0.80, 0.60);
+        vec3 col = mix(deep, light, cloud * 0.46 + haze * 0.22 + n * 0.18);
+        col = mix(col, warm, smoothstep(0.70, 0.90, n3) * 0.18);
+        return col;
+    }
+
+    /* ---- Build Ice Planet --------------------------------------------- */
+    if (u_planet_type == 12) {
+        float n2 = fbm(NL * 5.5 + vec3(2.6, 7.4, 1.3));
+        float bands = sin(NL.y * 8.0 + (n2 - 0.5) * 2.8) * 0.5 + 0.5;
+        vec3 deep = u_color * vec3(0.72, 0.88, 1.05);
+        vec3 light = u_color * vec3(1.04, 1.08, 1.10);
+        vec3 frost = vec3(0.92, 0.97, 1.0);
+        vec3 col = mix(deep, light, n * 0.45 + bands * 0.35);
+        col = mix(col, frost, smoothstep(0.78, 0.92, n2) * 0.26);
+        return col;
     }
 
     /* ---- Io ----------------------------------------------------------- */

--- a/assets/shaders/phong.frag
+++ b/assets/shaders/phong.frag
@@ -43,6 +43,7 @@ uniform vec2  u_screen;
 uniform float u_rotation;     /* body rotation angle, radians           */
 uniform float u_obliquity;    /* axial tilt, radians (0 = upright)      */
 uniform int   u_planet_type;  /* 0-9, selects colour recipe             */
+uniform float u_star_heat;    /* 0..1 surface heating from star approach */
 uniform int   u_impact_count;
 uniform vec3  u_impact_dir[32];
 uniform vec3  u_impact_tangent1[32];
@@ -319,7 +320,46 @@ void main() {
      * impact loop (kind 4 dampens edge/fringe emission on the lit hemisphere
      * to avoid a transparent-looking orange halo when viewed from the sun). */
     vec3  L    = normalize(u_sun_rel - hit_rel);
+    float sun_dot = dot(N, L);
     float diff = max(dot(N, L), 0.0);
+
+    if (u_star_heat > 0.001) {
+        float star_heat = clamp(u_star_heat, 0.0, 1.0);
+        float day_side = smoothstep(-0.12, 0.42, sun_dot);
+        float hot_side = pow(max(sun_dot, 0.0), 0.72);
+        float view_mu = max(dot(N, -ray_dir), 0.0);
+        float rim = pow(1.0 - view_mu, 2.4);
+        float heat_noise = fbm(NL * 7.4 + vec3(u_rotation * 0.35, star_heat * 4.0, -u_rotation * 0.22));
+        float heat_noise2 = fbm(NL * 13.0 + vec3(2.7, -u_rotation * 0.18, 4.1 + star_heat * 3.3));
+        float crack_mix = heat_noise * 0.64 + heat_noise2 * 0.36;
+        float warm_band = day_side * (0.32 + 0.68 * star_heat);
+        float crust = smoothstep(0.28 - star_heat * 0.10,
+                                 0.96 - star_heat * 0.18,
+                                 crack_mix + hot_side * (0.16 + star_heat * 0.26));
+        float molten_gate = smoothstep(0.46, 0.98, star_heat);
+        float molten = crust * hot_side * molten_gate;
+        float lava_pool = smoothstep(0.62, 1.0, star_heat)
+                        * pow(max(sun_dot, 0.0), 1.35)
+                        * smoothstep(0.50, 0.92, crack_mix + star_heat * 0.22);
+        float haze = smoothstep(0.36, 1.0, star_heat) * day_side * rim;
+        vec3 haze_col = mix(vec3(0.55, 0.08, 0.03),
+                            vec3(0.92, 0.18, 0.06),
+                            0.35 + star_heat * 0.45);
+        vec3 scorch = mix(base_surface * vec3(0.42, 0.24, 0.14),
+                          base_surface * vec3(0.86, 0.38, 0.16),
+                          0.35 + star_heat * 0.45);
+        vec3 crust_col = mix(scorch, lava_color(0.22 + star_heat * 0.38), 0.24 + crust * 0.34);
+        vec3 molten_col = lava_color(clamp(0.34 + star_heat * 0.58 + crack_mix * 0.16, 0.0, 1.0));
+        vec3 white_hot = mix(molten_col, vec3(1.0, 0.84, 0.42), smoothstep(0.82, 1.0, star_heat) * hot_side);
+
+        surface = mix(surface, scorch, warm_band * 0.42);
+        surface = mix(surface, crust_col, warm_band * (0.22 + star_heat * 0.44));
+        surface = mix(surface, molten_col, molten * (0.26 + star_heat * 0.48));
+        surface = mix(surface, white_hot, lava_pool * 0.55);
+        lava_emit += haze_col * haze * (0.18 + star_heat * 0.34);
+        lava_emit += molten_col * molten * (0.22 + star_heat * 1.05);
+        lava_emit += white_hot * lava_pool * (0.40 + star_heat * 1.45);
+    }
 
     /* Pre-pass: accumulate kind-4 (intersection) coverage so craters (kind 5)
      * don't overwrite the live collision bloom regardless of slot order. */

--- a/assets/shaders/solid.vert
+++ b/assets/shaders/solid.vert
@@ -3,20 +3,23 @@
  * solid.vert — uniform-colour geometry with explicit per-vertex alpha
  * Used for: orbital trails (GL_LINE_STRIP)
  *
- * Positions are camera-relative (pre-subtracted on CPU in double precision
- * to avoid float cancellation jitter when the camera is near the trail).
- * Alpha is provided by the CPU and typically represents normalized trail
- * distance from oldest (0) to newest (1).
+ * Positions are stored world-relative in the VBO (camera subtraction is NOT
+ * pre-baked per vertex). Instead, u_body_offset carries the per-body reference
+ * point minus the current camera position (computed CPU-side in double precision
+ * to preserve accuracy near planets). This lets the VBO remain valid across
+ * camera movement — only a cheap uniform update is needed per body per frame.
+ * Alpha represents normalized trail distance from oldest (0) to newest (1).
  */
 
 layout(location = 0) in vec3 a_pos;
 layout(location = 1) in float a_alpha;
 
 uniform mat4 u_vp;
+uniform vec3 u_body_offset;
 
 out float v_alpha;
 
 void main() {
     v_alpha = a_alpha;
-    gl_Position = u_vp * vec4(a_pos, 1.0);
+    gl_Position = u_vp * vec4(a_pos + u_body_offset, 1.0);
 }

--- a/assets/shaders/solid.vert
+++ b/assets/shaders/solid.vert
@@ -1,22 +1,22 @@
 #version 330 core
 /*
- * solid.vert — uniform-colour geometry with gl_VertexID alpha fade
+ * solid.vert — uniform-colour geometry with explicit per-vertex alpha
  * Used for: orbital trails (GL_LINE_STRIP)
  *
  * Positions are camera-relative (pre-subtracted on CPU in double precision
  * to avoid float cancellation jitter when the camera is near the trail).
- * Alpha fades quadratically from 0 (oldest vertex) to 1 (newest).
+ * Alpha is provided by the CPU and typically represents normalized trail
+ * distance from oldest (0) to newest (1).
  */
 
 layout(location = 0) in vec3 a_pos;
+layout(location = 1) in float a_alpha;
 
 uniform mat4 u_vp;
-uniform int  u_count;   /* total vertices in this draw call */
 
 out float v_alpha;
 
 void main() {
-    float t   = (u_count > 1) ? float(gl_VertexID) / float(u_count - 1) : 1.0;
-    v_alpha   = t * t;
+    v_alpha = a_alpha;
     gl_Position = u_vp * vec4(a_pos, 1.0);
 }

--- a/src/asteroids.c
+++ b/src/asteroids.c
@@ -33,6 +33,9 @@
 #include <string.h>
 #include <stdint.h>
 #include <stdio.h>
+#ifdef _OPENMP
+#include <omp.h>
+#endif
 
 #define GM_SUN_SI  1.327124e20   /* m³/s² */
 #define MAX_MAJOR  32            /* upper bound for major-body cache */
@@ -248,6 +251,7 @@ void asteroids_step(double dt) {
     double bx[MAX_MAJOR], by[MAX_MAJOR], bz[MAX_MAJOR], bgm[MAX_MAJOR];
     int nb = 0;
     for (int j = 0; j < g_nbodies && nb < MAX_MAJOR; j++) {
+        if (!g_bodies[j].alive) continue;
         /* skip moons (parent >= 0 and parent is not a star) */
         if (g_bodies[j].parent >= 0 &&
             !g_bodies[g_bodies[j].parent].is_star) continue;
@@ -262,6 +266,9 @@ void asteroids_step(double dt) {
         Belt *belt = &s_belts[b];
         if (!belt->initialized) continue;
 
+#ifdef _OPENMP
+#pragma omp parallel for schedule(static)
+#endif
         for (int i = 0; i < belt->n; i++) {
             Particle *p = &belt->p[i];
 

--- a/src/body.c
+++ b/src/body.c
@@ -161,7 +161,7 @@ int nearest_star_idx(void)
     double best_d2 = 1e300;
     int i;
     for (i = 0; i < g_nbodies; i++) {
-        if (!g_bodies[i].is_star) continue;
+        if (!g_bodies[i].alive || !g_bodies[i].is_star) continue;
         double dx = g_cam.pos[0] - g_bodies[i].pos[0] * RS;
         double dy = g_cam.pos[1] - g_bodies[i].pos[1] * RS;
         double dz = g_cam.pos[2] - g_bodies[i].pos[2] * RS;
@@ -169,4 +169,64 @@ int nearest_star_idx(void)
         if (d2 < best_d2) { best_d2 = d2; best = i; }
     }
     return best;
+}
+
+int body_root_star(int i)
+{
+    if (i < 0 || i >= g_nbodies) return -1;
+    while (g_bodies[i].parent >= 0) {
+        i = g_bodies[i].parent;
+        if (i < 0 || i >= g_nbodies) return -1;
+    }
+    return i;
+}
+
+void body_world_to_local_surface_dir(int body_idx, const double world_dir[3],
+                                     float out[3])
+{
+    Body *b;
+    double n[3];
+    double len, co, so, tx, ty, tz, cr, sr;
+    float flen;
+
+    if (!out || body_idx < 0 || body_idx >= g_nbodies) return;
+
+    b = &g_bodies[body_idx];
+    n[0] = world_dir[0];
+    n[1] = world_dir[1];
+    n[2] = world_dir[2];
+    len = sqrt(n[0]*n[0] + n[1]*n[1] + n[2]*n[2]);
+    if (len <= 1e-12) {
+        out[0] = 1.0f;
+        out[1] = 0.0f;
+        out[2] = 0.0f;
+        return;
+    }
+
+    n[0] /= len;
+    n[1] /= len;
+    n[2] /= len;
+
+    co = cos(b->obliquity * PI / 180.0);
+    so = sin(b->obliquity * PI / 180.0);
+    tx =  co * n[0] - so * n[1];
+    ty =  so * n[0] + co * n[1];
+    tz =  n[2];
+
+    cr = cos(-b->rotation_angle);
+    sr = sin(-b->rotation_angle);
+    out[0] = (float)(tx * cr - tz * sr);
+    out[1] = (float)ty;
+    out[2] = (float)(tx * sr + tz * cr);
+
+    flen = sqrtf(out[0]*out[0] + out[1]*out[1] + out[2]*out[2]);
+    if (flen <= 1e-8f) {
+        out[0] = 1.0f;
+        out[1] = 0.0f;
+        out[2] = 0.0f;
+        return;
+    }
+    out[0] /= flen;
+    out[1] /= flen;
+    out[2] /= flen;
 }

--- a/src/body.h
+++ b/src/body.h
@@ -38,6 +38,7 @@ typedef struct {
     int    trail_head;       /* index of next write slot                   */
     int    trail_count;      /* number of valid samples (0..TRAIL_LEN)     */
     double (*trail)[3];      /* heap-allocated [TRAIL_LEN][3]              */
+    double trail_fade;       /* 1.0 = full alpha; fades to 0 after death   */
 } Body;
 
 /* g_bodies is a heap-allocated array that grows via realloc.

--- a/src/body.h
+++ b/src/body.h
@@ -14,8 +14,13 @@ typedef struct {
     double fast_acc[3];    /* m/s^2 dominant parent force, RESPA inner step */
     float  col[3];         /* RGB display colour              */
     int    is_star;
+    int    alive;           /* 0 = removed/absorbed; index kept stable */
     int    parent;         /* index of parent body (-1 = none)                  */
                            /* stars: -1; planets: star idx; moons: planet idx   */
+    double dyn_period;     /* s, estimated local orbital/dynamical period       */
+    double dyn_dt_outer;   /* s, recommended slow-force timestep ceiling         */
+    double dyn_dt_inner;   /* s, recommended parent-force timestep ceiling       */
+    int    dyn_bucket;     /* 0=slow .. 3=very fast                             */
 
     /* Rotation */
     double obliquity;       /* axial tilt in degrees (from ecliptic north)  */
@@ -53,6 +58,14 @@ void keplerian_to_state(
 
 /* Index of the star body nearest to the camera (camera.h must be included first). */
 int nearest_star_idx(void);
+
+/* Walk parent links to find the owning root star for a body. */
+int body_root_star(int i);
+
+/* Convert a world-space direction into the body's surface-local frame.
+ * This matches the local-space convention used by the planet shader. */
+void body_world_to_local_surface_dir(int body_idx, const double world_dir[3],
+                                     float out[3]);
 
 /* Planetocentric state from simple moon elements (a in km, angles in degrees). */
 void moon_to_state(

--- a/src/body.h
+++ b/src/body.h
@@ -37,6 +37,8 @@ typedef struct {
     int    trail_head;       /* index of next write slot                   */
     int    trail_count;      /* number of valid samples (0..TRAIL_LEN)     */
     double (*trail)[3];      /* heap-allocated [TRAIL_LEN][3]              */
+    double *trail_seg_len;   /* segment length ending at each sample index */
+    double trail_total_len;  /* retained trail length in world meters      */
     double trail_fade;       /* 1.0 = full alpha; fades to 0 after death   */
     int    trail_emitting;   /* 1 while the body should keep adding points */
     double trail_prev_pos[3];/* previous trail tick position for interpolation */
@@ -44,6 +46,7 @@ typedef struct {
     double trail_frame_accum;     /* meters accumulated at frame start        */
     int    trail_frame_head;      /* trail head snapshot at frame start       */
     int    trail_frame_count;     /* trail count snapshot at frame start      */
+    double trail_frame_total_len; /* retained trail length at frame start     */
     double trail_frame_pos[3];    /* body position at frame start             */
     double trail_frame_vel[3];    /* body velocity at frame start             */
     double trail_frame_prev_pos[3];/* previous curve anchor at frame start    */

--- a/src/body.h
+++ b/src/body.h
@@ -33,12 +33,13 @@ typedef struct {
     float  atm_scale;       /* outer atm radius as multiple of planet radius */
 
     /* Orbital trail (circular buffer, TRAIL_LEN samples, positions in AU) */
-    double trail_interval;   /* sim-seconds between samples (≈ T/200)     */
-    double trail_accum;      /* accumulator toward next sample             */
+    double trail_accum;      /* sim-seconds accumulated toward next sample */
     int    trail_head;       /* index of next write slot                   */
     int    trail_count;      /* number of valid samples (0..TRAIL_LEN)     */
     double (*trail)[3];      /* heap-allocated [TRAIL_LEN][3]              */
     double trail_fade;       /* 1.0 = full alpha; fades to 0 after death   */
+    int    trail_emitting;   /* 1 while the body should keep adding points */
+    double trail_prev_pos[3];/* previous trail tick position for interpolation */
 } Body;
 
 /* g_bodies is a heap-allocated array that grows via realloc.

--- a/src/body.h
+++ b/src/body.h
@@ -33,13 +33,21 @@ typedef struct {
     float  atm_scale;       /* outer atm radius as multiple of planet radius */
 
     /* Orbital trail (circular buffer, TRAIL_LEN samples, positions in AU) */
-    double trail_accum;      /* sim-seconds accumulated toward next sample */
+    double trail_accum;      /* meters accumulated toward next sample      */
     int    trail_head;       /* index of next write slot                   */
     int    trail_count;      /* number of valid samples (0..TRAIL_LEN)     */
     double (*trail)[3];      /* heap-allocated [TRAIL_LEN][3]              */
     double trail_fade;       /* 1.0 = full alpha; fades to 0 after death   */
     int    trail_emitting;   /* 1 while the body should keep adding points */
     double trail_prev_pos[3];/* previous trail tick position for interpolation */
+    double trail_prev_vel[3];/* previous trail tick velocity for curve reconstruction */
+    double trail_frame_accum;     /* meters accumulated at frame start        */
+    int    trail_frame_head;      /* trail head snapshot at frame start       */
+    int    trail_frame_count;     /* trail count snapshot at frame start      */
+    double trail_frame_pos[3];    /* body position at frame start             */
+    double trail_frame_vel[3];    /* body velocity at frame start             */
+    double trail_frame_prev_pos[3];/* previous curve anchor at frame start    */
+    double trail_frame_prev_vel[3];/* previous curve velocity at frame start  */
 } Body;
 
 /* g_bodies is a heap-allocated array that grows via realloc.

--- a/src/build.c
+++ b/src/build.c
@@ -20,6 +20,7 @@ int g_build_tab_held = 0;
 static int s_selected = 0;
 static int s_prev_paused = 0;
 static int s_place_serial = 1;
+static unsigned int s_build_rng = 0x51f15eedu;
 
 #define BUILD_REF_LOCAL_AU        0.018
 #define BUILD_REF_INTERSTELLAR_AU 1200.0
@@ -29,17 +30,133 @@ static int s_place_serial = 1;
 #define BUILD_PARENT_STAR_MAX_AU  250.0
 
 static const BuildPreset s_presets[] = {
-    { "Rocky",    5.972e24,  6371.0e3,  {0.32f, 0.58f, 0.92f}, 0, 1, 0, {0.45f, 0.65f, 1.00f}, 0.45f, 1.25f },
-    { "Gas Giant",1.898e27, 71492.0e3,  {0.86f, 0.68f, 0.46f}, 0, 1, 0, {0.90f, 0.72f, 0.50f}, 0.25f, 1.22f },
-    { "Ice World",8.681e25,25559.0e3,  {0.54f, 0.86f, 0.96f}, 0, 1, 0, {0.62f, 0.90f, 1.00f}, 0.22f, 1.22f },
-    { "Moon",     7.342e22, 1737.4e3,  {0.72f, 0.72f, 0.68f}, 0, 0, 1, {0.00f, 0.00f, 0.00f}, 0.00f, 1.00f },
-    { "Dwarf",    1.309e22, 1188.3e3,  {0.68f, 0.63f, 0.58f}, 0, 1, 0, {0.00f, 0.00f, 0.00f}, 0.00f, 1.00f },
-    { "Star",     1.989e30,696000.0e3, {1.00f, 0.92f, 0.28f}, 1, 0, 0, {0.00f, 0.00f, 0.00f}, 0.00f, 1.00f }
+    { "Rocky Planet", 5.972e24,   6371.0e3,  {0.52f, 0.44f, 0.36f}, BUILD_VIS_ROCKY,        0, 1, 0, {0.00f, 0.00f, 0.00f}, 0.00f, 1.00f },
+    { "Gas Giant",    1.898e27,  71492.0e3,  {0.84f, 0.70f, 0.50f}, BUILD_VIS_GAS_GIANT,    0, 1, 0, {0.90f, 0.72f, 0.50f}, 0.25f, 1.22f },
+    { "Ice Planet",   8.681e25,  25559.0e3,  {0.62f, 0.84f, 0.96f}, BUILD_VIS_ICE_PLANET,   0, 1, 0, {0.62f, 0.90f, 1.00f}, 0.22f, 1.22f },
+    { "Moon",         7.342e22,   1737.4e3,  {0.72f, 0.72f, 0.68f}, BUILD_VIS_MOON,         0, 0, 1, {0.00f, 0.00f, 0.00f}, 0.00f, 1.00f },
+    { "Dwarf Planet", 1.309e22,   1188.3e3,  {0.68f, 0.63f, 0.58f}, BUILD_VIS_DWARF_PLANET, 0, 1, 0, {0.00f, 0.00f, 0.00f}, 0.00f, 1.00f },
+    { "Star",         1.989e30, 696000.0e3,  {1.00f, 0.92f, 0.28f}, BUILD_VIS_STAR,         1, 0, 0, {0.00f, 0.00f, 0.00f}, 0.00f, 1.00f }
 };
+
+static double build_rand01(void)
+{
+    s_build_rng = 1664525u * s_build_rng + 1013904223u;
+    return (double)(s_build_rng & 0x00ffffffu) / (double)0x01000000u;
+}
+
+static float lerpf(float a, float b, float t)
+{
+    return a + (b - a) * t;
+}
+
+static void random_color_in_range(BuildVisualType type, float out[3])
+{
+    float c0[3], c1[3], c2[3], c3[3];
+    double t = build_rand01();
+    double u = build_rand01();
+    double v = build_rand01();
+    double w = build_rand01();
+
+    switch (type) {
+    case BUILD_VIS_ROCKY:
+        /* basalt grey -> dusty tan -> rusty brown */
+        c0[0] = 0.30f; c0[1] = 0.30f; c0[2] = 0.31f;
+        c1[0] = 0.64f; c1[1] = 0.54f; c1[2] = 0.40f;
+        c2[0] = 0.46f; c2[1] = 0.36f; c2[2] = 0.30f;
+        c3[0] = 0.56f; c3[1] = 0.46f; c3[2] = 0.38f;
+        break;
+    case BUILD_VIS_GAS_GIANT:
+        /* warm ochre -> beige -> muted caramel */
+        c0[0] = 0.54f; c0[1] = 0.40f; c0[2] = 0.24f;
+        c1[0] = 0.92f; c1[1] = 0.84f; c1[2] = 0.66f;
+        c2[0] = 0.72f; c2[1] = 0.56f; c2[2] = 0.34f;
+        c3[0] = 0.84f; c3[1] = 0.70f; c3[2] = 0.48f;
+        break;
+    case BUILD_VIS_ICE_PLANET:
+        /* pale ice blue -> frosted cyan -> blue-white */
+        c0[0] = 0.56f; c0[1] = 0.72f; c0[2] = 0.88f;
+        c1[0] = 0.86f; c1[1] = 0.95f; c1[2] = 1.00f;
+        c2[0] = 0.66f; c2[1] = 0.82f; c2[2] = 0.94f;
+        c3[0] = 0.78f; c3[1] = 0.90f; c3[2] = 0.98f;
+        break;
+    case BUILD_VIS_MOON:
+        /* charcoal grey -> dusty light grey */
+        c0[0] = 0.36f; c0[1] = 0.36f; c0[2] = 0.37f;
+        c1[0] = 0.78f; c1[1] = 0.77f; c1[2] = 0.74f;
+        c2[0] = 0.54f; c2[1] = 0.54f; c2[2] = 0.55f;
+        c3[0] = 0.66f; c3[1] = 0.65f; c3[2] = 0.63f;
+        break;
+    case BUILD_VIS_DWARF_PLANET:
+        /* grey-brown dusty dwarf palette */
+        c0[0] = 0.38f; c0[1] = 0.38f; c0[2] = 0.39f;
+        c1[0] = 0.72f; c1[1] = 0.68f; c1[2] = 0.60f;
+        c2[0] = 0.52f; c2[1] = 0.48f; c2[2] = 0.44f;
+        c3[0] = 0.60f; c3[1] = 0.54f; c3[2] = 0.48f;
+        break;
+    default:
+        out[0] = out[1] = out[2] = 1.0f;
+        return;
+    }
+
+    if (t < 0.33) {
+        out[0] = lerpf(c0[0], c1[0], (float)(u * 0.95));
+        out[1] = lerpf(c0[1], c1[1], (float)(u * 0.95));
+        out[2] = lerpf(c0[2], c1[2], (float)(u * 0.95));
+    } else if (t < 0.66) {
+        out[0] = lerpf(c1[0], c2[0], (float)(u * 0.95));
+        out[1] = lerpf(c1[1], c2[1], (float)(u * 0.95));
+        out[2] = lerpf(c1[2], c2[2], (float)(u * 0.95));
+    } else {
+        out[0] = lerpf(c2[0], c3[0], (float)(u * 0.95));
+        out[1] = lerpf(c2[1], c3[1], (float)(u * 0.95));
+        out[2] = lerpf(c2[2], c3[2], (float)(u * 0.95));
+    }
+
+    out[0] = fminf(1.0f, fmaxf(0.0f, out[0] + (float)(v - 0.5) * 0.10f));
+    out[1] = fminf(1.0f, fmaxf(0.0f, out[1] + (float)(w - 0.5) * 0.08f));
+    out[2] = fminf(1.0f, fmaxf(0.0f, out[2] + (float)(u - 0.5) * 0.08f));
+}
+
+static double random_rotation_period_days(BuildVisualType type)
+{
+    double t = build_rand01();
+    switch (type) {
+    case BUILD_VIS_ROCKY:        return 0.35 + t * 3.4;
+    case BUILD_VIS_GAS_GIANT:    return 0.28 + t * 0.55;
+    case BUILD_VIS_ICE_PLANET:   return 0.45 + t * 1.6;
+    case BUILD_VIS_MOON:         return 0.4  + t * 18.0;
+    case BUILD_VIS_DWARF_PLANET: return 0.25 + t * 5.0;
+    case BUILD_VIS_STAR:         return 18.0 + t * 18.0;
+    default:                     return 1.0;
+    }
+}
+
+static double random_obliquity_deg(BuildVisualType type)
+{
+    double t = build_rand01();
+    switch (type) {
+    case BUILD_VIS_GAS_GIANT:    return t * 32.0;
+    case BUILD_VIS_ICE_PLANET:   return t * 98.0;
+    case BUILD_VIS_MOON:         return t * 18.0;
+    case BUILD_VIS_DWARF_PLANET: return t * 55.0;
+    case BUILD_VIS_ROCKY:        return t * 45.0;
+    case BUILD_VIS_STAR:         return 7.25;
+    default:                     return 0.0;
+    }
+}
+
+static double random_rotation_rate(BuildVisualType type)
+{
+    double period_days = random_rotation_period_days(type);
+    double sign = build_rand01() < 0.5 ? -1.0 : 1.0;
+    if (type == BUILD_VIS_STAR) sign = 1.0;
+    return sign * (2.0 * PI) / (period_days * DAY);
+}
 
 void build_init(void)
 {
     s_selected = 0;
+    s_build_rng = 0x51f15eedu;
 }
 
 int build_preset_count(void)
@@ -363,14 +480,17 @@ int build_place_current(void)
     spec.mass = p->mass;
     spec.radius = p->radius;
     build_preview_pos_m(spec.pos);
-    spec.col[0] = p->col[0];
-    spec.col[1] = p->col[1];
-    spec.col[2] = p->col[2];
+    if (p->visual_type == BUILD_VIS_STAR) {
+        spec.col[0] = p->col[0];
+        spec.col[1] = p->col[1];
+        spec.col[2] = p->col[2];
+    } else {
+        random_color_in_range(p->visual_type, spec.col);
+    }
     spec.is_star = p->is_star;
     spec.parent = -1;
-    spec.obliquity = p->is_star ? 7.25 : 23.4;
-    spec.rotation_rate = p->is_star ? (2.0 * PI) / (25.0 * DAY)
-                                    : (2.0 * PI) / DAY;
+    spec.obliquity = random_obliquity_deg(p->visual_type);
+    spec.rotation_rate = random_rotation_rate(p->visual_type);
     spec.atm_color[0] = p->atm_color[0];
     spec.atm_color[1] = p->atm_color[1];
     spec.atm_color[2] = p->atm_color[2];

--- a/src/build.c
+++ b/src/build.c
@@ -8,6 +8,7 @@
 #include "body.h"
 #include "camera.h"
 #include "physics.h"
+#include "collision.h"
 #include "universe.h"
 #include "trails.h"
 #include "labels.h"
@@ -146,6 +147,7 @@ void build_nearest3(const double pos_m[3], int out_idx[3], double out_dist_au[3]
     }
 
     for (int i = 0; i < g_nbodies; i++) {
+        if (!g_bodies[i].alive) continue;
         double dx = g_bodies[i].pos[0] - pos_m[0];
         double dy = g_bodies[i].pos[1] - pos_m[1];
         double dz = g_bodies[i].pos[2] - pos_m[2];
@@ -169,6 +171,7 @@ void build_nearest3(const double pos_m[3], int out_idx[3], double out_dist_au[3]
         int idx[3] = {-1, -1, -1};
 
         for (int i = 0; i < g_nbodies; i++) {
+            if (!g_bodies[i].alive) continue;
             int is_moon = (g_bodies[i].parent >= 0 &&
                            !g_bodies[g_bodies[i].parent].is_star);
             int accept = 0;
@@ -233,6 +236,7 @@ void build_nearest3(const double pos_m[3], int out_idx[3], double out_dist_au[3]
         double best = DBL_MAX;
         int best_idx = -1;
         for (int i = 0; i < g_nbodies; i++) {
+            if (!g_bodies[i].alive) continue;
             int used = 0;
             for (int u = 0; u < 3; u++)
                 if (out_idx[u] == i) used = 1;
@@ -258,6 +262,7 @@ static int nearest_star(const double pos_m[3])
     int best_idx = -1;
     double best_d2 = DBL_MAX;
     for (int i = 0; i < g_nbodies; i++) {
+        if (!g_bodies[i].alive) continue;
         if (!g_bodies[i].is_star) continue;
         double dx = g_bodies[i].pos[0] - pos_m[0];
         double dy = g_bodies[i].pos[1] - pos_m[1];
@@ -276,6 +281,7 @@ static int nearest_nonstar(const double pos_m[3])
     int best_idx = -1;
     double best_d2 = DBL_MAX;
     for (int i = 0; i < g_nbodies; i++) {
+        if (!g_bodies[i].alive) continue;
         if (g_bodies[i].is_star) continue;
         double dx = g_bodies[i].pos[0] - pos_m[0];
         double dy = g_bodies[i].pos[1] - pos_m[1];
@@ -367,8 +373,12 @@ int build_place_current(void)
 
     int idx = universe_add_body(&spec);
     if (idx >= 0) {
+        if (p->is_star)
+            universe_rebind_to_nearest_stars();
         trails_add_body(idx);
+        trails_reset_body(idx);
         labels_add_body(idx);
+        collision_on_body_added(idx);
         fprintf(stdout, "[Build] placed '%s' at %.3f %.3f %.3f AU\n",
                 g_bodies[idx].name,
                 g_bodies[idx].pos[0] / AU,

--- a/src/build.c
+++ b/src/build.c
@@ -26,6 +26,7 @@ static int s_place_serial = 1;
 #define BUILD_PREVIEW_TARGET_PX   18.0
 #define BUILD_PREVIEW_MIN_AU      0.00035
 #define BUILD_PREVIEW_MAX_AU      18.0
+#define BUILD_PARENT_STAR_MAX_AU  250.0
 
 static const BuildPreset s_presets[] = {
     { "Rocky",    5.972e24,  6371.0e3,  {0.32f, 0.58f, 0.92f}, 0, 1, 0, {0.45f, 0.65f, 1.00f}, 0.45f, 1.25f },
@@ -276,6 +277,21 @@ static int nearest_star(const double pos_m[3])
     return best_idx;
 }
 
+static int nearest_star_within(const double pos_m[3], double max_dist_au)
+{
+    int idx = nearest_star(pos_m);
+    if (idx < 0) return -1;
+
+    {
+        double dx = g_bodies[idx].pos[0] - pos_m[0];
+        double dy = g_bodies[idx].pos[1] - pos_m[1];
+        double dz = g_bodies[idx].pos[2] - pos_m[2];
+        double d_au = sqrt(dx*dx + dy*dy + dz*dz) / AU;
+        if (d_au > max_dist_au) return -1;
+    }
+    return idx;
+}
+
 static int nearest_nonstar(const double pos_m[3])
 {
     int best_idx = -1;
@@ -365,9 +381,9 @@ int build_place_current(void)
         if (p->wants_nonstar_parent)
             spec.parent = nearest_nonstar(spec.pos);
         if (spec.parent < 0 && p->wants_planet_parent)
-            spec.parent = nearest_star(spec.pos);
+            spec.parent = nearest_star_within(spec.pos, BUILD_PARENT_STAR_MAX_AU);
         if (spec.parent < 0)
-            spec.parent = nearest_star(spec.pos);
+            spec.parent = nearest_star_within(spec.pos, BUILD_PARENT_STAR_MAX_AU);
         add_parent_velocity(&spec, spec.parent);
     }
 

--- a/src/build.c
+++ b/src/build.c
@@ -155,7 +155,11 @@ static double random_rotation_rate(BuildVisualType type)
 
 void build_init(void)
 {
+    g_build_mode = 0;
+    g_build_tab_held = 0;
     s_selected = 0;
+    s_prev_paused = 0;
+    s_place_serial = 1;
     s_build_rng = 0x51f15eedu;
 }
 

--- a/src/build.h
+++ b/src/build.h
@@ -4,11 +4,21 @@
 #pragma once
 #include "common.h"
 
+typedef enum {
+    BUILD_VIS_ROCKY = 0,
+    BUILD_VIS_GAS_GIANT,
+    BUILD_VIS_ICE_PLANET,
+    BUILD_VIS_MOON,
+    BUILD_VIS_DWARF_PLANET,
+    BUILD_VIS_STAR
+} BuildVisualType;
+
 typedef struct {
     const char *name;
     double mass;
     double radius;
     float  col[3];
+    BuildVisualType visual_type;
     int    is_star;
     int    wants_planet_parent;
     int    wants_nonstar_parent;

--- a/src/collision.c
+++ b/src/collision.c
@@ -103,6 +103,24 @@ static int body_is_in_merge(int idx)
     return 0;
 }
 
+static int body_is_merge_target(int idx)
+{
+    for (int i = 0; i < MAX_MERGES; i++) {
+        if (!s_merges[i].active) continue;
+        if (s_merges[i].target == idx) return 1;
+    }
+    return 0;
+}
+
+static int body_is_merge_impactor(int idx)
+{
+    for (int i = 0; i < MAX_MERGES; i++) {
+        if (!s_merges[i].active) continue;
+        if (s_merges[i].impactor == idx) return 1;
+    }
+    return 0;
+}
+
 static void normalize3f(float v[3])
 {
     float len = sqrtf(v[0]*v[0] + v[1]*v[1] + v[2]*v[2]);
@@ -140,6 +158,48 @@ static double fast_then_slow_spread(double t, double fast_window)
     return 0.82 * ease_out_cubic(fast_t) + 0.18 * ease_out_cubic(slow_t);
 }
 
+static double impact_heat_curve(const ImpactEvent *e, double t)
+{
+    if (!e) return 0.0;
+    if (e->kind == COLLISION_VIS_MERGE)
+        return pow(1.0 - t, 1.45);
+    if (e->kind == COLLISION_VIS_CRATER)
+        return pow(1.0 - t, 2.35);
+    if (e->kind == COLLISION_VIS_INTERSECT)
+        return pow(1.0 - t, 1.65);
+    return (1.0 - t) * (1.0 - t);
+}
+
+static double impact_spread_curve(const ImpactEvent *e, double t)
+{
+    if (!e) return 0.0;
+    if (e->kind == COLLISION_VIS_MERGE)
+        return fast_then_slow_spread(t, 0.09);
+    if (e->kind == COLLISION_VIS_INTERSECT)
+        return fast_then_slow_spread(t, 0.16);
+    if (e->kind == COLLISION_VIS_MAJOR)
+        return fast_then_slow_spread(t, 0.14);
+    return fast_then_slow_spread(t, 0.18);
+}
+
+static double active_merge_glow_progress(int body_idx)
+{
+    double best = 0.0;
+    for (int i = 0; i < MAX_MERGES; i++) {
+        double t, grow_t;
+        MergeEvent *m = &s_merges[i];
+        if (!m->active) continue;
+        if (m->target != body_idx && m->impactor != body_idx) continue;
+        if (m->duration <= 1e-6) return 1.0;
+        t = m->age / m->duration;
+        if (t < 0.0) t = 0.0;
+        if (t > 1.0) t = 1.0;
+        grow_t = 0.20 + 0.80 * ease_out_cubic(t);
+        if (grow_t > best) best = grow_t;
+    }
+    return best;
+}
+
 static double current_visual_radius(int body_idx, double physical_radius)
 {
     RadiusTransition *fx;
@@ -160,15 +220,18 @@ static void start_radius_transition(int body_idx, double old_radius,
 {
     RadiusTransition *fx;
     double start_radius;
+    int had_active_transition;
     if (body_idx < 0 || body_idx >= MAX_BODIES) return;
     fx = &s_radius_fx[body_idx];
+    had_active_transition = fx->active;
+    start_radius = current_visual_radius(body_idx, old_radius);
     fx->active = 1;
     fx->age = 0.0;
     fx->duration = fmax(duration, 1.0);
-    start_radius = current_visual_radius(body_idx, old_radius);
-    if (new_radius > 0.0 && start_radius < new_radius * 0.35)
+    if (!had_active_transition &&
+        new_radius > 0.0 && start_radius < new_radius * 0.35)
         start_radius = new_radius * 0.35;
-    if (start_radius < old_radius)
+    if (!had_active_transition && start_radius < old_radius)
         start_radius = old_radius;
     fx->start_radius = start_radius;
     fx->target_radius = new_radius;
@@ -357,7 +420,7 @@ static void update_merge_events(double dt)
                 if (cap > scar->radius0) {
                     float local_dir[3];
                     scar->radius0 = cap;
-                    scar->radius1 = cap;
+                    scar->radius1 = fminf((float)(PI * 0.88), fmaxf(scar->radius1, cap * 1.06f));
                     body_world_to_local_surface_dir(m->target, m->dir, local_dir);
                     normalize3f(local_dir);
                     scar->dir[0] = local_dir[0];
@@ -384,7 +447,7 @@ static void update_merge_events(double dt)
                     float local_dir[3];
                     double neg_dir[3] = {-m->dir[0], -m->dir[1], -m->dir[2]};
                     scar->radius0 = cap;
-                    scar->radius1 = cap;
+                    scar->radius1 = fminf((float)(PI * 0.88), fmaxf(scar->radius1, cap * 1.06f));
                     body_world_to_local_surface_dir(m->impactor, neg_dir, local_dir);
                     normalize3f(local_dir);
                     scar->dir[0] = local_dir[0];
@@ -406,7 +469,10 @@ static void update_merge_events(double dt)
                 if (m->scar_slot >= 0 && m->scar_slot < MAX_IMPACTS &&
                     s_impacts[m->scar_slot].active && s_impacts[m->scar_slot].radius0 > 0.01f) {
                     float r0 = s_impacts[m->scar_slot].radius0;
-                    s_impacts[m->scar_slot].radius1 = fminf(r0 * 2.2f, (float)(PI * 0.88));
+                    float r1 = s_impacts[m->scar_slot].radius1;
+                    if (r1 < r0) r1 = r0;
+                    s_impacts[m->scar_slot].radius1 = fminf((float)(PI * 0.88),
+                                                            fmaxf(r1, r0 * 1.12f));
                 }
 
                 m->active = 0;
@@ -813,7 +879,7 @@ void collision_step(double dt)
             nb = member_count[other_root];
             for (int ai = 0; ai < na && !root_had_collision; ai++) {
                 int a = members[root][ai];
-                if (!g_bodies[a].alive || g_bodies[a].is_star || resolved[a] || body_is_in_merge(a)) continue;
+                if (!g_bodies[a].alive || g_bodies[a].is_star || resolved[a] || body_is_merge_impactor(a)) continue;
                 for (int bi = 0; bi < nb; bi++) {
                     int b = members[other_root][bi];
                     int lo, hi;
@@ -821,7 +887,7 @@ void collision_step(double dt)
 
                     if (same_root && bi <= ai) continue;
                     if (a == b) continue;
-                    if (!g_bodies[b].alive || g_bodies[b].is_star || resolved[b] || body_is_in_merge(b)) continue;
+                    if (!g_bodies[b].alive || g_bodies[b].is_star || resolved[b] || body_is_merge_impactor(b)) continue;
 
                     lo = a < b ? a : b;
                     hi = a < b ? b : a;
@@ -839,14 +905,29 @@ void collision_step(double dt)
                     }
 
                     {
-                        int target = g_bodies[a].mass >= g_bodies[b].mass ? a : b;
-                        int impactor = target == a ? b : a;
+                        int a_is_merge_target = body_is_merge_target(a);
+                        int b_is_merge_target = body_is_merge_target(b);
+                        int keep_target_open;
+                        int target;
+                        int impactor;
+                        if (a_is_merge_target && !b_is_merge_target)
+                            target = a;
+                        else if (b_is_merge_target && !a_is_merge_target)
+                            target = b;
+                        else
+                            target = g_bodies[a].mass >= g_bodies[b].mass ? a : b;
+                        impactor = target == a ? b : a;
                         absorb_body(target, impactor, speed, dt);
-                        resolved[target] = 1;
+                        keep_target_open = body_is_merge_target(target);
+                        if (!keep_target_open)
+                            resolved[target] = 1;
                         resolved[impactor] = 1;
                         s_pair_next[lo][hi] = HOT_PAIR_DT;
-                        root_had_collision = 1;
-                        break;
+                        if (!keep_target_open) {
+                            root_had_collision = 1;
+                            break;
+                        }
+                        if (impactor == a) break;
                     }
                 }
             }
@@ -870,21 +951,9 @@ int collision_spots_for_body(int body_idx, CollisionSpot spots[COLLISION_MAX_SPO
         t = e->age / e->duration;
         if (t < 0.0) t = 0.0;
         if (t > 1.0) t = 1.0;
-        heat_curve = (1.0 - t) * (1.0 - t);
-        if (e->kind == COLLISION_VIS_MERGE)
-            heat_curve = pow(1.0 - t, 1.45);
-        else if (e->kind == COLLISION_VIS_CRATER)
-            heat_curve = pow(1.0 - t, 2.35);
+        heat_curve = impact_heat_curve(e, t);
         {
-            double spread_t;
-            if (e->kind == COLLISION_VIS_MERGE)
-                spread_t = fast_then_slow_spread(t, 0.09);
-            else if (e->kind == COLLISION_VIS_INTERSECT)
-                spread_t = fast_then_slow_spread(t, 0.07);
-            else if (e->kind == COLLISION_VIS_MAJOR)
-                spread_t = fast_then_slow_spread(t, 0.14);
-            else
-                spread_t = fast_then_slow_spread(t, 0.18);
+            double spread_t = impact_spread_curve(e, t);
             rad = e->radius0 + (e->radius1 - e->radius0) * ease_out_cubic(spread_t);
         }
         {
@@ -918,6 +987,7 @@ void collision_body_heat_glow(int body_idx, float out_color[3],
 {
     float best_heat = 0.0f;
     int has_merge = 0;
+    double merge_growth = active_merge_glow_progress(body_idx);
 
     if (out_color) {
         out_color[0] = 0.0f;
@@ -937,11 +1007,7 @@ void collision_body_heat_glow(int body_idx, float out_color[3],
         t = e->age / e->duration;
         if (t < 0.0) t = 0.0;
         if (t > 1.0) t = 1.0;
-        heat_curve = (1.0 - t) * (1.0 - t);
-        if (e->kind == COLLISION_VIS_MERGE)
-            heat_curve = pow(1.0 - t, 1.45);
-        else if (e->kind == COLLISION_VIS_CRATER)
-            heat_curve = pow(1.0 - t, 2.35);
+        heat_curve = impact_heat_curve(e, t);
         heat = e->heat0 * (float)heat_curve;
         if (heat > best_heat) best_heat = heat;
         if (e->kind == COLLISION_VIS_MERGE || e->kind == COLLISION_VIS_INTERSECT)
@@ -953,6 +1019,7 @@ void collision_body_heat_glow(int body_idx, float out_color[3],
     if (best_heat < 0.0f) best_heat = 0.0f;
     if (best_heat > 1.0f) best_heat = 1.0f;
     best_heat = best_heat * best_heat * (3.0f - 2.0f * best_heat);
+    if (merge_growth > 0.0) best_heat *= (float)merge_growth;
 
     if (out_color) {
         out_color[0] = 0.90f;

--- a/src/collision.c
+++ b/src/collision.c
@@ -73,6 +73,7 @@ typedef struct {
     double vel[3];
     float color[4];
     float size;
+    float fade_start; /* normalized lifetime fraction at which alpha fade begins */
 } ImpactParticleState;
 
 static ImpactEvent s_impacts[MAX_IMPACTS];
@@ -527,7 +528,8 @@ static void spawn_impact_particles(int body_idx, int kind, const double world_di
         p->color[1] = base_g * (0.90f + 0.20f * (float)rand01());
         p->color[2] = base_b * (0.85f + 0.25f * (float)rand01());
         p->color[3] = 1.0f;
-        p->size = 0.5f + 2.5f * (float)rand01();
+        p->size       = (0.5f + 2.5f * (float)rand01()) * (float)size_mix;
+        p->fade_start = (float)(0.78 - 0.38 * (1.0 - size_mix));
     }
 }
 
@@ -591,21 +593,28 @@ static void add_impact(int body_idx, int kind, const double world_dir[3],
     radius_ratio = impactor_radius / fmax(b->radius, 1.0);
 
     if (kind == COLLISION_VIS_CRATER) {
-        e->duration = IMPACT_COOL_SECONDS;
+        /* No upper cap: classification already bounds radius_ratio < ~0.43.
+         * Duration scales with radius0 so small craters fade fast, large ones linger. */
+        e->radius0 = (float)fmax(0.004, radius_ratio * 0.65);
+        e->radius1 = e->radius0 * 1.20f;
+        e->duration = IMPACT_COOL_SECONDS * fmax(0.15, (double)e->radius0 / 0.15);
         e->heat0 = (float)fmin(0.95, 0.22 + rel_speed / 32000.0);
-        e->radius0 = (float)fmax(0.010, fmin(0.070, radius_ratio * 0.70));
-        e->radius1 = (float)fmax(e->radius0 + 0.020f, fmin(0.240, e->radius0 * 2.80f));
     } else if (kind == COLLISION_VIS_MAJOR) {
-        e->duration = MAJOR_COOL_SECONDS;
+        /* Same: no upper cap, duration proportional to radius0. */
+        e->radius0 = (float)fmax(0.018, radius_ratio * 0.90);
+        e->radius1 = e->radius0 * 1.20f;
+        e->duration = MAJOR_COOL_SECONDS * fmax(0.30, (double)e->radius0 / 0.50);
         e->heat0 = (float)fmin(1.0, 0.45 + rel_speed / 22000.0 + mass_ratio * 0.4);
-        e->radius0 = (float)fmax(0.030, fmin(0.140, radius_ratio * 1.05));
-        e->radius1 = (float)fmax(e->radius0 + 0.060f, fmin(0.650, e->radius0 * 3.10f));
     } else {
         e->duration = MERGE_COOL_SECONDS;
         e->heat0 = 1.0f;
         e->radius0 = (float)fmax(0.120, fmin(0.280, 0.12 + mass_ratio * 0.28));
         e->radius1 = (float)fmax(2.30f, fmin(3.20f, 2.30f + mass_ratio * 0.70f));
     }
+    fprintf(stderr, "[impact] kind=%s rr=%.3f r0=%.4f r1=%.4f dur=%.1fd\n",
+            kind == COLLISION_VIS_CRATER ? "crater" :
+            kind == COLLISION_VIS_MAJOR  ? "major"  : "merge",
+            radius_ratio, e->radius0, e->radius1, e->duration / DAY);
     body_world_to_local_surface_dir(body_idx, world_dir, e->dir);
     normalize3f(e->dir);
     spawn_impact_particles(body_idx, kind, world_dir, rel_vel,
@@ -692,7 +701,7 @@ static void finalize_absorb_body(int target, int impactor, double rel_speed,
     labels_remove_body(impactor);
     trails_remove_body(impactor);
     mark_system_dirty(body_root_star(target), SYSTEM_HOT_DURATION);
-    fprintf(stdout, "[collision] %s absorbed %s (%.0f m/s, %s, %.0f->%.0f km)\n",
+    fprintf(stderr, "[collision] %s absorbed %s (%.0f m/s, %s, %.0f->%.0f km)\n",
             a->name, b->name, rel_speed,
             outcome == COLLISION_VIS_MERGE ? "merge" :
             outcome == COLLISION_VIS_MAJOR ? "major" : "crater",
@@ -760,6 +769,38 @@ static void update_merge_events(double dt)
                 pen_t = fast_t * (1.0 - 0.12 * tail_blend) + t * (0.12 * tail_blend);
             }
             overlap_sep = m->start_sep + (final_target_sep - m->start_sep) * pen_t;
+
+            /* Despawn the impactor the moment it is fully inside the target. */
+            if (overlap_sep + impactor_r <= target_contact_r) {
+                double old_radius = target->radius;
+                impactor->pos[0] = target->pos[0] + m->dir[0] * overlap_sep;
+                impactor->pos[1] = target->pos[1] + m->dir[1] * overlap_sep;
+                impactor->pos[2] = target->pos[2] + m->dir[2] * overlap_sep;
+                /* Do not finish_radius_transition here — let it run to anim_dur
+                 * so the target grows smoothly to its final size. */
+                if (m->scar_slot >= 0 && m->scar_slot < MAX_IMPACTS &&
+                    s_impacts[m->scar_slot].active) {
+                    float r0 = s_impacts[m->scar_slot].radius0;
+                    float r1_old = s_impacts[m->scar_slot].radius1;
+                    if (r0 <= 0.01f) {
+                        /* Geometric tracking never ran (sim dt >= anim_dur or tiny impactor).
+                         * Estimate the peak cap angle from the impactor's angular size. */
+                        float ov = (float)impactor_r;
+                        float sv = (float)target_contact_r;
+                        r0 = (float)fmax(0.01, asin(fmin(0.999, ov / fmax(sv, ov))));
+                        s_impacts[m->scar_slot].radius0 = r0;
+                    }
+                    s_impacts[m->scar_slot].radius1 = fminf((float)(PI * 0.88), r0 * 1.20f);
+                    s_impacts[m->scar_slot].duration = MERGE_COOL_SECONDS
+                        * fmax(0.30, (double)r0 / (PI * 0.50));
+                    fprintf(stderr, "[early-despawn] r0=%.4f r1_old=%.4f r1_new=%.4f\n",
+                            r0, r1_old, s_impacts[m->scar_slot].radius1);
+                }
+                m->active = 0;
+                finalize_absorb_body(m->target, m->impactor, m->rel_speed,
+                                     COLLISION_VIS_MERGE, old_radius);
+                continue;
+            }
         }
         impactor->pos[0] = target->pos[0] + m->dir[0] * overlap_sep;
         impactor->pos[1] = target->pos[1] + m->dir[1] * overlap_sep;
@@ -854,14 +895,25 @@ static void update_merge_events(double dt)
                 double old_radius = target->radius;
                 finish_radius_transition(m->target);
 
-                /* Release target scar: set radius1 so it expands outward while cooling. */
+                /* Release target scar: expand 20% beyond the geometric cap reached
+                 * during the merge. Duration scales with scar size so growth speed
+                 * is proportional (smaller merger = faster fade). */
                 if (m->scar_slot >= 0 && m->scar_slot < MAX_IMPACTS &&
-                    s_impacts[m->scar_slot].active && s_impacts[m->scar_slot].radius0 > 0.01f) {
+                    s_impacts[m->scar_slot].active) {
                     float r0 = s_impacts[m->scar_slot].radius0;
-                    float r1 = s_impacts[m->scar_slot].radius1;
-                    if (r1 < r0) r1 = r0;
-                    s_impacts[m->scar_slot].radius1 = fminf((float)(PI * 0.88),
-                                                            fmaxf(r1, r0 * 1.12f));
+                    if (r0 <= 0.01f) {
+                        /* Tracking never ran — estimate from impactor angular size. */
+                        float ov = (float)g_bodies[m->impactor].radius;
+                        float sv = (float)current_contact_radius(m->target);
+                        r0 = (float)fmax(0.01, asin(fmin(0.999, ov / fmax(sv, ov))));
+                        s_impacts[m->scar_slot].radius0 = r0;
+                    }
+                    s_impacts[m->scar_slot].radius1 = fminf((float)(PI * 0.88), r0 * 1.20f);
+                    s_impacts[m->scar_slot].duration = MERGE_COOL_SECONDS
+                        * fmax(0.30, (double)r0 / (PI * 0.50));
+                    fprintf(stderr, "[merge-release] r0=%.4f r1=%.4f dur=%.1fd\n",
+                            r0, s_impacts[m->scar_slot].radius1,
+                            s_impacts[m->scar_slot].duration / DAY);
                 }
 
                 m->active = 0;
@@ -938,7 +990,7 @@ static void begin_merge_event(int target, int impactor, double rel_speed,
         s_merges[slot].duration  = anim_dur;
         s_merges[slot].start_sep = sep_init;
 
-        start_radius_transition(target, old_radius, a->radius, anim_dur * 0.78);
+        start_radius_transition(target, old_radius, a->radius, anim_dur);
         /* Impactor keeps its size throughout — no shrink transition. */
     }
 
@@ -1194,6 +1246,14 @@ static void absorb_body(int target, int impactor, double rel_speed, double colli
     old_radius = current_contact_radius(target);
     mass_ratio = fmin(a->mass, b->mass) / fmax(fmax(a->mass, b->mass), 1.0);
     outcome = classify_collision(target, impactor, rel_speed);
+    {
+        double ra = current_contact_radius(target);
+        double rb = current_contact_radius(impactor);
+        fprintf(stderr, "[absorb] %s <- %s  mr=%.3f rr=%.3f  outcome=%s\n",
+                a->name, b->name, mass_ratio, rb/fmax(ra,1.0),
+                outcome==COLLISION_VIS_MERGE?"MERGE":
+                outcome==COLLISION_VIS_MAJOR?"MAJOR":"CRATER");
+    }
     impact_dir_for_pair(target, impactor, collision_dt, dir);
     if (outcome == COLLISION_VIS_MERGE) {
         begin_merge_event(target, impactor, rel_speed, dir, rel_vel, old_radius);
@@ -1512,7 +1572,7 @@ int collision_particles(CollisionParticle *out, int max_particles,
         if (t < 0.0) t = 0.0;
         if (t > 1.0) t = 1.0;
         fade = 1.0 - t;
-        fade_t = (t - 0.78) / 0.22;
+        fade_t = (t - p->fade_start) / (1.0 - p->fade_start);
         if (fade_t < 0.0) fade_t = 0.0;
         if (fade_t > 1.0) fade_t = 1.0;
         alpha = 1.0 - fade_t * fade_t;

--- a/src/collision.c
+++ b/src/collision.c
@@ -4,6 +4,16 @@
  * Keeps body indices stable by marking absorbed bodies as !alive. The visual
  * side is deliberately lightweight: an impact creates a local hot spot that
  * the planet shader fades over time.
+ *
+ * Sections (search "§"):
+ *   § STATE     — constants, structs, static arrays, housekeeping
+ *   § MATH      — geometry helpers, body surface transforms, spin physics
+ *   § CURVES    — easing, heat/spread curves, visual radius helpers
+ *   § PARTICLES — intersection ring geometry, particle spawning
+ *   § SCARS     — radius transitions, impact events, permanent craters
+ *   § MERGE     — merge lifecycle: begin → update → finalize
+ *   § DETECT    — classification, swept-sphere, broadphase loop
+ *   § API       — public query functions
  */
 #include "collision.h"
 #include "body.h"
@@ -13,7 +23,10 @@
 #include <math.h>
 #include <stdio.h>
 
+/* ── § STATE — constants, structs, static arrays, housekeeping ───────── */
+
 #define MAX_IMPACTS 64
+#define TRAIL_FADE_DURATION (DAY * 60.0)
 #define MAX_PAIR_DT (DAY * 2.0)
 #define MIN_PAIR_DT (60.0 * 5.0)
 #define HOT_PAIR_DT (60.0 * 10.0)
@@ -128,6 +141,8 @@ void collision_on_body_added(int body_idx)
     int root = body_root_star(body_idx);
     if (root >= 0) mark_system_dirty(root, SYSTEM_HOT_DURATION);
 }
+
+/* ── § MATH — geometry helpers, body surface transforms, spin physics ── */
 
 static int body_is_descendant_of(int body_idx, int ancestor_idx)
 {
@@ -408,6 +423,8 @@ static void compute_collision_spin_state(int target, int impactor,
         *out_rotation_rate = (L_total[0] * merged_axis[0] + L_total[1] * merged_axis[1]) / fmax(merged_I, 1e-12);
 }
 
+/* ── § CURVES — easing, heat/spread curves, visual radius helpers ─────── */
+
 static double ease_out_cubic(double t)
 {
     double inv;
@@ -497,6 +514,8 @@ static double current_contact_radius(int body_idx)
     if (body_idx < 0 || body_idx >= g_nbodies) return 0.0;
     return current_visual_radius(body_idx, g_bodies[body_idx].radius);
 }
+
+/* ── § PARTICLES — intersection ring geometry, particle spawning ─────── */
 
 static int current_merge_intersection_ring(int body_idx, const double fallback_dir[3],
                                            double out_center[3], double out_normal[3],
@@ -732,6 +751,8 @@ static void spawn_impact_particles(int body_idx, int kind, const double world_di
     }
 }
 
+/* ── § SCARS — radius transitions, impact events, permanent craters ───── */
+
 static void finish_radius_transition(int body_idx)
 {
     RadiusTransition *fx;
@@ -868,6 +889,8 @@ static void add_permanent_crater(int body_idx, const double world_dir[3],
     s->seed = rand01f() * 100.0f;
 }
 
+/* ── § MERGE — merge lifecycle: begin → update → finalize ────────────── */
+
 static double trail_interval_for_body_after_merge(int body_idx)
 {
     Body *b;
@@ -939,14 +962,18 @@ static void finalize_absorb_body(int target, int impactor, double rel_speed,
     }
 
     rings_on_body_absorbed(target, impactor);
+    if (b->trail && b->trail_count > 0) {
+        b->trail[b->trail_head][0] = b->pos[0] * RS;
+        b->trail[b->trail_head][1] = b->pos[1] * RS;
+        b->trail[b->trail_head][2] = b->pos[2] * RS;
+        b->trail_head = (b->trail_head + 1) % TRAIL_LEN;
+        if (b->trail_count < TRAIL_LEN) b->trail_count++;
+    }
     b->alive = 0;
     b->mass = 0.0;
-    b->trail_count = 0;
     a->trail_interval = trail_interval_for_body_after_merge(target);
-    trails_reset_body(target);
     labels_add_body(target);
     labels_remove_body(impactor);
-    trails_remove_body(impactor);
     mark_system_dirty(body_root_star(target), SYSTEM_HOT_DURATION);
     fprintf(stderr, "[collision] %s absorbed %s (%.0f m/s, %s, %.0f->%.0f km)\n",
             a->name, b->name, rel_speed,
@@ -1200,6 +1227,16 @@ static void begin_merge_event(int target, int impactor, double rel_speed,
     }
     if (slot < 0) slot = 0;
 
+    if (b->trail && b->trail_count > 0) {
+        b->trail[b->trail_head][0] = b->pos[0] * RS;
+        b->trail[b->trail_head][1] = b->pos[1] * RS;
+        b->trail[b->trail_head][2] = b->pos[2] * RS;
+        b->trail_head = (b->trail_head + 1) % TRAIL_LEN;
+        if (b->trail_count < TRAIL_LEN) b->trail_count++;
+    }
+    b->trail_interval = 0.0;
+
+
     if (total <= 0.0) return;
 
     a->vel[0] = (a->vel[0] * a->mass + b->vel[0] * b->mass) / total;
@@ -1340,6 +1377,8 @@ static void begin_merge_event(int target, int impactor, double rel_speed,
     spawn_impact_particles(target, COLLISION_VIS_MERGE, dir, s_merges[slot].rel_vel,
                            b->radius, rel_speed, 0.85);
 }
+
+/* ── § DETECT — classification, swept-sphere, broadphase loop ────────── */
 
 static int classify_collision(int a, int b, double rel_speed)
 {
@@ -1612,6 +1651,16 @@ void collision_step(double dt)
 
     if (dt <= 0.0) return;
 
+    for (int i = 0; i < g_nbodies; i++) {
+        Body *b = &g_bodies[i];
+        if (b->alive || !b->trail || b->trail_count < 1 || b->trail_fade <= 0.0) continue;
+        b->trail_fade -= dt / TRAIL_FADE_DURATION;
+        if (b->trail_fade <= 0.0) {
+            b->trail_fade = 0.0;
+            b->trail_count = 0;
+        }
+    }
+
     for (int i = 0; i < MAX_BODIES; i++) {
         if (s_system_dirty[i]) { any_dirty = 1; break; }
     }
@@ -1734,6 +1783,8 @@ void collision_step(double dt)
         }
     }
 }
+
+/* ── § API — public query functions ──────────────────────────────────── */
 
 int collision_spots_for_body(int body_idx, CollisionSpot spots[COLLISION_MAX_SPOTS])
 {

--- a/src/collision.c
+++ b/src/collision.c
@@ -730,11 +730,12 @@ static void absorb_body(int target, int impactor, double rel_speed, double colli
 
 void collision_step(double dt)
 {
-    int root_of[MAX_BODIES];
     double system_radius[MAX_BODIES];
     int resolved[MAX_BODIES] = {0};
     int members[MAX_BODIES][MAX_BODIES];
     int member_count[MAX_BODIES] = {0};
+    int active_roots[MAX_BODIES];
+    int active_root_count = 0;
     int any_dirty = 0;
 
     update_merge_events(dt);
@@ -772,14 +773,14 @@ void collision_step(double dt)
     if (!any_dirty) return;
 
     for (int i = 0; i < MAX_BODIES; i++) {
-        root_of[i] = -1;
         system_radius[i] = SYSTEM_MARGIN_AU * AU;
     }
     for (int i = 0; i < g_nbodies; i++) {
         if (!g_bodies[i].alive) continue;
         int root = body_root_star(i);
-        root_of[i] = root;
         if (root < 0 || root >= g_nbodies) continue;
+        if (member_count[root] == 0 && active_root_count < MAX_BODIES)
+            active_roots[active_root_count++] = root;
         if (member_count[root] < MAX_BODIES)
             members[root][member_count[root]++] = i;
         double dx = g_bodies[i].pos[0] - g_bodies[root].pos[0];
@@ -797,41 +798,56 @@ void collision_step(double dt)
             continue;
         }
 
-        int n = member_count[root];
         int root_had_collision = 0;
-        for (int ai = 0; ai < n && !root_had_collision; ai++) {
-            int a = members[root][ai];
-            if (!g_bodies[a].alive || g_bodies[a].is_star || resolved[a] || body_is_in_merge(a)) continue;
-            for (int bi = ai + 1; bi < n; bi++) {
-                int b = members[root][bi];
-                int lo = a < b ? a : b;
-                int hi = a < b ? b : a;
-                double speed = 0.0;
+        for (int rj = 0; rj < active_root_count && !root_had_collision; rj++) {
+            int other_root = active_roots[rj];
+            int same_root = (other_root == root);
+            int na, nb;
 
-                if (!g_bodies[b].alive || g_bodies[b].is_star || resolved[b] || body_is_in_merge(b)) continue;
-                if (!systems_may_interact(root_of[a], root_of[b], system_radius)) continue;
+            if (other_root < 0 || other_root >= g_nbodies) continue;
+            if (!g_bodies[other_root].alive) continue;
+            if (other_root < root) continue;
+            if (!systems_may_interact(root, other_root, system_radius)) continue;
 
-                if (s_system_hot[root] > 0.0) {
-                    s_pair_next[lo][hi] = HOT_PAIR_DT;
-                } else {
-                    s_pair_next[lo][hi] -= dt;
-                    if (s_pair_next[lo][hi] > 0.0) continue;
-                }
+            na = member_count[root];
+            nb = member_count[other_root];
+            for (int ai = 0; ai < na && !root_had_collision; ai++) {
+                int a = members[root][ai];
+                if (!g_bodies[a].alive || g_bodies[a].is_star || resolved[a] || body_is_in_merge(a)) continue;
+                for (int bi = 0; bi < nb; bi++) {
+                    int b = members[other_root][bi];
+                    int lo, hi;
+                    double speed = 0.0;
 
-                if (!swept_spheres_collide(a, b, dt, &speed)) {
-                    s_pair_next[lo][hi] = pair_check_dt(a, b);
-                    continue;
-                }
+                    if (same_root && bi <= ai) continue;
+                    if (a == b) continue;
+                    if (!g_bodies[b].alive || g_bodies[b].is_star || resolved[b] || body_is_in_merge(b)) continue;
 
-                {
-                    int target = g_bodies[a].mass >= g_bodies[b].mass ? a : b;
-                    int impactor = target == a ? b : a;
-                    absorb_body(target, impactor, speed, dt);
-                    resolved[target] = 1;
-                    resolved[impactor] = 1;
-                    s_pair_next[lo][hi] = HOT_PAIR_DT;
-                    root_had_collision = 1;
-                    break;
+                    lo = a < b ? a : b;
+                    hi = a < b ? b : a;
+
+                    if (s_system_hot[root] > 0.0) {
+                        s_pair_next[lo][hi] = HOT_PAIR_DT;
+                    } else {
+                        s_pair_next[lo][hi] -= dt;
+                        if (s_pair_next[lo][hi] > 0.0) continue;
+                    }
+
+                    if (!swept_spheres_collide(a, b, dt, &speed)) {
+                        s_pair_next[lo][hi] = pair_check_dt(a, b);
+                        continue;
+                    }
+
+                    {
+                        int target = g_bodies[a].mass >= g_bodies[b].mass ? a : b;
+                        int impactor = target == a ? b : a;
+                        absorb_body(target, impactor, speed, dt);
+                        resolved[target] = 1;
+                        resolved[impactor] = 1;
+                        s_pair_next[lo][hi] = HOT_PAIR_DT;
+                        root_had_collision = 1;
+                        break;
+                    }
                 }
             }
         }

--- a/src/collision.c
+++ b/src/collision.c
@@ -25,6 +25,7 @@
 #define MERGE_COOL_SECONDS (DAY * 180.0)
 #define MERGE_PHASE_SECONDS (DAY * 8.0)
 #define MAX_MERGES 16
+#define MAX_COLLISION_PARTICLES 768
 
 typedef struct {
     int active;
@@ -54,19 +55,34 @@ typedef struct {
     double duration;
     double rel_speed;
     double dir[3];
+    double rel_vel[3];
     double start_sep;
+    double particle_emit_accum;
+    double particle_emit_next;
     double target_rotation_rate;   /* saved initial rates so both can slow together */
     double impactor_rotation_rate;
     int scar_slot;          /* s_impacts index for the target intersection scar */
     int imp_scar_slot;      /* s_impacts index for the impactor intersection scar */
 } MergeEvent;
 
+typedef struct {
+    int active;
+    double age;
+    double duration;
+    double pos[3];
+    double vel[3];
+    float color[4];
+    float size;
+} ImpactParticleState;
+
 static ImpactEvent s_impacts[MAX_IMPACTS];
 static RadiusTransition s_radius_fx[MAX_BODIES];
 static MergeEvent s_merges[MAX_MERGES];
+static ImpactParticleState s_particles[MAX_COLLISION_PARTICLES];
 static double s_pair_next[MAX_BODIES][MAX_BODIES];
 static unsigned char s_system_dirty[MAX_BODIES];
 static double s_system_hot[MAX_BODIES];
+static unsigned int s_particle_rng = 0x1234abcdu;
 
 static void mark_system_dirty(int root, double hot_duration)
 {
@@ -131,6 +147,54 @@ static void normalize3f(float v[3])
     v[0] /= len; v[1] /= len; v[2] /= len;
 }
 
+static double rand01(void)
+{
+    s_particle_rng = 1664525u * s_particle_rng + 1013904223u;
+    return (double)(s_particle_rng & 0x00ffffffu) / (double)0x01000000u;
+}
+
+static void orthonormal_basis(const double n[3], double t1[3], double t2[3])
+{
+    double ref[3] = {0.0, 1.0, 0.0};
+    double len;
+
+    if (fabs(n[1]) > 0.9) {
+        ref[0] = 1.0;
+        ref[1] = 0.0;
+        ref[2] = 0.0;
+    }
+
+    t1[0] = n[1]*ref[2] - n[2]*ref[1];
+    t1[1] = n[2]*ref[0] - n[0]*ref[2];
+    t1[2] = n[0]*ref[1] - n[1]*ref[0];
+    len = sqrt(dot3d(t1, t1));
+    if (len <= 1e-12) {
+        t1[0] = 1.0; t1[1] = 0.0; t1[2] = 0.0;
+    } else {
+        t1[0] /= len; t1[1] /= len; t1[2] /= len;
+    }
+
+    t2[0] = n[1]*t1[2] - n[2]*t1[1];
+    t2[1] = n[2]*t1[0] - n[0]*t1[2];
+    t2[2] = n[0]*t1[1] - n[1]*t1[0];
+    len = sqrt(dot3d(t2, t2));
+    if (len <= 1e-12) {
+        t2[0] = 0.0; t2[1] = 0.0; t2[2] = 1.0;
+    } else {
+        t2[0] /= len; t2[1] /= len; t2[2] /= len;
+    }
+}
+
+static void normalize3d(double v[3])
+{
+    double len = sqrt(dot3d(v, v));
+    if (len <= 1e-12) {
+        v[0] = 1.0; v[1] = 0.0; v[2] = 0.0;
+        return;
+    }
+    v[0] /= len; v[1] /= len; v[2] /= len;
+}
+
 static double ease_out_cubic(double t)
 {
     double inv;
@@ -176,7 +240,7 @@ static double impact_spread_curve(const ImpactEvent *e, double t)
     if (e->kind == COLLISION_VIS_MERGE)
         return fast_then_slow_spread(t, 0.09);
     if (e->kind == COLLISION_VIS_INTERSECT)
-        return fast_then_slow_spread(t, 0.16);
+        return fast_then_slow_spread(t, 0.42);
     if (e->kind == COLLISION_VIS_MAJOR)
         return fast_then_slow_spread(t, 0.14);
     return fast_then_slow_spread(t, 0.18);
@@ -194,7 +258,7 @@ static double active_merge_glow_progress(int body_idx)
         t = m->age / m->duration;
         if (t < 0.0) t = 0.0;
         if (t > 1.0) t = 1.0;
-        grow_t = 0.20 + 0.80 * ease_out_cubic(t);
+        grow_t = 0.78 + 0.22 * ease_out_cubic(t);
         if (grow_t > best) best = grow_t;
     }
     return best;
@@ -213,6 +277,256 @@ static double current_visual_radius(int body_idx, double physical_radius)
     if (t >= 1.0) return fx->target_radius;
     return fx->start_radius +
            (fx->target_radius - fx->start_radius) * ease_out_cubic(t);
+}
+
+static double current_contact_radius(int body_idx)
+{
+    if (body_idx < 0 || body_idx >= g_nbodies) return 0.0;
+    return current_visual_radius(body_idx, g_bodies[body_idx].radius);
+}
+
+static int current_merge_intersection_ring(int body_idx, const double fallback_dir[3],
+                                           double out_center[3], double out_normal[3],
+                                           double *out_ring_radius)
+{
+    double best_align = -2.0;
+    double fallback_n[3] = {1.0, 0.0, 0.0};
+    double fallback_len = sqrt(dot3d(fallback_dir, fallback_dir));
+
+    if (body_idx < 0 || body_idx >= g_nbodies) return 0;
+    if (fallback_len > 1e-12) {
+        fallback_n[0] = fallback_dir[0] / fallback_len;
+        fallback_n[1] = fallback_dir[1] / fallback_len;
+        fallback_n[2] = fallback_dir[2] / fallback_len;
+    }
+
+    for (int i = 0; i < MAX_MERGES; i++) {
+        MergeEvent *m = &s_merges[i];
+        int other_idx;
+        double c0[3], c1[3], n[3], d, r0, r1, x, rr2, align;
+
+        if (!m->active) continue;
+        if (m->target != body_idx && m->impactor != body_idx) continue;
+
+        other_idx = (m->target == body_idx) ? m->impactor : m->target;
+        if (other_idx < 0 || other_idx >= g_nbodies) continue;
+        if (!g_bodies[body_idx].alive || !g_bodies[other_idx].alive) continue;
+
+        c0[0] = g_bodies[body_idx].pos[0];
+        c0[1] = g_bodies[body_idx].pos[1];
+        c0[2] = g_bodies[body_idx].pos[2];
+        c1[0] = g_bodies[other_idx].pos[0];
+        c1[1] = g_bodies[other_idx].pos[1];
+        c1[2] = g_bodies[other_idx].pos[2];
+        n[0] = c1[0] - c0[0];
+        n[1] = c1[1] - c0[1];
+        n[2] = c1[2] - c0[2];
+        d = sqrt(dot3d(n, n));
+        if (d <= 1e-9) continue;
+
+        n[0] /= d; n[1] /= d; n[2] /= d;
+        align = dot3d(n, fallback_n);
+        if (align < best_align) continue;
+
+        r0 = current_contact_radius(body_idx);
+        r1 = current_contact_radius(other_idx);
+        if (d >= r0 + r1) continue;
+
+        x = (r0*r0 - r1*r1 + d*d) / (2.0 * d);
+        if (x < 0.0) x = 0.0;
+        if (x > r0) x = r0;
+        rr2 = r0*r0 - x*x;
+        if (rr2 <= 1e-6) continue;
+
+        out_center[0] = c0[0] + n[0] * x;
+        out_center[1] = c0[1] + n[1] * x;
+        out_center[2] = c0[2] + n[2] * x;
+        out_normal[0] = n[0];
+        out_normal[1] = n[1];
+        out_normal[2] = n[2];
+        *out_ring_radius = sqrt(rr2);
+        best_align = align;
+    }
+
+    return best_align > -1.5;
+}
+
+static void spawn_impact_particles(int body_idx, int kind, const double world_dir[3],
+                                   const double rel_vel[3], double impactor_radius,
+                                   double rel_speed, double pack_scale)
+{
+    double n[3] = {world_dir[0], world_dir[1], world_dir[2]};
+    double len = sqrt(dot3d(n, n));
+    double t1[3], t2[3];
+    double body_r, size_ratio, size_mix;
+    double anchor_center[3] = {0.0, 0.0, 0.0};
+    double anchor_normal[3] = {1.0, 0.0, 0.0};
+    double base_ring_radius = 0.0;
+    int use_live_ring = 0;
+    int count;
+    float base_r, base_g, base_b;
+
+    if (body_idx < 0 || body_idx >= g_nbodies) return;
+    if (!g_bodies[body_idx].alive || len <= 1e-12) return;
+
+    n[0] /= len; n[1] /= len; n[2] /= len;
+    body_r = current_contact_radius(body_idx);
+    size_ratio = impactor_radius / fmax(body_r, 1.0);
+    if (size_ratio < 0.015) size_ratio = 0.015;
+    if (size_ratio > 1.0) size_ratio = 1.0;
+    size_mix = pow(size_ratio, 0.68);
+    use_live_ring = current_merge_intersection_ring(body_idx, n, anchor_center,
+                                                    anchor_normal, &base_ring_radius);
+    if (!use_live_ring) {
+        anchor_normal[0] = n[0];
+        anchor_normal[1] = n[1];
+        anchor_normal[2] = n[2];
+        anchor_center[0] = g_bodies[body_idx].pos[0] + n[0] * body_r;
+        anchor_center[1] = g_bodies[body_idx].pos[1] + n[1] * body_r;
+        anchor_center[2] = g_bodies[body_idx].pos[2] + n[2] * body_r;
+        base_ring_radius = impactor_radius * (0.46 + 0.22 * size_mix);
+    } else {
+        base_ring_radius = fmin(base_ring_radius,
+                                impactor_radius * (0.58 + 0.24 * size_mix));
+    }
+    orthonormal_basis(anchor_normal, t1, t2);
+
+    if (kind == COLLISION_VIS_MERGE) count = 42;
+    else if (kind == COLLISION_VIS_MAJOR) count = 26;
+    else count = 14;
+    count = (int)(count * (0.18 + 0.95 * size_mix));
+    count = (int)(count * pack_scale);
+    if (count < 4) count = 4;
+    if (rel_speed > 16000.0) count += 10;
+    if (rel_speed > 28000.0) count += 10;
+    if (count > 72) count = 72;
+
+    if (kind == COLLISION_VIS_MAJOR || kind == COLLISION_VIS_MERGE) {
+        base_r = 1.00f; base_g = 0.66f; base_b = 0.24f;
+    } else {
+        base_r = 0.92f; base_g = 0.56f; base_b = 0.20f;
+    }
+
+    for (int i = 0; i < count; i++) {
+        int slot = -1;
+        double phi, ring_radius, tangent_mix, eject_speed, spread_speed;
+        double outward_bias;
+        double speed_scale;
+        double ring_dir[3], ring_t1[3], ring_t2[3];
+        double rel_vhat[3], tangent_dir[3], tangent_len, normal_approach;
+        double out_plane_angle, in_plane_angle;
+        double heat_mix;
+        ImpactParticleState *p;
+
+        for (int k = 0; k < MAX_COLLISION_PARTICLES; k++) {
+            if (!s_particles[k].active) { slot = k; break; }
+        }
+        if (slot < 0) {
+            slot = 0;
+            for (int k = 1; k < MAX_COLLISION_PARTICLES; k++)
+                if (s_particles[k].age > s_particles[slot].age) slot = k;
+        }
+
+        phi = rand01() * 2.0 * PI;
+        if (use_live_ring)
+            ring_radius = (0.98 + 0.06 * rand01()) * fmax(base_ring_radius,
+                                                          impactor_radius * (0.14 + 0.05 * size_mix));
+        else
+            ring_radius = (0.92 + 0.16 * rand01()) * base_ring_radius;
+        tangent_mix = 0.55 + 0.75 * rand01();
+        speed_scale = rel_speed / 42000.0;
+        if (speed_scale < 0.0) speed_scale = 0.0;
+        if (speed_scale > 1.2) speed_scale = 1.2;
+        eject_speed = 180.0
+                    + rel_speed * (0.045 + 0.070 * rand01())
+                    + rel_speed * speed_scale * (0.010 + 0.016 * rand01());
+        rel_vhat[0] = rel_vel ? rel_vel[0] : -anchor_normal[0];
+        rel_vhat[1] = rel_vel ? rel_vel[1] : -anchor_normal[1];
+        rel_vhat[2] = rel_vel ? rel_vel[2] : -anchor_normal[2];
+        normalize3d(rel_vhat);
+        normal_approach = -(rel_vhat[0]*anchor_normal[0] +
+                            rel_vhat[1]*anchor_normal[1] +
+                            rel_vhat[2]*anchor_normal[2]);
+        if (normal_approach < 0.0) normal_approach = 0.0;
+        if (normal_approach > 1.0) normal_approach = 1.0;
+        tangent_dir[0] = rel_vhat[0] + anchor_normal[0] * normal_approach;
+        tangent_dir[1] = rel_vhat[1] + anchor_normal[1] * normal_approach;
+        tangent_dir[2] = rel_vhat[2] + anchor_normal[2] * normal_approach;
+        tangent_len = sqrt(dot3d(tangent_dir, tangent_dir));
+        if (tangent_len > 1e-8) {
+            tangent_dir[0] /= tangent_len;
+            tangent_dir[1] /= tangent_len;
+            tangent_dir[2] /= tangent_len;
+        } else {
+            tangent_dir[0] = t1[0];
+            tangent_dir[1] = t1[1];
+            tangent_dir[2] = t1[2];
+        }
+        ring_dir[0] = t1[0] * cos(phi) + t2[0] * sin(phi);
+        ring_dir[1] = t1[1] * cos(phi) + t2[1] * sin(phi);
+        ring_dir[2] = t1[2] * cos(phi) + t2[2] * sin(phi);
+        normalize3d(ring_dir);
+        ring_t1[0] = tangent_dir[0];
+        ring_t1[1] = tangent_dir[1];
+        ring_t1[2] = tangent_dir[2];
+        ring_t2[0] = anchor_normal[0];
+        ring_t2[1] = anchor_normal[1];
+        ring_t2[2] = anchor_normal[2];
+        in_plane_angle = ((rand01() * 2.0) - 1.0) * (PI / 12.0);
+        out_plane_angle = ((rand01() * 2.0) - 1.0) * ((PI / 18.0) + (PI / 14.0) * normal_approach);
+        spread_speed = eject_speed * (0.20 + 0.24 * tangent_mix + 0.08 * (1.0 - normal_approach));
+        outward_bias = use_live_ring
+                     ? impactor_radius * (0.07 + 0.03 * size_mix)
+                     : impactor_radius * (0.14 + 0.05 * size_mix);
+
+        p = &s_particles[slot];
+        p->active = 1;
+        p->duration = (kind == COLLISION_VIS_MERGE ? 1.2 : kind == COLLISION_VIS_MAJOR ? 0.9 : 0.55) * DAY
+                    * (0.65 + 0.55 * rand01());
+        p->age = 0.0;
+        p->pos[0] = anchor_center[0]
+                  + anchor_normal[0] * outward_bias
+                  + t1[0] * cos(phi) * ring_radius
+                  + t2[0] * sin(phi) * ring_radius;
+        p->pos[1] = anchor_center[1]
+                  + anchor_normal[1] * outward_bias
+                  + t1[1] * cos(phi) * ring_radius
+                  + t2[1] * sin(phi) * ring_radius;
+        p->pos[2] = anchor_center[2]
+                  + anchor_normal[2] * outward_bias
+                  + t1[2] * cos(phi) * ring_radius
+                  + t2[2] * sin(phi) * ring_radius;
+        p->vel[0] = g_bodies[body_idx].vel[0]
+                  + ring_dir[0] * eject_speed
+                  + ring_t1[0] * (spread_speed * sin(in_plane_angle))
+                  + ring_t2[0] * (spread_speed * sin(out_plane_angle));
+        p->vel[1] = g_bodies[body_idx].vel[1]
+                  + ring_dir[1] * eject_speed
+                  + ring_t1[1] * (spread_speed * sin(in_plane_angle))
+                  + ring_t2[1] * (spread_speed * sin(out_plane_angle));
+        p->vel[2] = g_bodies[body_idx].vel[2]
+                  + ring_dir[2] * eject_speed
+                  + ring_t1[2] * (spread_speed * sin(in_plane_angle))
+                  + ring_t2[2] * (spread_speed * sin(out_plane_angle));
+        heat_mix = 0.24 + 0.58 * rand01() + 0.18 * fmin(speed_scale, 1.0);
+        (void)heat_mix;
+        p->color[0] = base_r;
+        p->color[1] = base_g * (0.90f + 0.20f * (float)rand01());
+        p->color[2] = base_b * (0.85f + 0.25f * (float)rand01());
+        p->color[3] = 1.0f;
+        p->size = 0.5f + 2.5f * (float)rand01();
+    }
+}
+
+static void finish_radius_transition(int body_idx)
+{
+    RadiusTransition *fx;
+
+    if (body_idx < 0 || body_idx >= MAX_BODIES) return;
+    fx = &s_radius_fx[body_idx];
+    if (!fx->active) return;
+    fx->age = fx->duration;
+    fx->active = 0;
 }
 
 static void start_radius_transition(int body_idx, double old_radius,
@@ -238,8 +552,8 @@ static void start_radius_transition(int body_idx, double old_radius,
 }
 
 static void add_impact(int body_idx, int kind, const double world_dir[3],
-                       double impactor_radius, double rel_speed,
-                       double mass_ratio)
+                       const double rel_vel[3], double impactor_radius,
+                       double rel_speed, double mass_ratio)
 {
     int slot = -1;
     Body *b;
@@ -281,6 +595,8 @@ static void add_impact(int body_idx, int kind, const double world_dir[3],
     }
     body_world_to_local_surface_dir(body_idx, world_dir, e->dir);
     normalize3f(e->dir);
+    spawn_impact_particles(body_idx, kind, world_dir, rel_vel,
+                           impactor_radius, rel_speed, 1.0);
 }
 
 static double trail_interval_for_body_after_merge(int body_idx)
@@ -311,6 +627,7 @@ static double merge_duration_for_bodies(int target, int impactor, double rel_spe
 {
     double radius_scale;
     double speed_scale;
+    double speed_factor;
     double duration;
 
     radius_scale = (g_bodies[target].radius + g_bodies[impactor].radius)
@@ -318,12 +635,23 @@ static double merge_duration_for_bodies(int target, int impactor, double rel_spe
     if (radius_scale < 0.35) radius_scale = 0.35;
 
     speed_scale = 1.0 / (1.0 + rel_speed / 18000.0);
-    if (speed_scale < 0.45) speed_scale = 0.45;
+    if (speed_scale < 0.40) speed_scale = 0.40;
+    /* Faster impacts should finish their penetration phase sooner, but not
+     * so fast that the merge loses readability. */
+    speed_factor = 0.55 + 0.45 * speed_scale;
 
-    duration = DAY * 1.18 * pow(radius_scale, 0.55) / speed_scale;
+    duration = DAY * 1.28 * pow(radius_scale, 0.55) * speed_factor;
     if (duration < DAY * 1.2) duration = DAY * 1.2;
     if (duration > DAY * 14.0) duration = DAY * 14.0;
     return duration;
+}
+
+static double merge_speed_boost(double rel_speed)
+{
+    double t = rel_speed / 12000.0;
+    if (t < 0.0) t = 0.0;
+    if (t > 2.2) t = 2.2;
+    return t;
 }
 
 static void finalize_absorb_body(int target, int impactor, double rel_speed,
@@ -364,6 +692,7 @@ static void update_merge_events(double dt)
         MergeEvent *m = &s_merges[i];
         Body *target, *impactor;
         double t, overlap_sep;
+        double speed_boost;
 
         if (!m->active) continue;
         if (m->target < 0 || m->target >= g_nbodies ||
@@ -382,28 +711,71 @@ static void update_merge_events(double dt)
         m->age += dt;
         t = m->age / m->duration;
         if (t > 1.0) t = 1.0;
+        speed_boost = merge_speed_boost(m->rel_speed);
+        m->particle_emit_accum += dt;
 
         /* Lock impactor velocity to target. */
         impactor->vel[0] = target->vel[0];
         impactor->vel[1] = target->vel[1];
         impactor->vel[2] = target->vel[2];
 
-        /* Both rotations snap to nearly zero in the first 15% of the merge —
+        /* Both rotations snap to nearly zero very early in the merge —
          * the deceleration should feel simultaneous with the impact. */
         {
-            double slow = 1.0 - ease_out_cubic(fmin(1.0, t / 0.15));
+            double spin_window = 0.07 - 0.02 * fmin(speed_boost, 1.0);
+            double slow = 1.0 - ease_out_cubic(fmin(1.0, t / spin_window));
             target->rotation_rate   = m->target_rotation_rate   * slow;
             impactor->rotation_rate = m->impactor_rotation_rate * slow;
         }
 
         {
-            double merge_t = 0.78 * ease_out_cubic(fmin(1.0, t / 0.30))
-                           + 0.22 * ease_out_cubic(t);
-            overlap_sep = m->start_sep + (target->radius * 0.08 - m->start_sep) * merge_t;
+            double target_contact_r = current_contact_radius(m->target);
+            double impactor_r = g_bodies[m->impactor].radius;
+            double depth_boost = fmin(speed_boost, 2.0);
+            double final_target_sep = target_contact_r
+                                    - impactor_r * (1.06 + 0.42 * depth_boost);
+            double pen_t;
+            if (final_target_sep < target_contact_r * 0.004)
+                final_target_sep = target_contact_r * 0.004;
+            {
+                double pen_exp = 3.0 + 2.8 * depth_boost;
+                double fast_t = 1.0 - pow(1.0 - t, pen_exp);
+                double tail_blend = (t - 0.22) / 0.78;
+                if (tail_blend < 0.0) tail_blend = 0.0;
+                if (tail_blend > 1.0) tail_blend = 1.0;
+                tail_blend = tail_blend * tail_blend * (3.0 - 2.0 * tail_blend);
+                pen_t = fast_t * (1.0 - 0.12 * tail_blend) + t * (0.12 * tail_blend);
+            }
+            overlap_sep = m->start_sep + (final_target_sep - m->start_sep) * pen_t;
         }
         impactor->pos[0] = target->pos[0] + m->dir[0] * overlap_sep;
         impactor->pos[1] = target->pos[1] + m->dir[1] * overlap_sep;
         impactor->pos[2] = target->pos[2] + m->dir[2] * overlap_sep;
+
+        if (t < 0.04) {
+            double emit_t = t / 0.04;
+            double emit_decay = 1.0 - emit_t;
+            if (emit_t > 1.0) emit_t = 1.0;
+            double emit_slice = DAY * (0.003 + 0.010 * emit_t);
+            double emit_prob = 0.88 * emit_decay * emit_decay * emit_decay
+                             * emit_decay * emit_decay;
+            if (emit_slice < DAY * 0.0025) emit_slice = DAY * 0.0025;
+            while (m->particle_emit_accum >= emit_slice) {
+                m->particle_emit_accum -= emit_slice;
+                if (rand01() < emit_prob) {
+                    double pack_scale = (0.10 + 0.05 * fmin(speed_boost, 1.4))
+                                      * emit_decay * emit_decay * emit_decay
+                                      * emit_decay * emit_decay;
+                    if (pack_scale < 0.020) pack_scale = 0.020;
+                spawn_impact_particles(m->target, COLLISION_VIS_MERGE, m->dir,
+                                       m->rel_vel, g_bodies[m->impactor].radius,
+                                       m->rel_speed, pack_scale);
+                }
+            }
+        } else {
+            m->particle_emit_accum = 0.0;
+            m->particle_emit_next = 0.0;
+        }
 
         /* Keep the scar event frozen and growing while the merge is live. */
         if (m->scar_slot >= 0 && m->scar_slot < MAX_IMPACTS &&
@@ -419,8 +791,10 @@ static void update_merge_events(double dt)
                 float cap = (float)acos(cos_a);
                 if (cap > scar->radius0) {
                     float local_dir[3];
+                    float boost = (float)(0.06 + 0.12 * fmin(speed_boost, 1.2));
                     scar->radius0 = cap;
-                    scar->radius1 = fminf((float)(PI * 0.88), fmaxf(scar->radius1, cap * 1.06f));
+                    scar->radius1 = fminf((float)(PI * 0.88),
+                                          fmaxf(scar->radius1, cap * (1.08f + boost)));
                     body_world_to_local_surface_dir(m->target, m->dir, local_dir);
                     normalize3f(local_dir);
                     scar->dir[0] = local_dir[0];
@@ -446,8 +820,10 @@ static void update_merge_events(double dt)
                 if (cap > scar->radius0) {
                     float local_dir[3];
                     double neg_dir[3] = {-m->dir[0], -m->dir[1], -m->dir[2]};
+                    float boost = (float)(0.05 + 0.10 * fmin(speed_boost, 1.2));
                     scar->radius0 = cap;
-                    scar->radius1 = fminf((float)(PI * 0.88), fmaxf(scar->radius1, cap * 1.06f));
+                    scar->radius1 = fminf((float)(PI * 0.88),
+                                          fmaxf(scar->radius1, cap * (1.06f + boost)));
                     body_world_to_local_surface_dir(m->impactor, neg_dir, local_dir);
                     normalize3f(local_dir);
                     scar->dir[0] = local_dir[0];
@@ -458,12 +834,12 @@ static void update_merge_events(double dt)
             scar->age = 0.0;
         }
 
-        /* Despawn when the impactor is fully inside the target, or time runs out. */
+        /* Keep the merge alive until the full animation duration finishes so
+         * radius growth completes during the merge instead of after it. */
         {
-            double imp_r     = g_bodies[m->impactor].radius; /* constant, no shrink */
-            double tgt_vis_r = collision_visual_radius(m->target, target->radius);
-            if (overlap_sep + imp_r <= tgt_vis_r || m->age >= m->duration) {
+            if (m->age >= m->duration) {
                 double old_radius = target->radius;
+                finish_radius_transition(m->target);
 
                 /* Release target scar: set radius1 so it expands outward while cooling. */
                 if (m->scar_slot >= 0 && m->scar_slot < MAX_IMPACTS &&
@@ -484,7 +860,8 @@ static void update_merge_events(double dt)
 }
 
 static void begin_merge_event(int target, int impactor, double rel_speed,
-                              const double dir[3], double old_radius)
+                              const double dir[3], const double rel_vel[3],
+                              double old_radius)
 {
     int slot = -1;
     Body *a = &g_bodies[target];
@@ -521,7 +898,15 @@ static void begin_merge_event(int target, int impactor, double rel_speed,
     s_merges[slot].dir[0]    = dir[0];
     s_merges[slot].dir[1]    = dir[1];
     s_merges[slot].dir[2]    = dir[2];
-    s_merges[slot].target_rotation_rate   = a->rotation_rate;
+    s_merges[slot].rel_vel[0] = rel_vel[0];
+    s_merges[slot].rel_vel[1] = rel_vel[1];
+    s_merges[slot].rel_vel[2] = rel_vel[2];
+        s_merges[slot].rel_vel[0] = b->vel[0] - a->vel[0];
+        s_merges[slot].rel_vel[1] = b->vel[1] - a->vel[1];
+        s_merges[slot].rel_vel[2] = b->vel[2] - a->vel[2];
+        s_merges[slot].particle_emit_accum    = 0.0;
+        s_merges[slot].particle_emit_next     = 0.0;
+        s_merges[slot].target_rotation_rate   = a->rotation_rate;
     s_merges[slot].impactor_rotation_rate = b->rotation_rate;
     s_merges[slot].scar_slot     = -1;
     s_merges[slot].imp_scar_slot = -1;
@@ -540,7 +925,7 @@ static void begin_merge_event(int target, int impactor, double rel_speed,
         s_merges[slot].duration  = anim_dur;
         s_merges[slot].start_sep = sep_init;
 
-        start_radius_transition(target, old_radius, a->radius, anim_dur);
+        start_radius_transition(target, old_radius, a->radius, anim_dur * 0.78);
         /* Impactor keeps its size throughout — no shrink transition. */
     }
 
@@ -568,7 +953,7 @@ static void begin_merge_event(int target, int impactor, double rel_speed,
         scar->duration = MERGE_COOL_SECONDS;
         scar->heat0    = 1.0f;
         scar->radius0  = 0.0f;
-        scar->radius1  = 0.0f;
+        scar->radius1  = (float)(0.22 + 0.12 * fmin(merge_speed_boost(rel_speed), 1.5));
         scar->dir[0]   = local_dir[0];
         scar->dir[1]   = local_dir[1];
         scar->dir[2]   = local_dir[2];
@@ -599,19 +984,24 @@ static void begin_merge_event(int target, int impactor, double rel_speed,
         scar->duration = MERGE_COOL_SECONDS;
         scar->heat0    = 1.0f;
         scar->radius0  = 0.0f;
-        scar->radius1  = 0.0f;
+        scar->radius1  = (float)(0.18 + 0.10 * fmin(merge_speed_boost(rel_speed), 1.5));
         scar->dir[0]   = local_dir[0];
         scar->dir[1]   = local_dir[1];
         scar->dir[2]   = local_dir[2];
         s_merges[slot].imp_scar_slot = scar_slot;
     }
+
+    spawn_impact_particles(target, COLLISION_VIS_MERGE, dir, s_merges[slot].rel_vel,
+                           b->radius, rel_speed, 0.85);
 }
 
 static int classify_collision(int a, int b, double rel_speed)
 {
     double m_small = g_bodies[a].mass < g_bodies[b].mass ? g_bodies[a].mass : g_bodies[b].mass;
     double m_large = g_bodies[a].mass > g_bodies[b].mass ? g_bodies[a].mass : g_bodies[b].mass;
-    double r_sum = g_bodies[a].radius + g_bodies[b].radius;
+    double ra = current_contact_radius(a);
+    double rb = current_contact_radius(b);
+    double r_sum = ra + rb;
     double mass_ratio, v_escape;
 
     if (m_large <= 0.0) return COLLISION_VIS_CRATER;
@@ -619,8 +1009,8 @@ static int classify_collision(int a, int b, double rel_speed)
     v_escape = sqrt(fmax(0.0, 2.0 * G_CONST * (g_bodies[a].mass + g_bodies[b].mass) /
                          fmax(r_sum, 1.0)));
 
-    if (mass_ratio >= 0.45 || g_bodies[a].radius >= 0.74 * g_bodies[b].radius ||
-        g_bodies[b].radius >= 0.74 * g_bodies[a].radius)
+    if (mass_ratio >= 0.45 || ra >= 0.74 * rb ||
+        rb >= 0.74 * ra)
         return COLLISION_VIS_MERGE;
     if (mass_ratio >= 0.08 || rel_speed >= v_escape * 1.35)
         return COLLISION_VIS_MAJOR;
@@ -653,7 +1043,7 @@ static double pair_check_dt(int a, int b)
     double vy = g_bodies[b].vel[1] - g_bodies[a].vel[1];
     double vz = g_bodies[b].vel[2] - g_bodies[a].vel[2];
     double vr = -(rx*vx + ry*vy + rz*vz) / dist;
-    double gap = dist - (g_bodies[a].radius + g_bodies[b].radius);
+    double gap = dist - (current_contact_radius(a) + current_contact_radius(b));
 
     if (gap <= 0.0) return MIN_PAIR_DT;
     if (vr <= 1e-3) {
@@ -703,7 +1093,7 @@ static int swept_spheres_collide(int a, int b, double dt, double *out_speed)
         rel_p[1] + rel_v[1] * t,
         rel_p[2] + rel_v[2] * t
     };
-    double r = g_bodies[a].radius + g_bodies[b].radius;
+    double r = current_contact_radius(a) + current_contact_radius(b);
     if (out_speed) *out_speed = sqrt(vv);
     return dot3d(c, c) <= r*r;
 }
@@ -764,17 +1154,22 @@ static void absorb_body(int target, int impactor, double rel_speed, double colli
     Body *b = &g_bodies[impactor];
     double old_radius;
     double mass_ratio;
+    double rel_vel[3] = {
+        g_bodies[impactor].vel[0] - g_bodies[target].vel[0],
+        g_bodies[impactor].vel[1] - g_bodies[target].vel[1],
+        g_bodies[impactor].vel[2] - g_bodies[target].vel[2]
+    };
     double dir[3];
     int outcome;
 
     if (!a->alive || !b->alive || a->is_star || b->is_star) return;
 
-    old_radius = a->radius;
+    old_radius = current_contact_radius(target);
     mass_ratio = fmin(a->mass, b->mass) / fmax(fmax(a->mass, b->mass), 1.0);
     outcome = classify_collision(target, impactor, rel_speed);
     impact_dir_for_pair(target, impactor, collision_dt, dir);
     if (outcome == COLLISION_VIS_MERGE) {
-        begin_merge_event(target, impactor, rel_speed, dir, old_radius);
+        begin_merge_event(target, impactor, rel_speed, dir, rel_vel, old_radius);
         return;
     }
 
@@ -782,7 +1177,7 @@ static void absorb_body(int target, int impactor, double rel_speed, double colli
         double total = a->mass + b->mass;
     if (total <= 0.0) return;
 
-    add_impact(target, outcome, dir, b->radius, rel_speed, mass_ratio);
+    add_impact(target, outcome, dir, rel_vel, b->radius, rel_speed, mass_ratio);
 
     a->vel[0] = (a->vel[0] * a->mass + b->vel[0] * b->mass) / total;
     a->vel[1] = (a->vel[1] * a->mass + b->vel[1] * b->mass) / total;
@@ -805,6 +1200,26 @@ void collision_step(double dt)
     int any_dirty = 0;
 
     update_merge_events(dt);
+
+    for (int i = 0; i < MAX_COLLISION_PARTICLES; i++) {
+        ImpactParticleState *p = &s_particles[i];
+        double drag;
+        if (!p->active) continue;
+        p->age += dt;
+        if (p->age >= p->duration) {
+            p->active = 0;
+            continue;
+        }
+        p->pos[0] += p->vel[0] * dt;
+        p->pos[1] += p->vel[1] * dt;
+        p->pos[2] += p->vel[2] * dt;
+        /* Mild time-based drag so debris keeps travelling with the impact
+         * instead of appearing to freeze in world space. */
+        drag = exp(-dt / (DAY * 18.0));
+        p->vel[0] *= drag;
+        p->vel[1] *= drag;
+        p->vel[2] *= drag;
+    }
 
     for (int i = 0; i < MAX_IMPACTS; i++) {
         if (!s_impacts[i].active) continue;
@@ -852,7 +1267,7 @@ void collision_step(double dt)
         double dx = g_bodies[i].pos[0] - g_bodies[root].pos[0];
         double dy = g_bodies[i].pos[1] - g_bodies[root].pos[1];
         double dz = g_bodies[i].pos[2] - g_bodies[root].pos[2];
-        double d = sqrt(dx*dx + dy*dy + dz*dz) + g_bodies[i].radius;
+        double d = sqrt(dx*dx + dy*dy + dz*dz) + current_contact_radius(i);
         if (d > system_radius[root]) system_radius[root] = d;
     }
 
@@ -872,7 +1287,7 @@ void collision_step(double dt)
 
             if (other_root < 0 || other_root >= g_nbodies) continue;
             if (!g_bodies[other_root].alive) continue;
-            if (other_root < root) continue;
+            if (other_root < root && s_system_dirty[other_root]) continue;
             if (!systems_may_interact(root, other_root, system_radius)) continue;
 
             na = member_count[root];
@@ -1037,4 +1452,46 @@ int collision_body_has_active_merge(int body_idx)
 {
     if (body_idx < 0 || body_idx >= g_nbodies) return 0;
     return body_is_in_merge(body_idx);
+}
+
+int collision_particles(CollisionParticle *out, int max_particles,
+                        const double cam_pos[3])
+{
+    int n = 0;
+    if (!out || max_particles <= 0 || !cam_pos) return 0;
+
+    for (int i = 0; i < MAX_COLLISION_PARTICLES && n < max_particles; i++) {
+        ImpactParticleState *p = &s_particles[i];
+        double t, fade, alpha, fade_t;
+        double dx, dy, dz, dist;
+        double dist_fade = 1.0;
+        if (!p->active) continue;
+        t = p->age / p->duration;
+        if (t < 0.0) t = 0.0;
+        if (t > 1.0) t = 1.0;
+        fade = 1.0 - t;
+        fade_t = (t - 0.78) / 0.22;
+        if (fade_t < 0.0) fade_t = 0.0;
+        if (fade_t > 1.0) fade_t = 1.0;
+        alpha = 1.0 - fade_t * fade_t;
+        dx = p->pos[0] * RS - cam_pos[0];
+        dy = p->pos[1] * RS - cam_pos[1];
+        dz = p->pos[2] * RS - cam_pos[2];
+        dist = sqrt(dx*dx + dy*dy + dz*dz);
+        if (dist >= 0.30 * AU * RS) continue;
+        if (dist > 0.10 * AU * RS) {
+            dist_fade = 1.0 - (dist - 0.10 * AU * RS) / (0.20 * AU * RS);
+            if (dist_fade < 0.0) dist_fade = 0.0;
+        }
+        out[n].pos[0] = (float)dx;
+        out[n].pos[1] = (float)dy;
+        out[n].pos[2] = (float)dz;
+        out[n].color[0] = p->color[0] * (0.70f + 0.30f * (float)fade);
+        out[n].color[1] = p->color[1] * (0.70f + 0.30f * (float)fade);
+        out[n].color[2] = p->color[2] * (0.70f + 0.30f * (float)fade);
+        out[n].color[3] = (float)(alpha * dist_fade);
+        out[n].size = p->size;
+        n++;
+    }
+    return n;
 }

--- a/src/collision.c
+++ b/src/collision.c
@@ -14,7 +14,7 @@
 #include <stdio.h>
 
 #define MAX_IMPACTS 64
-#define MAX_PAIR_DT (DAY * 20.0)
+#define MAX_PAIR_DT (DAY * 2.0)
 #define MIN_PAIR_DT (60.0 * 5.0)
 #define HOT_PAIR_DT (60.0 * 10.0)
 #define SYSTEM_HOT_DURATION (DAY * 3.0)
@@ -83,6 +83,10 @@ static double s_pair_next[MAX_BODIES][MAX_BODIES];
 static unsigned char s_system_dirty[MAX_BODIES];
 static double s_system_hot[MAX_BODIES];
 static unsigned int s_particle_rng = 0x1234abcdu;
+static double s_pos_before[MAX_BODIES][3];
+static int s_pos_before_valid = 0;
+static int s_debug_frames = 0;           /* non-zero: enhanced diagnostics active */
+static int s_debug_skip_logged[MAX_BODIES]; /* 1 if "SKIPPED" already printed this window */
 
 static void mark_system_dirty(int root, double hot_duration)
 {
@@ -91,10 +95,27 @@ static void mark_system_dirty(int root, double hot_duration)
     if (hot_duration > s_system_hot[root]) s_system_hot[root] = hot_duration;
 }
 
+void collision_snapshot_positions(void)
+{
+    int n = g_nbodies < MAX_BODIES ? g_nbodies : MAX_BODIES;
+    for (int i = 0; i < n; i++) {
+        s_pos_before[i][0] = g_bodies[i].pos[0];
+        s_pos_before[i][1] = g_bodies[i].pos[1];
+        s_pos_before[i][2] = g_bodies[i].pos[2];
+    }
+    s_pos_before_valid = 1;
+}
+
 void collision_on_body_added(int body_idx)
 {
     int root = body_root_star(body_idx);
     if (root >= 0) mark_system_dirty(root, SYSTEM_HOT_DURATION);
+    s_debug_frames = 300;
+    memset(s_debug_skip_logged, 0, sizeof(s_debug_skip_logged));
+    fprintf(stderr, "[coll-dbg] body added: idx=%d root=%d dirty=%d hot=%.2f days\n",
+            body_idx, root,
+            (root >= 0 && root < MAX_BODIES) ? s_system_dirty[root] : -1,
+            (root >= 0 && root < MAX_BODIES) ? s_system_hot[root] / DAY : 0.0);
 }
 
 static int body_is_descendant_of(int body_idx, int ancestor_idx)
@@ -679,6 +700,19 @@ static void finalize_absorb_body(int target, int impactor, double rel_speed,
     labels_remove_body(impactor);
     trails_remove_body(impactor);
     mark_system_dirty(body_root_star(target), SYSTEM_HOT_DURATION);
+    s_debug_frames = 300;
+    memset(s_debug_skip_logged, 0, sizeof(s_debug_skip_logged));
+    {
+        int root = body_root_star(target);
+        fprintf(stderr, "[coll-dbg] merge done: target=%d root=%d hot=%.2f days | alive bodies:",
+                target, root, s_system_hot[root] / DAY);
+        for (int i = 0; i < g_nbodies; i++) {
+            if (!g_bodies[i].alive) continue;
+            fprintf(stderr, " %d(root=%d,imp=%d)", i,
+                    body_root_star(i), body_is_merge_impactor(i));
+        }
+        fprintf(stderr, "\n");
+    }
     fprintf(stdout, "[collision] %s absorbed %s (%.0f m/s, %s, %.0f->%.0f km)\n",
             a->name, b->name, rel_speed,
             outcome == COLLISION_VIS_MERGE ? "merge" :
@@ -1070,32 +1104,46 @@ static int swept_spheres_collide(int a, int b, double dt, double *out_speed)
         g_bodies[b].pos[1] - g_bodies[a].pos[1],
         g_bodies[b].pos[2] - g_bodies[a].pos[2]
     };
-    double rel_v[3] = {
-        g_bodies[b].vel[0] - g_bodies[a].vel[0],
-        g_bodies[b].vel[1] - g_bodies[a].vel[1],
-        g_bodies[b].vel[2] - g_bodies[a].vel[2]
-    };
-    double rel_p[3] = {
-        rel_now[0] - rel_v[0] * dt,
-        rel_now[1] - rel_v[1] * dt,
-        rel_now[2] - rel_v[2] * dt
-    };
-    double vv = dot3d(rel_v, rel_v);
-    double t = 0.0;
-    if (vv > MIN_COLLISION_SPEED * MIN_COLLISION_SPEED) {
-        t = -dot3d(rel_p, rel_v) / vv;
-        if (t < 0.0) t = 0.0;
-        if (t > dt) t = dt;
+    /* Use actual pre-physics positions when available so that bodies which
+     * tunnel completely through each other in one large timestep are still
+     * detected.  The old formula (rel_now - vel*dt) fails when gravity
+     * reverses the relative velocity mid-step: the reconstructed "past"
+     * position ends up on the wrong side of the target, so the swept path
+     * never crosses the contact sphere. */
+    double rel_p[3];
+    double rel_v[3];
+    double vv;
+    if (s_pos_before_valid && dt > 0.0) {
+        rel_p[0] = s_pos_before[b][0] - s_pos_before[a][0];
+        rel_p[1] = s_pos_before[b][1] - s_pos_before[a][1];
+        rel_p[2] = s_pos_before[b][2] - s_pos_before[a][2];
+        rel_v[0] = (rel_now[0] - rel_p[0]) / dt;
+        rel_v[1] = (rel_now[1] - rel_p[1]) / dt;
+        rel_v[2] = (rel_now[2] - rel_p[2]) / dt;
+    } else {
+        rel_v[0] = g_bodies[b].vel[0] - g_bodies[a].vel[0];
+        rel_v[1] = g_bodies[b].vel[1] - g_bodies[a].vel[1];
+        rel_v[2] = g_bodies[b].vel[2] - g_bodies[a].vel[2];
+        rel_p[0] = rel_now[0] - rel_v[0] * dt;
+        rel_p[1] = rel_now[1] - rel_v[1] * dt;
+        rel_p[2] = rel_now[2] - rel_v[2] * dt;
     }
-
-    double c[3] = {
-        rel_p[0] + rel_v[0] * t,
-        rel_p[1] + rel_v[1] * t,
-        rel_p[2] + rel_v[2] * t
-    };
-    double r = current_contact_radius(a) + current_contact_radius(b);
-    if (out_speed) *out_speed = sqrt(vv);
-    return dot3d(c, c) <= r*r;
+    vv = dot3d(rel_v, rel_v);
+    {
+        double t = 0.0;
+        double c[3];
+        double r = current_contact_radius(a) + current_contact_radius(b);
+        if (vv > MIN_COLLISION_SPEED * MIN_COLLISION_SPEED) {
+            t = -dot3d(rel_p, rel_v) / vv;
+            if (t < 0.0) t = 0.0;
+            if (t > dt) t = dt;
+        }
+        c[0] = rel_p[0] + rel_v[0] * t;
+        c[1] = rel_p[1] + rel_v[1] * t;
+        c[2] = rel_p[2] + rel_v[2] * t;
+        if (out_speed) *out_speed = sqrt(vv);
+        return dot3d(c, c) <= r*r;
+    }
 }
 
 static void impact_dir_for_pair(int target, int impactor, double dt, double out_dir[3])
@@ -1169,6 +1217,8 @@ static void absorb_body(int target, int impactor, double rel_speed, double colli
     outcome = classify_collision(target, impactor, rel_speed);
     impact_dir_for_pair(target, impactor, collision_dt, dir);
     if (outcome == COLLISION_VIS_MERGE) {
+        fprintf(stderr, "[coll-dbg] merge start: target=%d impactor=%d speed=%.3g m/s\n",
+                target, impactor, rel_speed);
         begin_merge_event(target, impactor, rel_speed, dir, rel_vel, old_radius);
         return;
     }
@@ -1245,11 +1295,7 @@ void collision_step(double dt)
     if (dt <= 0.0) return;
 
     for (int i = 0; i < MAX_BODIES; i++) {
-        if (s_system_dirty[i]) any_dirty = 1;
-        if (s_system_hot[i] > 0.0) {
-            s_system_hot[i] -= dt;
-            if (s_system_hot[i] < 0.0) s_system_hot[i] = 0.0;
-        }
+        if (s_system_dirty[i]) { any_dirty = 1; break; }
     }
     if (!any_dirty) return;
 
@@ -1270,6 +1316,8 @@ void collision_step(double dt)
         double d = sqrt(dx*dx + dy*dy + dz*dz) + current_contact_radius(i);
         if (d > system_radius[root]) system_radius[root] = d;
     }
+
+    if (s_debug_frames > 0) s_debug_frames--;
 
     for (int root = 0; root < g_nbodies; root++) {
         if (!s_system_dirty[root]) continue;
@@ -1294,7 +1342,15 @@ void collision_step(double dt)
             nb = member_count[other_root];
             for (int ai = 0; ai < na && !root_had_collision; ai++) {
                 int a = members[root][ai];
-                if (!g_bodies[a].alive || g_bodies[a].is_star || resolved[a] || body_is_merge_impactor(a)) continue;
+                if (!g_bodies[a].alive || g_bodies[a].is_star || resolved[a] || body_is_merge_impactor(a)) {
+                    if (s_debug_frames > 0 && g_bodies[a].alive && !g_bodies[a].is_star
+                            && !s_debug_skip_logged[a]) {
+                        fprintf(stderr, "[coll-dbg] body %d first SKIPPED resolved=%d impactor=%d\n",
+                                a, resolved[a], body_is_merge_impactor(a));
+                        s_debug_skip_logged[a] = 1;
+                    }
+                    continue;
+                }
                 for (int bi = 0; bi < nb; bi++) {
                     int b = members[other_root][bi];
                     int lo, hi;
@@ -1314,9 +1370,30 @@ void collision_step(double dt)
                         if (s_pair_next[lo][hi] > 0.0) continue;
                     }
 
-                    if (!swept_spheres_collide(a, b, dt, &speed)) {
-                        s_pair_next[lo][hi] = pair_check_dt(a, b);
-                        continue;
+                    {
+                        int hit = swept_spheres_collide(a, b, dt, &speed);
+                        if (s_debug_frames > 0) {
+                            double dx = g_bodies[b].pos[0] - g_bodies[a].pos[0];
+                            double dy = g_bodies[b].pos[1] - g_bodies[a].pos[1];
+                            double dz = g_bodies[b].pos[2] - g_bodies[a].pos[2];
+                            double dist = sqrt(dx*dx + dy*dy + dz*dz);
+                            double r = current_contact_radius(a) + current_contact_radius(b);
+                            if (hit || dist < r * 20.0)
+                                fprintf(stderr, "[coll-dbg] pair (%d,%d) dist=%.3g r=%.3g hit=%d hot=%.2f\n",
+                                        a, b, dist, r, hit, s_system_hot[root] / DAY);
+                        }
+                        if (!hit) {
+                            double pdt = pair_check_dt(a, b);
+                            s_pair_next[lo][hi] = pdt;
+                            if (!same_root) {
+                                /* Cross-system approaching pair: keep both roots
+                                 * dirty so the pair continues to be evaluated
+                                 * after their individual hot periods expire. */
+                                mark_system_dirty(root, pdt);
+                                mark_system_dirty(other_root, pdt);
+                            }
+                            continue;
+                        }
                     }
 
                     {
@@ -1349,6 +1426,13 @@ void collision_step(double dt)
         }
 
         (void)root_had_collision;
+    }
+
+    for (int i = 0; i < MAX_BODIES; i++) {
+        if (s_system_hot[i] > 0.0) {
+            s_system_hot[i] -= dt;
+            if (s_system_hot[i] < 0.0) s_system_hot[i] = 0.0;
+        }
     }
 }
 

--- a/src/collision.c
+++ b/src/collision.c
@@ -25,6 +25,7 @@
 #define MERGE_COOL_SECONDS (DAY * 180.0)
 #define MERGE_PHASE_SECONDS (DAY * 8.0)
 #define MAX_MERGES 16
+#define MAX_PERSISTENT_SCARS 128
 #define MAX_COLLISION_PARTICLES 768
 
 typedef struct {
@@ -39,6 +40,17 @@ typedef struct {
     float radius1;
     float heat0;
 } ImpactEvent;
+
+typedef struct {
+    int active;
+    int body;
+    unsigned int stamp;
+    float dir[3];
+    float tangent1[3];
+    float angular_radius;
+    float depth;
+    float seed;
+} PersistentScar;
 
 typedef struct {
     int active;
@@ -81,6 +93,7 @@ typedef struct {
 } ImpactParticleState;
 
 static ImpactEvent s_impacts[MAX_IMPACTS];
+static PersistentScar s_perm_scars[MAX_PERSISTENT_SCARS];
 static RadiusTransition s_radius_fx[MAX_BODIES];
 static MergeEvent s_merges[MAX_MERGES];
 static ImpactParticleState s_particles[MAX_COLLISION_PARTICLES];
@@ -88,6 +101,7 @@ static double s_pair_next[MAX_BODIES][MAX_BODIES];
 static unsigned char s_system_dirty[MAX_BODIES];
 static double s_system_hot[MAX_BODIES];
 static unsigned int s_particle_rng = 0x1234abcdu;
+static unsigned int s_perm_scar_stamp = 1u;
 static double s_pos_before[MAX_BODIES][3];
 static int s_pos_before_valid = 0;
 
@@ -169,6 +183,11 @@ static double rand01(void)
 {
     s_particle_rng = 1664525u * s_particle_rng + 1013904223u;
     return (double)(s_particle_rng & 0x00ffffffu) / (double)0x01000000u;
+}
+
+static float rand01f(void)
+{
+    return (float)rand01();
 }
 
 static void orthonormal_basis(const double n[3], double t1[3], double t2[3])
@@ -287,6 +306,10 @@ static void build_local_scar_tangent(int body_idx, const double world_dir[3],
     normalize3f(out_local_t1);
 }
 
+static void add_permanent_crater(int body_idx, const double world_dir[3],
+                                 const double rel_vel[3], double impactor_radius,
+                                 double strength);
+
 static double body_moment_of_inertia(const Body *b)
 {
     if (!b) return 0.0;
@@ -306,13 +329,6 @@ static double obliquity_from_spin_axis(const double axis[3])
     return atan2(axis[0], axis[1]) * (180.0 / PI);
 }
 
-static double wrap_angle_pm_pi(double a)
-{
-    while (a > PI) a -= 2.0 * PI;
-    while (a < -PI) a += 2.0 * PI;
-    return a;
-}
-
 static void compute_collision_spin_state(int target, int impactor,
                                          const double contact_dir[3],
                                          const double rel_vel[3],
@@ -323,7 +339,7 @@ static void compute_collision_spin_state(int target, int impactor,
     const Body *b = &g_bodies[impactor];
     double axis_a[3], axis_b[3], merged_axis[3];
     double L_spin_a[3], L_spin_b[3], L_orbit[3], L_total[3];
-    double contact_r[3], merged_I, planar_len;
+    double contact_r[3], merged_I, planar_len, axis_dot;
 
     spin_axis_from_obliquity(a->obliquity, axis_a);
     spin_axis_from_obliquity(b->obliquity, axis_b);
@@ -370,6 +386,16 @@ static void compute_collision_spin_state(int target, int impactor,
         merged_axis[0] = L_total[0] / planar_len;
         merged_axis[1] = L_total[1] / planar_len;
         merged_axis[2] = 0.0;
+    }
+
+    /* Axis direction and spin-rate sign are interchangeable in the current
+     * obliquity+rotation_rate model. Keep the chosen axis close to the
+     * target's pre-impact axis so the resulting rotation can be signed
+     * correctly instead of always collapsing to a positive spin. */
+    axis_dot = merged_axis[0] * axis_a[0] + merged_axis[1] * axis_a[1];
+    if (axis_dot < 0.0) {
+        merged_axis[0] = -merged_axis[0];
+        merged_axis[1] = -merged_axis[1];
     }
 
     merged_I = 0.40 * (a->mass + b->mass)
@@ -791,8 +817,55 @@ static void add_impact(int body_idx, int kind, const double world_dir[3],
     body_world_to_local_surface_dir(body_idx, world_dir, e->dir);
     normalize3f(e->dir);
     build_local_scar_tangent(body_idx, world_dir, rel_vel, e->tangent1);
+    if (kind == COLLISION_VIS_CRATER || kind == COLLISION_VIS_MAJOR)
+        add_permanent_crater(body_idx, world_dir, rel_vel, impactor_radius,
+                             kind == COLLISION_VIS_MAJOR ? 1.0 : 0.65 + 0.25 * fmin(mass_ratio, 1.0));
     spawn_impact_particles(body_idx, kind, world_dir, rel_vel,
                            impactor_radius, rel_speed, 1.0);
+}
+
+static void add_permanent_crater(int body_idx, const double world_dir[3],
+                                 const double rel_vel[3], double impactor_radius,
+                                 double strength)
+{
+    int slot = -1;
+    int oldest = 0;
+    double radius_limit;
+    float local_dir[3];
+    PersistentScar *s;
+
+    if (body_idx < 0 || body_idx >= g_nbodies) return;
+    if (!g_bodies[body_idx].alive) return;
+    if (impactor_radius <= 0.0) return;
+
+    radius_limit = asin(fmin(0.999, impactor_radius / fmax(g_bodies[body_idx].radius, impactor_radius)));
+    radius_limit *= 0.92 + 0.10 * fmin(fmax(strength, 0.0), 1.0);
+    if (radius_limit < 0.006) radius_limit = 0.006;
+
+    for (int i = 0; i < MAX_PERSISTENT_SCARS; i++) {
+        if (!s_perm_scars[i].active) {
+            slot = i;
+            break;
+        }
+        if (s_perm_scars[i].stamp < s_perm_scars[oldest].stamp)
+            oldest = i;
+    }
+    if (slot < 0) slot = oldest;
+
+    s = &s_perm_scars[slot];
+    s->active = 1;
+    s->body = body_idx;
+    s->stamp = s_perm_scar_stamp++;
+    if (s_perm_scar_stamp == 0u) s_perm_scar_stamp = 1u;
+    body_world_to_local_surface_dir(body_idx, world_dir, local_dir);
+    normalize3f(local_dir);
+    s->dir[0] = local_dir[0];
+    s->dir[1] = local_dir[1];
+    s->dir[2] = local_dir[2];
+    build_local_scar_tangent(body_idx, world_dir, rel_vel, s->tangent1);
+    s->angular_radius = (float)radius_limit;
+    s->depth = 0.45f + 0.35f * (float)fmin(fmax(strength, 0.0), 1.0);
+    s->seed = rand01f() * 100.0f;
 }
 
 static double trail_interval_for_body_after_merge(int body_idx)
@@ -1171,6 +1244,7 @@ static void begin_merge_event(int target, int impactor, double rel_speed,
     s_merges[slot].target_obliquity       = a->obliquity;
     s_merges[slot].scar_slot     = -1;
     s_merges[slot].imp_scar_slot = -1;
+    add_permanent_crater(target, dir, rel_vel, b->radius, 1.0);
 
     {
         double anim_dur = merge_duration_for_bodies(target, impactor, rel_speed);
@@ -1666,6 +1740,23 @@ int collision_spots_for_body(int body_idx, CollisionSpot spots[COLLISION_MAX_SPO
     int n = 0;
     if (!spots || body_idx < 0 || body_idx >= g_nbodies) return 0;
 
+    for (int i = 0; i < MAX_PERSISTENT_SCARS && n < COLLISION_MAX_SPOTS; i++) {
+        PersistentScar *s = &s_perm_scars[i];
+        if (!s->active || s->body != body_idx) continue;
+        spots[n].dir[0] = s->dir[0];
+        spots[n].dir[1] = s->dir[1];
+        spots[n].dir[2] = s->dir[2];
+        spots[n].tangent1[0] = s->tangent1[0];
+        spots[n].tangent1[1] = s->tangent1[1];
+        spots[n].tangent1[2] = s->tangent1[2];
+        spots[n].angular_radius = s->angular_radius;
+        spots[n].heat = s->depth;
+        spots[n].progress = 0.0f;
+        spots[n].seed = s->seed;
+        spots[n].kind = COLLISION_VIS_PERM_CRATER;
+        n++;
+    }
+
     for (int i = 0; i < MAX_IMPACTS && n < COLLISION_MAX_SPOTS; i++) {
         ImpactEvent *e = &s_impacts[i];
         double t;
@@ -1692,6 +1783,7 @@ int collision_spots_for_body(int body_idx, CollisionSpot spots[COLLISION_MAX_SPO
         spots[n].angular_radius = (float)rad;
         spots[n].heat = heat;
         spots[n].progress = (float)t;
+        spots[n].seed = 0.0f;
         spots[n].kind = e->kind;
         n++;
         }

--- a/src/collision.c
+++ b/src/collision.c
@@ -56,11 +56,13 @@ typedef struct {
     double rel_speed;
     double dir[3];
     double rel_vel[3];
+    double target_local_attach_dir[3];
     double start_sep;
     double particle_emit_accum;
     double particle_emit_next;
-    double target_rotation_rate;   /* saved initial rates so both can slow together */
+    double target_rotation_rate;
     double impactor_rotation_rate;
+    double target_obliquity;
     int scar_slot;          /* s_impacts index for the target intersection scar */
     int imp_scar_slot;      /* s_impacts index for the impactor intersection scar */
 } MergeEvent;
@@ -207,6 +209,132 @@ static void normalize3d(double v[3])
         return;
     }
     v[0] /= len; v[1] /= len; v[2] /= len;
+}
+
+static void body_local_surface_dir_to_world(int body_idx, const double local_dir[3],
+                                            double out[3])
+{
+    Body *b;
+    double cr, sr, co, so;
+    double tx, ty, tz;
+    double len;
+
+    if (!out || body_idx < 0 || body_idx >= g_nbodies) return;
+    b = &g_bodies[body_idx];
+
+    cr = cos(b->rotation_angle);
+    sr = sin(b->rotation_angle);
+    tx = local_dir[0] * cr - local_dir[2] * sr;
+    ty = local_dir[1];
+    tz = local_dir[0] * sr + local_dir[2] * cr;
+
+    co = cos(b->obliquity * PI / 180.0);
+    so = sin(b->obliquity * PI / 180.0);
+    out[0] =  co * tx + so * ty;
+    out[1] = -so * tx + co * ty;
+    out[2] =  tz;
+
+    len = sqrt(dot3d(out, out));
+    if (len <= 1e-12) {
+        out[0] = 1.0; out[1] = 0.0; out[2] = 0.0;
+        return;
+    }
+    out[0] /= len; out[1] /= len; out[2] /= len;
+}
+
+static double body_moment_of_inertia(const Body *b)
+{
+    if (!b) return 0.0;
+    return 0.40 * b->mass * b->radius * b->radius;
+}
+
+static void spin_axis_from_obliquity(double obliquity_deg, double axis[3])
+{
+    double ob = obliquity_deg * (PI / 180.0);
+    axis[0] = sin(ob);
+    axis[1] = cos(ob);
+    axis[2] = 0.0;
+}
+
+static double obliquity_from_spin_axis(const double axis[3])
+{
+    return atan2(axis[0], axis[1]) * (180.0 / PI);
+}
+
+static double wrap_angle_pm_pi(double a)
+{
+    while (a > PI) a -= 2.0 * PI;
+    while (a < -PI) a += 2.0 * PI;
+    return a;
+}
+
+static void compute_collision_spin_state(int target, int impactor,
+                                         const double contact_dir[3],
+                                         const double rel_vel[3],
+                                         double *out_obliquity,
+                                         double *out_rotation_rate)
+{
+    const Body *a = &g_bodies[target];
+    const Body *b = &g_bodies[impactor];
+    double axis_a[3], axis_b[3], merged_axis[3];
+    double L_spin_a[3], L_spin_b[3], L_orbit[3], L_total[3];
+    double contact_r[3], merged_I, planar_len;
+
+    spin_axis_from_obliquity(a->obliquity, axis_a);
+    spin_axis_from_obliquity(b->obliquity, axis_b);
+
+    {
+        double Ia = body_moment_of_inertia(a);
+        double Ib = body_moment_of_inertia(b);
+        L_spin_a[0] = axis_a[0] * Ia * a->rotation_rate;
+        L_spin_a[1] = axis_a[1] * Ia * a->rotation_rate;
+        L_spin_a[2] = axis_a[2] * Ia * a->rotation_rate;
+        L_spin_b[0] = axis_b[0] * Ib * b->rotation_rate;
+        L_spin_b[1] = axis_b[1] * Ib * b->rotation_rate;
+        L_spin_b[2] = axis_b[2] * Ib * b->rotation_rate;
+    }
+
+    contact_r[0] = contact_dir[0] * a->radius;
+    contact_r[1] = contact_dir[1] * a->radius;
+    contact_r[2] = contact_dir[2] * a->radius;
+
+    L_orbit[0] = b->mass * (contact_r[1] * rel_vel[2] - contact_r[2] * rel_vel[1]);
+    L_orbit[1] = b->mass * (contact_r[2] * rel_vel[0] - contact_r[0] * rel_vel[2]);
+    L_orbit[2] = b->mass * (contact_r[0] * rel_vel[1] - contact_r[1] * rel_vel[0]);
+
+    L_total[0] = L_spin_a[0] + L_spin_b[0] + L_orbit[0];
+    L_total[1] = L_spin_a[1] + L_spin_b[1] + L_orbit[1];
+    L_total[2] = L_spin_a[2] + L_spin_b[2] + L_orbit[2];
+
+    planar_len = sqrt(L_total[0]*L_total[0] + L_total[1]*L_total[1]);
+    if (planar_len <= 1e-12) {
+        merged_axis[0] = axis_a[0];
+        merged_axis[1] = axis_a[1];
+        merged_axis[2] = 0.0;
+        planar_len = sqrt(merged_axis[0]*merged_axis[0] + merged_axis[1]*merged_axis[1]);
+        if (planar_len <= 1e-12) {
+            merged_axis[0] = 0.0;
+            merged_axis[1] = 1.0;
+        } else {
+            merged_axis[0] /= planar_len;
+            merged_axis[1] /= planar_len;
+        }
+        L_total[0] = merged_axis[0] * body_moment_of_inertia(a) * a->rotation_rate;
+        L_total[1] = merged_axis[1] * body_moment_of_inertia(a) * a->rotation_rate;
+    } else {
+        merged_axis[0] = L_total[0] / planar_len;
+        merged_axis[1] = L_total[1] / planar_len;
+        merged_axis[2] = 0.0;
+    }
+
+    merged_I = 0.40 * (a->mass + b->mass)
+             * pow(cbrt(a->radius*a->radius*a->radius + b->radius*b->radius*b->radius), 2.0);
+    if (merged_I <= 1e-12) merged_I = body_moment_of_inertia(a);
+
+    if (out_obliquity)
+        *out_obliquity = obliquity_from_spin_axis(merged_axis);
+    if (out_rotation_rate)
+        *out_rotation_rate = (L_total[0] * merged_axis[0] + L_total[1] * merged_axis[1]) / fmax(merged_I, 1e-12);
 }
 
 static double ease_out_cubic(double t)
@@ -715,6 +843,7 @@ static void update_merge_events(double dt)
         Body *target, *impactor;
         double t, overlap_sep;
         double speed_boost;
+        double attach_world_dir[3];
 
         if (!m->active) continue;
         if (m->target < 0 || m->target >= g_nbodies ||
@@ -735,6 +864,8 @@ static void update_merge_events(double dt)
         if (t > 1.0) t = 1.0;
         speed_boost = merge_speed_boost(m->rel_speed);
         m->particle_emit_accum += dt;
+        body_local_surface_dir_to_world(m->target, m->target_local_attach_dir,
+                                        attach_world_dir);
 
         /* Lock impactor velocity to target. */
         impactor->vel[0] = target->vel[0];
@@ -746,7 +877,8 @@ static void update_merge_events(double dt)
         {
             double spin_window = 0.07 - 0.02 * fmin(speed_boost, 1.0);
             double slow = 1.0 - ease_out_cubic(fmin(1.0, t / spin_window));
-            target->rotation_rate   = m->target_rotation_rate   * slow;
+            target->obliquity = m->target_obliquity;
+            target->rotation_rate = m->target_rotation_rate;
             impactor->rotation_rate = m->impactor_rotation_rate * slow;
         }
 
@@ -773,9 +905,9 @@ static void update_merge_events(double dt)
             /* Despawn the impactor the moment it is fully inside the target. */
             if (overlap_sep + impactor_r <= target_contact_r) {
                 double old_radius = target->radius;
-                impactor->pos[0] = target->pos[0] + m->dir[0] * overlap_sep;
-                impactor->pos[1] = target->pos[1] + m->dir[1] * overlap_sep;
-                impactor->pos[2] = target->pos[2] + m->dir[2] * overlap_sep;
+                impactor->pos[0] = target->pos[0] + attach_world_dir[0] * overlap_sep;
+                impactor->pos[1] = target->pos[1] + attach_world_dir[1] * overlap_sep;
+                impactor->pos[2] = target->pos[2] + attach_world_dir[2] * overlap_sep;
                 /* Do not finish_radius_transition here — let it run to anim_dur
                  * so the target grows smoothly to its final size. */
                 if (m->scar_slot >= 0 && m->scar_slot < MAX_IMPACTS &&
@@ -802,9 +934,9 @@ static void update_merge_events(double dt)
                 continue;
             }
         }
-        impactor->pos[0] = target->pos[0] + m->dir[0] * overlap_sep;
-        impactor->pos[1] = target->pos[1] + m->dir[1] * overlap_sep;
-        impactor->pos[2] = target->pos[2] + m->dir[2] * overlap_sep;
+        impactor->pos[0] = target->pos[0] + attach_world_dir[0] * overlap_sep;
+        impactor->pos[1] = target->pos[1] + attach_world_dir[1] * overlap_sep;
+        impactor->pos[2] = target->pos[2] + attach_world_dir[2] * overlap_sep;
 
         if (t < 0.04) {
             double emit_t = t / 0.04;
@@ -821,7 +953,7 @@ static void update_merge_events(double dt)
                                       * emit_decay * emit_decay * emit_decay
                                       * emit_decay * emit_decay;
                     if (pack_scale < 0.020) pack_scale = 0.020;
-                spawn_impact_particles(m->target, COLLISION_VIS_MERGE, m->dir,
+                spawn_impact_particles(m->target, COLLISION_VIS_MERGE, attach_world_dir,
                                        m->rel_vel, g_bodies[m->impactor].radius,
                                        m->rel_speed, pack_scale);
                 }
@@ -844,16 +976,13 @@ static void update_merge_events(double dt)
                 if (cos_a >  1.0) cos_a =  1.0;
                 float cap = (float)acos(cos_a);
                 if (cap > scar->radius0) {
-                    float local_dir[3];
                     float boost = (float)(0.06 + 0.12 * fmin(speed_boost, 1.2));
                     scar->radius0 = cap;
                     scar->radius1 = fminf((float)(PI * 0.88),
                                           fmaxf(scar->radius1, cap * (1.08f + boost)));
-                    body_world_to_local_surface_dir(m->target, m->dir, local_dir);
-                    normalize3f(local_dir);
-                    scar->dir[0] = local_dir[0];
-                    scar->dir[1] = local_dir[1];
-                    scar->dir[2] = local_dir[2];
+                    scar->dir[0] = (float)m->target_local_attach_dir[0];
+                    scar->dir[1] = (float)m->target_local_attach_dir[1];
+                    scar->dir[2] = (float)m->target_local_attach_dir[2];
                 }
             }
             scar->age = 0.0; /* frozen at full heat until merge ends */
@@ -873,7 +1002,7 @@ static void update_merge_events(double dt)
                 float cap = (float)acos(cos_a);
                 if (cap > scar->radius0) {
                     float local_dir[3];
-                    double neg_dir[3] = {-m->dir[0], -m->dir[1], -m->dir[2]};
+                    double neg_dir[3] = {-attach_world_dir[0], -attach_world_dir[1], -attach_world_dir[2]};
                     float boost = (float)(0.05 + 0.10 * fmin(speed_boost, 1.2));
                     scar->radius0 = cap;
                     scar->radius1 = fminf((float)(PI * 0.88),
@@ -933,6 +1062,7 @@ static void begin_merge_event(int target, int impactor, double rel_speed,
     Body *b = &g_bodies[impactor];
     double total = a->mass + b->mass;
     double merged_radius;
+    float local_dir[3];
 
     for (int i = 0; i < MAX_MERGES; i++) {
         if (!s_merges[i].active) { slot = i; break; }
@@ -954,6 +1084,8 @@ static void begin_merge_event(int target, int impactor, double rel_speed,
     b->vel[0] = a->vel[0];
     b->vel[1] = a->vel[1];
     b->vel[2] = a->vel[2];
+    compute_collision_spin_state(target, impactor, dir, rel_vel,
+                                 &a->obliquity, &a->rotation_rate);
 
     s_merges[slot].active    = 1;
     s_merges[slot].target    = target;
@@ -966,13 +1098,15 @@ static void begin_merge_event(int target, int impactor, double rel_speed,
     s_merges[slot].rel_vel[0] = rel_vel[0];
     s_merges[slot].rel_vel[1] = rel_vel[1];
     s_merges[slot].rel_vel[2] = rel_vel[2];
-        s_merges[slot].rel_vel[0] = b->vel[0] - a->vel[0];
-        s_merges[slot].rel_vel[1] = b->vel[1] - a->vel[1];
-        s_merges[slot].rel_vel[2] = b->vel[2] - a->vel[2];
-        s_merges[slot].particle_emit_accum    = 0.0;
-        s_merges[slot].particle_emit_next     = 0.0;
-        s_merges[slot].target_rotation_rate   = a->rotation_rate;
+    body_world_to_local_surface_dir(target, dir, local_dir);
+    s_merges[slot].target_local_attach_dir[0] = local_dir[0];
+    s_merges[slot].target_local_attach_dir[1] = local_dir[1];
+    s_merges[slot].target_local_attach_dir[2] = local_dir[2];
+    s_merges[slot].particle_emit_accum    = 0.0;
+    s_merges[slot].particle_emit_next     = 0.0;
+    s_merges[slot].target_rotation_rate   = a->rotation_rate;
     s_merges[slot].impactor_rotation_rate = b->rotation_rate;
+    s_merges[slot].target_obliquity       = a->obliquity;
     s_merges[slot].scar_slot     = -1;
     s_merges[slot].imp_scar_slot = -1;
 

--- a/src/collision.c
+++ b/src/collision.c
@@ -1,0 +1,571 @@
+/*
+ * collision.c - first-pass solid-body impacts.
+ *
+ * Keeps body indices stable by marking absorbed bodies as !alive. The visual
+ * side is deliberately lightweight: an impact creates a local hot spot that
+ * the planet shader fades over time.
+ */
+#include "collision.h"
+#include "body.h"
+#include "labels.h"
+#include "rings.h"
+#include "trails.h"
+#include <math.h>
+#include <stdio.h>
+
+#define MAX_IMPACTS 64
+#define MAX_PAIR_DT (DAY * 20.0)
+#define MIN_PAIR_DT (60.0 * 5.0)
+#define HOT_PAIR_DT (60.0 * 10.0)
+#define SYSTEM_HOT_DURATION (DAY * 3.0)
+#define MIN_COLLISION_SPEED 1.0
+#define SYSTEM_MARGIN_AU 5.0
+#define IMPACT_COOL_SECONDS (DAY * 45.0)
+#define MAJOR_COOL_SECONDS (DAY * 90.0)
+#define MERGE_COOL_SECONDS (DAY * 180.0)
+
+typedef struct {
+    int active;
+    int body;
+    int kind;
+    double age;
+    double duration;
+    float dir[3];
+    float radius0;
+    float radius1;
+    float heat0;
+} ImpactEvent;
+
+typedef struct {
+    int active;
+    double age;
+    double duration;
+    double start_radius;
+    double target_radius;
+} RadiusTransition;
+
+static ImpactEvent s_impacts[MAX_IMPACTS];
+static RadiusTransition s_radius_fx[MAX_BODIES];
+static double s_pair_next[MAX_BODIES][MAX_BODIES];
+static unsigned char s_system_dirty[MAX_BODIES];
+static double s_system_hot[MAX_BODIES];
+
+static void mark_system_dirty(int root, double hot_duration)
+{
+    if (root < 0 || root >= MAX_BODIES) return;
+    s_system_dirty[root] = 1;
+    if (hot_duration > s_system_hot[root]) s_system_hot[root] = hot_duration;
+}
+
+void collision_on_body_added(int body_idx)
+{
+    int root = body_root_star(body_idx);
+    if (root >= 0) mark_system_dirty(root, SYSTEM_HOT_DURATION);
+}
+
+static int body_is_descendant_of(int body_idx, int ancestor_idx)
+{
+    if (body_idx < 0 || ancestor_idx < 0) return 0;
+    for (int p = g_bodies[body_idx].parent; p >= 0; p = g_bodies[p].parent)
+        if (p == ancestor_idx) return 1;
+    return 0;
+}
+
+static double dot3d(const double a[3], const double b[3])
+{
+    return a[0]*b[0] + a[1]*b[1] + a[2]*b[2];
+}
+
+static void normalize3f(float v[3])
+{
+    float len = sqrtf(v[0]*v[0] + v[1]*v[1] + v[2]*v[2]);
+    if (len <= 1e-8f) {
+        v[0] = 1.0f; v[1] = 0.0f; v[2] = 0.0f;
+        return;
+    }
+    v[0] /= len; v[1] /= len; v[2] /= len;
+}
+
+static double ease_out_cubic(double t)
+{
+    double inv;
+    if (t < 0.0) t = 0.0;
+    if (t > 1.0) t = 1.0;
+    inv = 1.0 - t;
+    return 1.0 - inv*inv*inv;
+}
+
+static double current_visual_radius(int body_idx, double physical_radius)
+{
+    RadiusTransition *fx;
+    double t;
+
+    if (body_idx < 0 || body_idx >= MAX_BODIES) return physical_radius;
+    fx = &s_radius_fx[body_idx];
+    if (!fx->active || fx->duration <= 0.0) return physical_radius;
+
+    t = fx->age / fx->duration;
+    if (t >= 1.0) return fx->target_radius;
+    return fx->start_radius +
+           (fx->target_radius - fx->start_radius) * ease_out_cubic(t);
+}
+
+static void start_radius_transition(int body_idx, double old_radius,
+                                    double new_radius, double duration)
+{
+    RadiusTransition *fx;
+    double start_radius;
+    if (body_idx < 0 || body_idx >= MAX_BODIES) return;
+    fx = &s_radius_fx[body_idx];
+    fx->active = 1;
+    fx->age = 0.0;
+    fx->duration = fmax(duration, 1.0);
+    start_radius = current_visual_radius(body_idx, old_radius);
+    if (new_radius > 0.0 && start_radius < new_radius * 0.35)
+        start_radius = new_radius * 0.35;
+    if (start_radius < old_radius)
+        start_radius = old_radius;
+    fx->start_radius = start_radius;
+    fx->target_radius = new_radius;
+}
+
+static void add_impact(int body_idx, int kind, const double world_dir[3],
+                       double impactor_radius, double rel_speed,
+                       double mass_ratio)
+{
+    int slot = -1;
+    Body *b;
+    ImpactEvent *e;
+    double radius_ratio;
+
+    for (int i = 0; i < MAX_IMPACTS; i++) {
+        if (!s_impacts[i].active) { slot = i; break; }
+    }
+    if (slot < 0) {
+        slot = 0;
+        for (int i = 1; i < MAX_IMPACTS; i++)
+            if (s_impacts[i].age > s_impacts[slot].age) slot = i;
+    }
+
+    b = &g_bodies[body_idx];
+    e = &s_impacts[slot];
+    e->active = 1;
+    e->body = body_idx;
+    e->kind = kind;
+    e->age = 0.0;
+    radius_ratio = impactor_radius / fmax(b->radius, 1.0);
+
+    if (kind == COLLISION_VIS_CRATER) {
+        e->duration = IMPACT_COOL_SECONDS;
+        e->heat0 = (float)fmin(0.95, 0.22 + rel_speed / 32000.0);
+        e->radius0 = (float)fmax(0.020, fmin(0.120, radius_ratio * 1.20));
+        e->radius1 = (float)fmax(e->radius0, fmin(0.180, e->radius0 * 1.35f));
+    } else if (kind == COLLISION_VIS_MAJOR) {
+        e->duration = MAJOR_COOL_SECONDS;
+        e->heat0 = (float)fmin(1.0, 0.45 + rel_speed / 22000.0 + mass_ratio * 0.4);
+        e->radius0 = (float)fmax(0.060, fmin(0.240, radius_ratio * 1.70));
+        e->radius1 = (float)fmax(e->radius0 + 0.040f, fmin(0.420, e->radius0 * 1.85f));
+    } else {
+        e->duration = MERGE_COOL_SECONDS;
+        e->heat0 = 1.0f;
+        e->radius0 = (float)fmax(0.120, fmin(0.320, 0.14 + mass_ratio * 0.42));
+        e->radius1 = (float)fmax(0.650, fmin(1.180, e->radius0 + 0.58f + mass_ratio * 0.32f));
+    }
+    body_world_to_local_surface_dir(body_idx, world_dir, e->dir);
+    normalize3f(e->dir);
+}
+
+static double trail_interval_for_body_after_merge(int body_idx)
+{
+    Body *b;
+    double dx, dy, dz, r, gm, T, interval;
+
+    if (body_idx < 0 || body_idx >= g_nbodies) return DAY;
+    b = &g_bodies[body_idx];
+    if (b->is_star) return DAY * 25.0;
+    if (b->parent < 0 || b->parent >= g_nbodies || !g_bodies[b->parent].alive)
+        return DAY;
+
+    dx = b->pos[0] - g_bodies[b->parent].pos[0];
+    dy = b->pos[1] - g_bodies[b->parent].pos[1];
+    dz = b->pos[2] - g_bodies[b->parent].pos[2];
+    r = sqrt(dx*dx + dy*dy + dz*dz);
+    gm = G_CONST * g_bodies[b->parent].mass;
+    if (r <= 0.0 || gm <= 0.0) return DAY;
+
+    T = 2.0 * PI * sqrt(r * r * r / gm);
+    interval = T / 400.0;
+    if (interval < 60.0) interval = 60.0;
+    return interval;
+}
+
+static int classify_collision(int a, int b, double rel_speed)
+{
+    double m_small = g_bodies[a].mass < g_bodies[b].mass ? g_bodies[a].mass : g_bodies[b].mass;
+    double m_large = g_bodies[a].mass > g_bodies[b].mass ? g_bodies[a].mass : g_bodies[b].mass;
+    double r_sum = g_bodies[a].radius + g_bodies[b].radius;
+    double mass_ratio, v_escape;
+
+    if (m_large <= 0.0) return COLLISION_VIS_CRATER;
+    mass_ratio = m_small / m_large;
+    v_escape = sqrt(fmax(0.0, 2.0 * G_CONST * (g_bodies[a].mass + g_bodies[b].mass) /
+                         fmax(r_sum, 1.0)));
+
+    if (mass_ratio >= 0.33 || g_bodies[a].radius >= 0.58 * g_bodies[b].radius ||
+        g_bodies[b].radius >= 0.58 * g_bodies[a].radius)
+        return COLLISION_VIS_MERGE;
+    if (mass_ratio >= 0.08 || rel_speed >= v_escape * 1.35)
+        return COLLISION_VIS_MAJOR;
+    return COLLISION_VIS_CRATER;
+}
+
+static int systems_may_interact(int root_a, int root_b, const double system_radius[MAX_BODIES])
+{
+    if (root_a == root_b) return 1;
+    if (root_a < 0 || root_b < 0) return 0;
+    if (!g_bodies[root_a].alive || !g_bodies[root_b].alive) return 0;
+
+    double dx = g_bodies[root_b].pos[0] - g_bodies[root_a].pos[0];
+    double dy = g_bodies[root_b].pos[1] - g_bodies[root_a].pos[1];
+    double dz = g_bodies[root_b].pos[2] - g_bodies[root_a].pos[2];
+    double r = system_radius[root_a] + system_radius[root_b];
+    return dx*dx + dy*dy + dz*dz <= r*r;
+}
+
+static double pair_check_dt(int a, int b)
+{
+    double rx = g_bodies[b].pos[0] - g_bodies[a].pos[0];
+    double ry = g_bodies[b].pos[1] - g_bodies[a].pos[1];
+    double rz = g_bodies[b].pos[2] - g_bodies[a].pos[2];
+    double dist2 = rx*rx + ry*ry + rz*rz;
+    if (dist2 <= 1e-12) return MIN_PAIR_DT;
+
+    double dist = sqrt(dist2);
+    double vx = g_bodies[b].vel[0] - g_bodies[a].vel[0];
+    double vy = g_bodies[b].vel[1] - g_bodies[a].vel[1];
+    double vz = g_bodies[b].vel[2] - g_bodies[a].vel[2];
+    double vr = -(rx*vx + ry*vy + rz*vz) / dist;
+    double gap = dist - (g_bodies[a].radius + g_bodies[b].radius);
+
+    if (gap <= 0.0) return MIN_PAIR_DT;
+    if (vr <= 1e-3) {
+        double rel_speed = sqrt(vx*vx + vy*vy + vz*vz);
+        if (dist > 200.0 * (g_bodies[a].radius + g_bodies[b].radius) &&
+            rel_speed < 100.0)
+            return MAX_PAIR_DT;
+        return fmin(MAX_PAIR_DT, fmax(MIN_PAIR_DT, dist / fmax(rel_speed, 1.0) * 0.2));
+    }
+
+    {
+        double tau = gap / vr;
+        double dt = tau * 0.2;
+        if (dt < MIN_PAIR_DT) dt = MIN_PAIR_DT;
+        if (dt > MAX_PAIR_DT) dt = MAX_PAIR_DT;
+        return dt;
+    }
+}
+
+static int swept_spheres_collide(int a, int b, double dt, double *out_speed)
+{
+    double rel_now[3] = {
+        g_bodies[b].pos[0] - g_bodies[a].pos[0],
+        g_bodies[b].pos[1] - g_bodies[a].pos[1],
+        g_bodies[b].pos[2] - g_bodies[a].pos[2]
+    };
+    double rel_v[3] = {
+        g_bodies[b].vel[0] - g_bodies[a].vel[0],
+        g_bodies[b].vel[1] - g_bodies[a].vel[1],
+        g_bodies[b].vel[2] - g_bodies[a].vel[2]
+    };
+    double rel_p[3] = {
+        rel_now[0] - rel_v[0] * dt,
+        rel_now[1] - rel_v[1] * dt,
+        rel_now[2] - rel_v[2] * dt
+    };
+    double vv = dot3d(rel_v, rel_v);
+    double t = 0.0;
+    if (vv > MIN_COLLISION_SPEED * MIN_COLLISION_SPEED) {
+        t = -dot3d(rel_p, rel_v) / vv;
+        if (t < 0.0) t = 0.0;
+        if (t > dt) t = dt;
+    }
+
+    double c[3] = {
+        rel_p[0] + rel_v[0] * t,
+        rel_p[1] + rel_v[1] * t,
+        rel_p[2] + rel_v[2] * t
+    };
+    double r = g_bodies[a].radius + g_bodies[b].radius;
+    if (out_speed) *out_speed = sqrt(vv);
+    return dot3d(c, c) <= r*r;
+}
+
+static void impact_dir_for_pair(int target, int impactor, double dt, double out_dir[3])
+{
+    double rel_now[3] = {
+        g_bodies[impactor].pos[0] - g_bodies[target].pos[0],
+        g_bodies[impactor].pos[1] - g_bodies[target].pos[1],
+        g_bodies[impactor].pos[2] - g_bodies[target].pos[2]
+    };
+    double rel_v[3] = {
+        g_bodies[impactor].vel[0] - g_bodies[target].vel[0],
+        g_bodies[impactor].vel[1] - g_bodies[target].vel[1],
+        g_bodies[impactor].vel[2] - g_bodies[target].vel[2]
+    };
+    double rel_p[3] = {
+        rel_now[0] - rel_v[0] * dt,
+        rel_now[1] - rel_v[1] * dt,
+        rel_now[2] - rel_v[2] * dt
+    };
+    double vv = dot3d(rel_v, rel_v);
+    double t = 0.0;
+    double c[3];
+    double len;
+
+    if (vv > MIN_COLLISION_SPEED * MIN_COLLISION_SPEED) {
+        t = -dot3d(rel_p, rel_v) / vv;
+        if (t < 0.0) t = 0.0;
+        if (t > dt) t = dt;
+    }
+
+    c[0] = rel_p[0] + rel_v[0] * t;
+    c[1] = rel_p[1] + rel_v[1] * t;
+    c[2] = rel_p[2] + rel_v[2] * t;
+    len = sqrt(dot3d(c, c));
+    if (len <= 1e-12) {
+        c[0] = rel_now[0];
+        c[1] = rel_now[1];
+        c[2] = rel_now[2];
+        len = sqrt(dot3d(c, c));
+    }
+    if (len <= 1e-12) {
+        out_dir[0] = 1.0;
+        out_dir[1] = 0.0;
+        out_dir[2] = 0.0;
+        return;
+    }
+
+    out_dir[0] = c[0] / len;
+    out_dir[1] = c[1] / len;
+    out_dir[2] = c[2] / len;
+}
+
+static void absorb_body(int target, int impactor, double rel_speed, double collision_dt)
+{
+    Body *a = &g_bodies[target];
+    Body *b = &g_bodies[impactor];
+    double old_radius;
+    double mass_ratio;
+    double merged_radius;
+    double dir[3];
+    int outcome;
+
+    if (!a->alive || !b->alive || a->is_star || b->is_star) return;
+
+    old_radius = a->radius;
+    mass_ratio = fmin(a->mass, b->mass) / fmax(fmax(a->mass, b->mass), 1.0);
+    outcome = classify_collision(target, impactor, rel_speed);
+    {
+        double total = a->mass + b->mass;
+    if (total <= 0.0) return;
+
+    impact_dir_for_pair(target, impactor, collision_dt, dir);
+    add_impact(target, outcome, dir, b->radius, rel_speed, mass_ratio);
+
+    a->pos[0] = (a->pos[0] * a->mass + b->pos[0] * b->mass) / total;
+    a->pos[1] = (a->pos[1] * a->mass + b->pos[1] * b->mass) / total;
+    a->pos[2] = (a->pos[2] * a->mass + b->pos[2] * b->mass) / total;
+    a->vel[0] = (a->vel[0] * a->mass + b->vel[0] * b->mass) / total;
+    a->vel[1] = (a->vel[1] * a->mass + b->vel[1] * b->mass) / total;
+    a->vel[2] = (a->vel[2] * a->mass + b->vel[2] * b->mass) / total;
+    merged_radius = cbrt(a->radius*a->radius*a->radius +
+                         b->radius*b->radius*b->radius);
+    if (merged_radius < old_radius) merged_radius = old_radius;
+    if (merged_radius < b->radius) merged_radius = b->radius;
+    a->radius = merged_radius;
+    a->mass = total;
+    }
+
+    if (outcome == COLLISION_VIS_MERGE)
+        start_radius_transition(target, old_radius, a->radius, DAY * 12.0);
+    else if (outcome == COLLISION_VIS_MAJOR)
+        start_radius_transition(target, old_radius, a->radius, DAY * 5.0);
+    else if (a->radius > old_radius * 1.015)
+        start_radius_transition(target, old_radius, a->radius, DAY * 1.5);
+
+    for (int i = 0; i < g_nbodies; i++) {
+        if (!g_bodies[i].alive || g_bodies[i].parent != impactor) continue;
+        if (target == i || body_is_descendant_of(target, i))
+            g_bodies[i].parent = body_root_star(target);
+        else
+            g_bodies[i].parent = target;
+        labels_add_body(i);
+    }
+
+    rings_on_body_absorbed(target, impactor);
+    b->alive = 0;
+    b->mass = 0.0;
+    b->trail_count = 0;
+    a->trail_interval = trail_interval_for_body_after_merge(target);
+    trails_reset_body(target);
+    labels_add_body(target);
+    labels_remove_body(impactor);
+    trails_remove_body(impactor);
+    mark_system_dirty(body_root_star(target), SYSTEM_HOT_DURATION);
+    fprintf(stdout, "[collision] %s absorbed %s (%.0f m/s, %s, %.0f->%.0f km)\n",
+            a->name, b->name, rel_speed,
+            outcome == COLLISION_VIS_MERGE ? "merge" :
+            outcome == COLLISION_VIS_MAJOR ? "major" : "crater",
+            old_radius / 1000.0, a->radius / 1000.0);
+}
+
+void collision_step(double dt)
+{
+    int root_of[MAX_BODIES];
+    double system_radius[MAX_BODIES];
+    int resolved[MAX_BODIES] = {0};
+    int members[MAX_BODIES][MAX_BODIES];
+    int member_count[MAX_BODIES] = {0};
+    int any_dirty = 0;
+
+    for (int i = 0; i < MAX_IMPACTS; i++) {
+        if (!s_impacts[i].active) continue;
+        s_impacts[i].age += dt;
+        if (s_impacts[i].age >= s_impacts[i].duration ||
+            s_impacts[i].body < 0 || s_impacts[i].body >= g_nbodies ||
+            !g_bodies[s_impacts[i].body].alive)
+            s_impacts[i].active = 0;
+    }
+    for (int i = 0; i < MAX_BODIES; i++) {
+        if (!s_radius_fx[i].active) continue;
+        if (i >= g_nbodies || !g_bodies[i].alive) {
+            s_radius_fx[i].active = 0;
+            continue;
+        }
+        s_radius_fx[i].age += dt;
+        if (s_radius_fx[i].age >= s_radius_fx[i].duration) {
+            s_radius_fx[i].active = 0;
+            s_radius_fx[i].age = s_radius_fx[i].duration;
+        }
+    }
+
+    if (dt <= 0.0) return;
+
+    for (int i = 0; i < MAX_BODIES; i++) {
+        if (s_system_dirty[i]) any_dirty = 1;
+        if (s_system_hot[i] > 0.0) {
+            s_system_hot[i] -= dt;
+            if (s_system_hot[i] < 0.0) s_system_hot[i] = 0.0;
+        }
+    }
+    if (!any_dirty) return;
+
+    for (int i = 0; i < MAX_BODIES; i++) {
+        root_of[i] = -1;
+        system_radius[i] = SYSTEM_MARGIN_AU * AU;
+    }
+    for (int i = 0; i < g_nbodies; i++) {
+        if (!g_bodies[i].alive) continue;
+        int root = body_root_star(i);
+        root_of[i] = root;
+        if (root < 0 || root >= g_nbodies) continue;
+        if (member_count[root] < MAX_BODIES)
+            members[root][member_count[root]++] = i;
+        double dx = g_bodies[i].pos[0] - g_bodies[root].pos[0];
+        double dy = g_bodies[i].pos[1] - g_bodies[root].pos[1];
+        double dz = g_bodies[i].pos[2] - g_bodies[root].pos[2];
+        double d = sqrt(dx*dx + dy*dy + dz*dz) + g_bodies[i].radius;
+        if (d > system_radius[root]) system_radius[root] = d;
+    }
+
+    for (int root = 0; root < g_nbodies; root++) {
+        if (!s_system_dirty[root]) continue;
+        if (!g_bodies[root].alive) {
+            s_system_dirty[root] = 0;
+            s_system_hot[root] = 0.0;
+            continue;
+        }
+
+        int n = member_count[root];
+        int root_had_collision = 0;
+        for (int ai = 0; ai < n && !root_had_collision; ai++) {
+            int a = members[root][ai];
+            if (!g_bodies[a].alive || g_bodies[a].is_star || resolved[a]) continue;
+            for (int bi = ai + 1; bi < n; bi++) {
+                int b = members[root][bi];
+                int lo = a < b ? a : b;
+                int hi = a < b ? b : a;
+                double speed = 0.0;
+
+                if (!g_bodies[b].alive || g_bodies[b].is_star || resolved[b]) continue;
+                if (!systems_may_interact(root_of[a], root_of[b], system_radius)) continue;
+
+                if (s_system_hot[root] > 0.0) {
+                    s_pair_next[lo][hi] = HOT_PAIR_DT;
+                } else {
+                    s_pair_next[lo][hi] -= dt;
+                    if (s_pair_next[lo][hi] > 0.0) continue;
+                }
+
+                if (!swept_spheres_collide(a, b, dt, &speed)) {
+                    s_pair_next[lo][hi] = pair_check_dt(a, b);
+                    continue;
+                }
+
+                {
+                    int target = g_bodies[a].mass >= g_bodies[b].mass ? a : b;
+                    int impactor = target == a ? b : a;
+                    absorb_body(target, impactor, speed, dt);
+                    resolved[target] = 1;
+                    resolved[impactor] = 1;
+                    s_pair_next[lo][hi] = HOT_PAIR_DT;
+                    root_had_collision = 1;
+                    break;
+                }
+            }
+        }
+
+        (void)root_had_collision;
+    }
+}
+
+int collision_spots_for_body(int body_idx, CollisionSpot spots[COLLISION_MAX_SPOTS])
+{
+    int n = 0;
+    if (!spots || body_idx < 0 || body_idx >= g_nbodies) return 0;
+
+    for (int i = 0; i < MAX_IMPACTS && n < COLLISION_MAX_SPOTS; i++) {
+        ImpactEvent *e = &s_impacts[i];
+        double t;
+        double heat_curve;
+        double rad;
+        if (!e->active || e->body != body_idx) continue;
+        t = e->age / e->duration;
+        if (t < 0.0) t = 0.0;
+        if (t > 1.0) t = 1.0;
+        heat_curve = (1.0 - t) * (1.0 - t);
+        if (e->kind == COLLISION_VIS_MERGE)
+            heat_curve = pow(1.0 - t, 1.45);
+        else if (e->kind == COLLISION_VIS_CRATER)
+            heat_curve = pow(1.0 - t, 2.35);
+        rad = e->radius0 + (e->radius1 - e->radius0) * ease_out_cubic(t);
+        {
+        float heat = e->heat0 * (float)heat_curve;
+        if (heat <= 0.01f) continue;
+        spots[n].dir[0] = e->dir[0];
+        spots[n].dir[1] = e->dir[1];
+        spots[n].dir[2] = e->dir[2];
+        spots[n].angular_radius = (float)rad;
+        spots[n].heat = heat;
+        spots[n].progress = (float)t;
+        spots[n].kind = e->kind;
+        n++;
+        }
+    }
+    return n;
+}
+
+double collision_visual_radius(int body_idx, double physical_radius)
+{
+    return current_visual_radius(body_idx, physical_radius);
+}

--- a/src/collision.c
+++ b/src/collision.c
@@ -85,8 +85,6 @@ static double s_system_hot[MAX_BODIES];
 static unsigned int s_particle_rng = 0x1234abcdu;
 static double s_pos_before[MAX_BODIES][3];
 static int s_pos_before_valid = 0;
-static int s_debug_frames = 0;           /* non-zero: enhanced diagnostics active */
-static int s_debug_skip_logged[MAX_BODIES]; /* 1 if "SKIPPED" already printed this window */
 
 static void mark_system_dirty(int root, double hot_duration)
 {
@@ -110,12 +108,6 @@ void collision_on_body_added(int body_idx)
 {
     int root = body_root_star(body_idx);
     if (root >= 0) mark_system_dirty(root, SYSTEM_HOT_DURATION);
-    s_debug_frames = 300;
-    memset(s_debug_skip_logged, 0, sizeof(s_debug_skip_logged));
-    fprintf(stderr, "[coll-dbg] body added: idx=%d root=%d dirty=%d hot=%.2f days\n",
-            body_idx, root,
-            (root >= 0 && root < MAX_BODIES) ? s_system_dirty[root] : -1,
-            (root >= 0 && root < MAX_BODIES) ? s_system_hot[root] / DAY : 0.0);
 }
 
 static int body_is_descendant_of(int body_idx, int ancestor_idx)
@@ -700,19 +692,6 @@ static void finalize_absorb_body(int target, int impactor, double rel_speed,
     labels_remove_body(impactor);
     trails_remove_body(impactor);
     mark_system_dirty(body_root_star(target), SYSTEM_HOT_DURATION);
-    s_debug_frames = 300;
-    memset(s_debug_skip_logged, 0, sizeof(s_debug_skip_logged));
-    {
-        int root = body_root_star(target);
-        fprintf(stderr, "[coll-dbg] merge done: target=%d root=%d hot=%.2f days | alive bodies:",
-                target, root, s_system_hot[root] / DAY);
-        for (int i = 0; i < g_nbodies; i++) {
-            if (!g_bodies[i].alive) continue;
-            fprintf(stderr, " %d(root=%d,imp=%d)", i,
-                    body_root_star(i), body_is_merge_impactor(i));
-        }
-        fprintf(stderr, "\n");
-    }
     fprintf(stdout, "[collision] %s absorbed %s (%.0f m/s, %s, %.0f->%.0f km)\n",
             a->name, b->name, rel_speed,
             outcome == COLLISION_VIS_MERGE ? "merge" :
@@ -1217,8 +1196,6 @@ static void absorb_body(int target, int impactor, double rel_speed, double colli
     outcome = classify_collision(target, impactor, rel_speed);
     impact_dir_for_pair(target, impactor, collision_dt, dir);
     if (outcome == COLLISION_VIS_MERGE) {
-        fprintf(stderr, "[coll-dbg] merge start: target=%d impactor=%d speed=%.3g m/s\n",
-                target, impactor, rel_speed);
         begin_merge_event(target, impactor, rel_speed, dir, rel_vel, old_radius);
         return;
     }
@@ -1317,8 +1294,6 @@ void collision_step(double dt)
         if (d > system_radius[root]) system_radius[root] = d;
     }
 
-    if (s_debug_frames > 0) s_debug_frames--;
-
     for (int root = 0; root < g_nbodies; root++) {
         if (!s_system_dirty[root]) continue;
         if (!g_bodies[root].alive) {
@@ -1342,15 +1317,8 @@ void collision_step(double dt)
             nb = member_count[other_root];
             for (int ai = 0; ai < na && !root_had_collision; ai++) {
                 int a = members[root][ai];
-                if (!g_bodies[a].alive || g_bodies[a].is_star || resolved[a] || body_is_merge_impactor(a)) {
-                    if (s_debug_frames > 0 && g_bodies[a].alive && !g_bodies[a].is_star
-                            && !s_debug_skip_logged[a]) {
-                        fprintf(stderr, "[coll-dbg] body %d first SKIPPED resolved=%d impactor=%d\n",
-                                a, resolved[a], body_is_merge_impactor(a));
-                        s_debug_skip_logged[a] = 1;
-                    }
+                if (!g_bodies[a].alive || g_bodies[a].is_star || resolved[a] || body_is_merge_impactor(a))
                     continue;
-                }
                 for (int bi = 0; bi < nb; bi++) {
                     int b = members[other_root][bi];
                     int lo, hi;
@@ -1372,16 +1340,6 @@ void collision_step(double dt)
 
                     {
                         int hit = swept_spheres_collide(a, b, dt, &speed);
-                        if (s_debug_frames > 0) {
-                            double dx = g_bodies[b].pos[0] - g_bodies[a].pos[0];
-                            double dy = g_bodies[b].pos[1] - g_bodies[a].pos[1];
-                            double dz = g_bodies[b].pos[2] - g_bodies[a].pos[2];
-                            double dist = sqrt(dx*dx + dy*dy + dz*dz);
-                            double r = current_contact_radius(a) + current_contact_radius(b);
-                            if (hit || dist < r * 20.0)
-                                fprintf(stderr, "[coll-dbg] pair (%d,%d) dist=%.3g r=%.3g hit=%d hot=%.2f\n",
-                                        a, b, dist, r, hit, s_system_hot[root] / DAY);
-                        }
                         if (!hit) {
                             double pdt = pair_check_dt(a, b);
                             s_pair_next[lo][hi] = pdt;

--- a/src/collision.c
+++ b/src/collision.c
@@ -34,6 +34,7 @@ typedef struct {
     double age;
     double duration;
     float dir[3];
+    float tangent1[3];
     float radius0;
     float radius1;
     float heat0;
@@ -57,6 +58,7 @@ typedef struct {
     double dir[3];
     double rel_vel[3];
     double target_local_attach_dir[3];
+    double target_local_attach_t1[3];
     double start_sep;
     double particle_emit_accum;
     double particle_emit_next;
@@ -240,6 +242,49 @@ static void body_local_surface_dir_to_world(int body_idx, const double local_dir
         return;
     }
     out[0] /= len; out[1] /= len; out[2] /= len;
+}
+
+static void build_local_scar_tangent(int body_idx, const double world_dir[3],
+                                     const double rel_vel[3], float out_local_t1[3])
+{
+    double world_t1[3];
+    double fallback_t1[3], fallback_t2[3];
+    double dotn;
+
+    if (!out_local_t1) return;
+    if (!world_dir) {
+        out_local_t1[0] = 1.0f;
+        out_local_t1[1] = 0.0f;
+        out_local_t1[2] = 0.0f;
+        return;
+    }
+
+    if (rel_vel) {
+        double len;
+        dotn = dot3d(rel_vel, world_dir);
+        world_t1[0] = rel_vel[0] - world_dir[0] * dotn;
+        world_t1[1] = rel_vel[1] - world_dir[1] * dotn;
+        world_t1[2] = rel_vel[2] - world_dir[2] * dotn;
+        len = sqrt(dot3d(world_t1, world_t1));
+        if (len > 1e-12) {
+            world_t1[0] /= len;
+            world_t1[1] /= len;
+            world_t1[2] /= len;
+        } else {
+            orthonormal_basis(world_dir, fallback_t1, fallback_t2);
+            world_t1[0] = fallback_t1[0];
+            world_t1[1] = fallback_t1[1];
+            world_t1[2] = fallback_t1[2];
+        }
+    } else {
+        orthonormal_basis(world_dir, fallback_t1, fallback_t2);
+        world_t1[0] = fallback_t1[0];
+        world_t1[1] = fallback_t1[1];
+        world_t1[2] = fallback_t1[2];
+    }
+
+    body_world_to_local_surface_dir(body_idx, world_t1, out_local_t1);
+    normalize3f(out_local_t1);
 }
 
 static double body_moment_of_inertia(const Body *b)
@@ -745,6 +790,7 @@ static void add_impact(int body_idx, int kind, const double world_dir[3],
             radius_ratio, e->radius0, e->radius1, e->duration / DAY);
     body_world_to_local_surface_dir(body_idx, world_dir, e->dir);
     normalize3f(e->dir);
+    build_local_scar_tangent(body_idx, world_dir, rel_vel, e->tangent1);
     spawn_impact_particles(body_idx, kind, world_dir, rel_vel,
                            impactor_radius, rel_speed, 1.0);
 }
@@ -844,6 +890,7 @@ static void update_merge_events(double dt)
         double t, overlap_sep;
         double speed_boost;
         double attach_world_dir[3];
+        double attach_world_t1[3];
 
         if (!m->active) continue;
         if (m->target < 0 || m->target >= g_nbodies ||
@@ -866,6 +913,8 @@ static void update_merge_events(double dt)
         m->particle_emit_accum += dt;
         body_local_surface_dir_to_world(m->target, m->target_local_attach_dir,
                                         attach_world_dir);
+        body_local_surface_dir_to_world(m->target, m->target_local_attach_t1,
+                                        attach_world_t1);
 
         /* Lock impactor velocity to target. */
         impactor->vel[0] = target->vel[0];
@@ -983,6 +1032,9 @@ static void update_merge_events(double dt)
                     scar->dir[0] = (float)m->target_local_attach_dir[0];
                     scar->dir[1] = (float)m->target_local_attach_dir[1];
                     scar->dir[2] = (float)m->target_local_attach_dir[2];
+                    scar->tangent1[0] = (float)m->target_local_attach_t1[0];
+                    scar->tangent1[1] = (float)m->target_local_attach_t1[1];
+                    scar->tangent1[2] = (float)m->target_local_attach_t1[2];
                 }
             }
             scar->age = 0.0; /* frozen at full heat until merge ends */
@@ -1002,16 +1054,22 @@ static void update_merge_events(double dt)
                 float cap = (float)acos(cos_a);
                 if (cap > scar->radius0) {
                     float local_dir[3];
+                    float local_t1[3];
                     double neg_dir[3] = {-attach_world_dir[0], -attach_world_dir[1], -attach_world_dir[2]};
                     float boost = (float)(0.05 + 0.10 * fmin(speed_boost, 1.2));
                     scar->radius0 = cap;
                     scar->radius1 = fminf((float)(PI * 0.88),
                                           fmaxf(scar->radius1, cap * (1.06f + boost)));
                     body_world_to_local_surface_dir(m->impactor, neg_dir, local_dir);
+                    body_world_to_local_surface_dir(m->impactor, attach_world_t1, local_t1);
                     normalize3f(local_dir);
+                    normalize3f(local_t1);
                     scar->dir[0] = local_dir[0];
                     scar->dir[1] = local_dir[1];
                     scar->dir[2] = local_dir[2];
+                    scar->tangent1[0] = local_t1[0];
+                    scar->tangent1[1] = local_t1[1];
+                    scar->tangent1[2] = local_t1[2];
                 }
             }
             scar->age = 0.0;
@@ -1062,7 +1120,7 @@ static void begin_merge_event(int target, int impactor, double rel_speed,
     Body *b = &g_bodies[impactor];
     double total = a->mass + b->mass;
     double merged_radius;
-    float local_dir[3];
+    float local_dir[3], local_t1[3];
 
     for (int i = 0; i < MAX_MERGES; i++) {
         if (!s_merges[i].active) { slot = i; break; }
@@ -1102,6 +1160,10 @@ static void begin_merge_event(int target, int impactor, double rel_speed,
     s_merges[slot].target_local_attach_dir[0] = local_dir[0];
     s_merges[slot].target_local_attach_dir[1] = local_dir[1];
     s_merges[slot].target_local_attach_dir[2] = local_dir[2];
+    build_local_scar_tangent(target, dir, rel_vel, local_t1);
+    s_merges[slot].target_local_attach_t1[0] = local_t1[0];
+    s_merges[slot].target_local_attach_t1[1] = local_t1[1];
+    s_merges[slot].target_local_attach_t1[2] = local_t1[2];
     s_merges[slot].particle_emit_accum    = 0.0;
     s_merges[slot].particle_emit_next     = 0.0;
     s_merges[slot].target_rotation_rate   = a->rotation_rate;
@@ -1152,18 +1214,23 @@ static void begin_merge_event(int target, int impactor, double rel_speed,
         scar->duration = MERGE_COOL_SECONDS;
         scar->heat0    = 1.0f;
         scar->radius0  = 0.0f;
-        scar->radius1  = (float)(0.22 + 0.12 * fmin(merge_speed_boost(rel_speed), 1.5));
+        scar->radius1  = (float)(0.18 + 0.08 * fmin(merge_speed_boost(rel_speed), 1.5));
         scar->dir[0]   = local_dir[0];
         scar->dir[1]   = local_dir[1];
         scar->dir[2]   = local_dir[2];
+        scar->tangent1[0] = (float)s_merges[slot].target_local_attach_t1[0];
+        scar->tangent1[1] = (float)s_merges[slot].target_local_attach_t1[1];
+        scar->tangent1[2] = (float)s_merges[slot].target_local_attach_t1[2];
         s_merges[slot].scar_slot = scar_slot;
     }
 
     /* Impactor-side scar: same setup, direction reversed. */
     {
         double neg_dir[3] = {-dir[0], -dir[1], -dir[2]};
+        double world_t1[3];
         int k, scar_slot = -1;
         float local_dir[3];
+        float local_t1[3];
         ImpactEvent *scar;
         for (k = 0; k < MAX_IMPACTS; k++) {
             if (!s_impacts[k].active) { scar_slot = k; break; }
@@ -1173,8 +1240,11 @@ static void begin_merge_event(int target, int impactor, double rel_speed,
             for (k = 1; k < MAX_IMPACTS; k++)
                 if (s_impacts[k].age > s_impacts[scar_slot].age) scar_slot = k;
         }
+        body_local_surface_dir_to_world(target, s_merges[slot].target_local_attach_t1, world_t1);
         body_world_to_local_surface_dir(impactor, neg_dir, local_dir);
+        body_world_to_local_surface_dir(impactor, world_t1, local_t1);
         normalize3f(local_dir);
+        normalize3f(local_t1);
         scar = &s_impacts[scar_slot];
         scar->active   = 1;
         scar->body     = impactor;
@@ -1183,10 +1253,13 @@ static void begin_merge_event(int target, int impactor, double rel_speed,
         scar->duration = MERGE_COOL_SECONDS;
         scar->heat0    = 1.0f;
         scar->radius0  = 0.0f;
-        scar->radius1  = (float)(0.18 + 0.10 * fmin(merge_speed_boost(rel_speed), 1.5));
+        scar->radius1  = (float)(0.15 + 0.07 * fmin(merge_speed_boost(rel_speed), 1.5));
         scar->dir[0]   = local_dir[0];
         scar->dir[1]   = local_dir[1];
         scar->dir[2]   = local_dir[2];
+        scar->tangent1[0] = local_t1[0];
+        scar->tangent1[1] = local_t1[1];
+        scar->tangent1[2] = local_t1[2];
         s_merges[slot].imp_scar_slot = scar_slot;
     }
 
@@ -1613,6 +1686,9 @@ int collision_spots_for_body(int body_idx, CollisionSpot spots[COLLISION_MAX_SPO
         spots[n].dir[0] = e->dir[0];
         spots[n].dir[1] = e->dir[1];
         spots[n].dir[2] = e->dir[2];
+        spots[n].tangent1[0] = e->tangent1[0];
+        spots[n].tangent1[1] = e->tangent1[1];
+        spots[n].tangent1[2] = e->tangent1[2];
         spots[n].angular_radius = (float)rad;
         spots[n].heat = heat;
         spots[n].progress = (float)t;

--- a/src/collision.c
+++ b/src/collision.c
@@ -23,6 +23,8 @@
 #define IMPACT_COOL_SECONDS (DAY * 45.0)
 #define MAJOR_COOL_SECONDS (DAY * 90.0)
 #define MERGE_COOL_SECONDS (DAY * 180.0)
+#define MERGE_PHASE_SECONDS (DAY * 8.0)
+#define MAX_MERGES 16
 
 typedef struct {
     int active;
@@ -44,8 +46,24 @@ typedef struct {
     double target_radius;
 } RadiusTransition;
 
+typedef struct {
+    int active;
+    int target;
+    int impactor;
+    double age;
+    double duration;
+    double rel_speed;
+    double dir[3];
+    double start_sep;
+    double target_rotation_rate;   /* saved initial rates so both can slow together */
+    double impactor_rotation_rate;
+    int scar_slot;          /* s_impacts index for the target intersection scar */
+    int imp_scar_slot;      /* s_impacts index for the impactor intersection scar */
+} MergeEvent;
+
 static ImpactEvent s_impacts[MAX_IMPACTS];
 static RadiusTransition s_radius_fx[MAX_BODIES];
+static MergeEvent s_merges[MAX_MERGES];
 static double s_pair_next[MAX_BODIES][MAX_BODIES];
 static unsigned char s_system_dirty[MAX_BODIES];
 static double s_system_hot[MAX_BODIES];
@@ -76,6 +94,15 @@ static double dot3d(const double a[3], const double b[3])
     return a[0]*b[0] + a[1]*b[1] + a[2]*b[2];
 }
 
+static int body_is_in_merge(int idx)
+{
+    for (int i = 0; i < MAX_MERGES; i++) {
+        if (!s_merges[i].active) continue;
+        if (s_merges[i].target == idx || s_merges[i].impactor == idx) return 1;
+    }
+    return 0;
+}
+
 static void normalize3f(float v[3])
 {
     float len = sqrtf(v[0]*v[0] + v[1]*v[1] + v[2]*v[2]);
@@ -93,6 +120,24 @@ static double ease_out_cubic(double t)
     if (t > 1.0) t = 1.0;
     inv = 1.0 - t;
     return 1.0 - inv*inv*inv;
+}
+
+static double fast_then_slow_spread(double t, double fast_window)
+{
+    double fast_t, slow_t;
+
+    if (t < 0.0) t = 0.0;
+    if (t > 1.0) t = 1.0;
+    if (fast_window < 1e-6) return ease_out_cubic(t);
+
+    fast_t = t / fast_window;
+    if (fast_t > 1.0) fast_t = 1.0;
+    slow_t = (t - fast_window) / (1.0 - fast_window);
+    if (slow_t < 0.0) slow_t = 0.0;
+    if (slow_t > 1.0) slow_t = 1.0;
+
+    /* Large burst during active contact, then a long taper. */
+    return 0.82 * ease_out_cubic(fast_t) + 0.18 * ease_out_cubic(slow_t);
 }
 
 static double current_visual_radius(int body_idx, double physical_radius)
@@ -158,18 +203,18 @@ static void add_impact(int body_idx, int kind, const double world_dir[3],
     if (kind == COLLISION_VIS_CRATER) {
         e->duration = IMPACT_COOL_SECONDS;
         e->heat0 = (float)fmin(0.95, 0.22 + rel_speed / 32000.0);
-        e->radius0 = (float)fmax(0.020, fmin(0.120, radius_ratio * 1.20));
-        e->radius1 = (float)fmax(e->radius0, fmin(0.180, e->radius0 * 1.35f));
+        e->radius0 = (float)fmax(0.010, fmin(0.070, radius_ratio * 0.70));
+        e->radius1 = (float)fmax(e->radius0 + 0.020f, fmin(0.240, e->radius0 * 2.80f));
     } else if (kind == COLLISION_VIS_MAJOR) {
         e->duration = MAJOR_COOL_SECONDS;
         e->heat0 = (float)fmin(1.0, 0.45 + rel_speed / 22000.0 + mass_ratio * 0.4);
-        e->radius0 = (float)fmax(0.060, fmin(0.240, radius_ratio * 1.70));
-        e->radius1 = (float)fmax(e->radius0 + 0.040f, fmin(0.420, e->radius0 * 1.85f));
+        e->radius0 = (float)fmax(0.030, fmin(0.140, radius_ratio * 1.05));
+        e->radius1 = (float)fmax(e->radius0 + 0.060f, fmin(0.650, e->radius0 * 3.10f));
     } else {
         e->duration = MERGE_COOL_SECONDS;
         e->heat0 = 1.0f;
-        e->radius0 = (float)fmax(0.120, fmin(0.320, 0.14 + mass_ratio * 0.42));
-        e->radius1 = (float)fmax(0.650, fmin(1.180, e->radius0 + 0.58f + mass_ratio * 0.32f));
+        e->radius0 = (float)fmax(0.120, fmin(0.280, 0.12 + mass_ratio * 0.28));
+        e->radius1 = (float)fmax(2.30f, fmin(3.20f, 2.30f + mass_ratio * 0.70f));
     }
     body_world_to_local_surface_dir(body_idx, world_dir, e->dir);
     normalize3f(e->dir);
@@ -199,6 +244,303 @@ static double trail_interval_for_body_after_merge(int body_idx)
     return interval;
 }
 
+static double merge_duration_for_bodies(int target, int impactor, double rel_speed)
+{
+    double radius_scale;
+    double speed_scale;
+    double duration;
+
+    radius_scale = (g_bodies[target].radius + g_bodies[impactor].radius)
+                 / (2.0 * 6371.0e3);
+    if (radius_scale < 0.35) radius_scale = 0.35;
+
+    speed_scale = 1.0 / (1.0 + rel_speed / 18000.0);
+    if (speed_scale < 0.45) speed_scale = 0.45;
+
+    duration = DAY * 1.18 * pow(radius_scale, 0.55) / speed_scale;
+    if (duration < DAY * 1.2) duration = DAY * 1.2;
+    if (duration > DAY * 14.0) duration = DAY * 14.0;
+    return duration;
+}
+
+static void finalize_absorb_body(int target, int impactor, double rel_speed,
+                                 int outcome, double old_radius)
+{
+    Body *a = &g_bodies[target];
+    Body *b = &g_bodies[impactor];
+
+    for (int i = 0; i < g_nbodies; i++) {
+        if (!g_bodies[i].alive || g_bodies[i].parent != impactor) continue;
+        if (target == i || body_is_descendant_of(target, i))
+            g_bodies[i].parent = body_root_star(target);
+        else
+            g_bodies[i].parent = target;
+        labels_add_body(i);
+    }
+
+    rings_on_body_absorbed(target, impactor);
+    b->alive = 0;
+    b->mass = 0.0;
+    b->trail_count = 0;
+    a->trail_interval = trail_interval_for_body_after_merge(target);
+    trails_reset_body(target);
+    labels_add_body(target);
+    labels_remove_body(impactor);
+    trails_remove_body(impactor);
+    mark_system_dirty(body_root_star(target), SYSTEM_HOT_DURATION);
+    fprintf(stdout, "[collision] %s absorbed %s (%.0f m/s, %s, %.0f->%.0f km)\n",
+            a->name, b->name, rel_speed,
+            outcome == COLLISION_VIS_MERGE ? "merge" :
+            outcome == COLLISION_VIS_MAJOR ? "major" : "crater",
+            old_radius / 1000.0, a->radius / 1000.0);
+}
+
+static void update_merge_events(double dt)
+{
+    for (int i = 0; i < MAX_MERGES; i++) {
+        MergeEvent *m = &s_merges[i];
+        Body *target, *impactor;
+        double t, overlap_sep;
+
+        if (!m->active) continue;
+        if (m->target < 0 || m->target >= g_nbodies ||
+            m->impactor < 0 || m->impactor >= g_nbodies) {
+            m->active = 0;
+            continue;
+        }
+
+        target   = &g_bodies[m->target];
+        impactor = &g_bodies[m->impactor];
+        if (!target->alive || !impactor->alive) {
+            m->active = 0;
+            continue;
+        }
+
+        m->age += dt;
+        t = m->age / m->duration;
+        if (t > 1.0) t = 1.0;
+
+        /* Lock impactor velocity to target. */
+        impactor->vel[0] = target->vel[0];
+        impactor->vel[1] = target->vel[1];
+        impactor->vel[2] = target->vel[2];
+
+        /* Both rotations snap to nearly zero in the first 15% of the merge —
+         * the deceleration should feel simultaneous with the impact. */
+        {
+            double slow = 1.0 - ease_out_cubic(fmin(1.0, t / 0.15));
+            target->rotation_rate   = m->target_rotation_rate   * slow;
+            impactor->rotation_rate = m->impactor_rotation_rate * slow;
+        }
+
+        {
+            double merge_t = 0.78 * ease_out_cubic(fmin(1.0, t / 0.30))
+                           + 0.22 * ease_out_cubic(t);
+            overlap_sep = m->start_sep + (target->radius * 0.08 - m->start_sep) * merge_t;
+        }
+        impactor->pos[0] = target->pos[0] + m->dir[0] * overlap_sep;
+        impactor->pos[1] = target->pos[1] + m->dir[1] * overlap_sep;
+        impactor->pos[2] = target->pos[2] + m->dir[2] * overlap_sep;
+
+        /* Keep the scar event frozen and growing while the merge is live. */
+        if (m->scar_slot >= 0 && m->scar_slot < MAX_IMPACTS &&
+            s_impacts[m->scar_slot].active) {
+            ImpactEvent *scar = &s_impacts[m->scar_slot];
+            double sv = collision_visual_radius(m->target, target->radius);
+            double ov = g_bodies[m->impactor].radius;
+            double d  = overlap_sep;
+            if (d < sv + ov && d > 1e-6) {
+                double cos_a = (sv*sv + d*d - ov*ov) / (2.0*sv*d);
+                if (cos_a < -1.0) cos_a = -1.0;
+                if (cos_a >  1.0) cos_a =  1.0;
+                float cap = (float)acos(cos_a);
+                if (cap > scar->radius0) {
+                    float local_dir[3];
+                    scar->radius0 = cap;
+                    scar->radius1 = cap;
+                    body_world_to_local_surface_dir(m->target, m->dir, local_dir);
+                    normalize3f(local_dir);
+                    scar->dir[0] = local_dir[0];
+                    scar->dir[1] = local_dir[1];
+                    scar->dir[2] = local_dir[2];
+                }
+            }
+            scar->age = 0.0; /* frozen at full heat until merge ends */
+        }
+
+        /* Impactor-side scar: same freeze + peak-tracking, opposite cap formula. */
+        if (m->imp_scar_slot >= 0 && m->imp_scar_slot < MAX_IMPACTS &&
+            s_impacts[m->imp_scar_slot].active) {
+            ImpactEvent *scar = &s_impacts[m->imp_scar_slot];
+            double ov = collision_visual_radius(m->impactor, g_bodies[m->impactor].radius);
+            double sv = collision_visual_radius(m->target,   target->radius);
+            double d  = overlap_sep;
+            if (d < sv + ov && d > 1e-6) {
+                double cos_a = (ov*ov + d*d - sv*sv) / (2.0*ov*d);
+                if (cos_a < -1.0) cos_a = -1.0;
+                if (cos_a >  1.0) cos_a =  1.0;
+                float cap = (float)acos(cos_a);
+                if (cap > scar->radius0) {
+                    float local_dir[3];
+                    double neg_dir[3] = {-m->dir[0], -m->dir[1], -m->dir[2]};
+                    scar->radius0 = cap;
+                    scar->radius1 = cap;
+                    body_world_to_local_surface_dir(m->impactor, neg_dir, local_dir);
+                    normalize3f(local_dir);
+                    scar->dir[0] = local_dir[0];
+                    scar->dir[1] = local_dir[1];
+                    scar->dir[2] = local_dir[2];
+                }
+            }
+            scar->age = 0.0;
+        }
+
+        /* Despawn when the impactor is fully inside the target, or time runs out. */
+        {
+            double imp_r     = g_bodies[m->impactor].radius; /* constant, no shrink */
+            double tgt_vis_r = collision_visual_radius(m->target, target->radius);
+            if (overlap_sep + imp_r <= tgt_vis_r || m->age >= m->duration) {
+                double old_radius = target->radius;
+
+                /* Release target scar: set radius1 so it expands outward while cooling. */
+                if (m->scar_slot >= 0 && m->scar_slot < MAX_IMPACTS &&
+                    s_impacts[m->scar_slot].active && s_impacts[m->scar_slot].radius0 > 0.01f) {
+                    float r0 = s_impacts[m->scar_slot].radius0;
+                    s_impacts[m->scar_slot].radius1 = fminf(r0 * 2.2f, (float)(PI * 0.88));
+                }
+
+                m->active = 0;
+                finalize_absorb_body(m->target, m->impactor, m->rel_speed,
+                                     COLLISION_VIS_MERGE, old_radius);
+            }
+        }
+    }
+}
+
+static void begin_merge_event(int target, int impactor, double rel_speed,
+                              const double dir[3], double old_radius)
+{
+    int slot = -1;
+    Body *a = &g_bodies[target];
+    Body *b = &g_bodies[impactor];
+    double total = a->mass + b->mass;
+    double merged_radius;
+
+    for (int i = 0; i < MAX_MERGES; i++) {
+        if (!s_merges[i].active) { slot = i; break; }
+    }
+    if (slot < 0) slot = 0;
+
+    if (total <= 0.0) return;
+
+    a->vel[0] = (a->vel[0] * a->mass + b->vel[0] * b->mass) / total;
+    a->vel[1] = (a->vel[1] * a->mass + b->vel[1] * b->mass) / total;
+    a->vel[2] = (a->vel[2] * a->mass + b->vel[2] * b->mass) / total;
+    merged_radius = cbrt(a->radius*a->radius*a->radius +
+                         b->radius*b->radius*b->radius);
+    if (merged_radius < old_radius) merged_radius = old_radius;
+    if (merged_radius < b->radius) merged_radius = b->radius;
+    a->mass = total;
+    a->radius = merged_radius;
+    b->mass = 0.0;
+    b->vel[0] = a->vel[0];
+    b->vel[1] = a->vel[1];
+    b->vel[2] = a->vel[2];
+
+    s_merges[slot].active    = 1;
+    s_merges[slot].target    = target;
+    s_merges[slot].impactor  = impactor;
+    s_merges[slot].age       = 0.0;
+    s_merges[slot].rel_speed = rel_speed;
+    s_merges[slot].dir[0]    = dir[0];
+    s_merges[slot].dir[1]    = dir[1];
+    s_merges[slot].dir[2]    = dir[2];
+    s_merges[slot].target_rotation_rate   = a->rotation_rate;
+    s_merges[slot].impactor_rotation_rate = b->rotation_rate;
+    s_merges[slot].scar_slot     = -1;
+    s_merges[slot].imp_scar_slot = -1;
+
+    {
+        double anim_dur = merge_duration_for_bodies(target, impactor, rel_speed);
+
+        /* Start from the actual current separation, but never further apart
+         * than just-touching. This avoids glitching when swept-sphere fires
+         * before visual contact, while still handling mid-step interpenetration. */
+        double sep_actual = sqrt((b->pos[0]-a->pos[0])*(b->pos[0]-a->pos[0]) +
+                                 (b->pos[1]-a->pos[1])*(b->pos[1]-a->pos[1]) +
+                                 (b->pos[2]-a->pos[2])*(b->pos[2]-a->pos[2]));
+        double sep_init = fmin(sep_actual, old_radius + b->radius);
+
+        s_merges[slot].duration  = anim_dur;
+        s_merges[slot].start_sep = sep_init;
+
+        start_radius_transition(target, old_radius, a->radius, anim_dur);
+        /* Impactor keeps its size throughout — no shrink transition. */
+    }
+
+    /* Allocate the intersection scar event immediately so it can be updated
+     * each frame during the merge and then cool after the merge ends. */
+    {
+        int k, scar_slot = -1;
+        float local_dir[3];
+        ImpactEvent *scar;
+        for (k = 0; k < MAX_IMPACTS; k++) {
+            if (!s_impacts[k].active) { scar_slot = k; break; }
+        }
+        if (scar_slot < 0) {
+            scar_slot = 0;
+            for (k = 1; k < MAX_IMPACTS; k++)
+                if (s_impacts[k].age > s_impacts[scar_slot].age) scar_slot = k;
+        }
+        body_world_to_local_surface_dir(target, dir, local_dir);
+        normalize3f(local_dir);
+        scar = &s_impacts[scar_slot];
+        scar->active   = 1;
+        scar->body     = target;
+        scar->kind     = COLLISION_VIS_INTERSECT;
+        scar->age      = 0.0;
+        scar->duration = MERGE_COOL_SECONDS;
+        scar->heat0    = 1.0f;
+        scar->radius0  = 0.0f;
+        scar->radius1  = 0.0f;
+        scar->dir[0]   = local_dir[0];
+        scar->dir[1]   = local_dir[1];
+        scar->dir[2]   = local_dir[2];
+        s_merges[slot].scar_slot = scar_slot;
+    }
+
+    /* Impactor-side scar: same setup, direction reversed. */
+    {
+        double neg_dir[3] = {-dir[0], -dir[1], -dir[2]};
+        int k, scar_slot = -1;
+        float local_dir[3];
+        ImpactEvent *scar;
+        for (k = 0; k < MAX_IMPACTS; k++) {
+            if (!s_impacts[k].active) { scar_slot = k; break; }
+        }
+        if (scar_slot < 0) {
+            scar_slot = 0;
+            for (k = 1; k < MAX_IMPACTS; k++)
+                if (s_impacts[k].age > s_impacts[scar_slot].age) scar_slot = k;
+        }
+        body_world_to_local_surface_dir(impactor, neg_dir, local_dir);
+        normalize3f(local_dir);
+        scar = &s_impacts[scar_slot];
+        scar->active   = 1;
+        scar->body     = impactor;
+        scar->kind     = COLLISION_VIS_INTERSECT;
+        scar->age      = 0.0;
+        scar->duration = MERGE_COOL_SECONDS;
+        scar->heat0    = 1.0f;
+        scar->radius0  = 0.0f;
+        scar->radius1  = 0.0f;
+        scar->dir[0]   = local_dir[0];
+        scar->dir[1]   = local_dir[1];
+        scar->dir[2]   = local_dir[2];
+        s_merges[slot].imp_scar_slot = scar_slot;
+    }
+}
+
 static int classify_collision(int a, int b, double rel_speed)
 {
     double m_small = g_bodies[a].mass < g_bodies[b].mass ? g_bodies[a].mass : g_bodies[b].mass;
@@ -211,8 +553,8 @@ static int classify_collision(int a, int b, double rel_speed)
     v_escape = sqrt(fmax(0.0, 2.0 * G_CONST * (g_bodies[a].mass + g_bodies[b].mass) /
                          fmax(r_sum, 1.0)));
 
-    if (mass_ratio >= 0.33 || g_bodies[a].radius >= 0.58 * g_bodies[b].radius ||
-        g_bodies[b].radius >= 0.58 * g_bodies[a].radius)
+    if (mass_ratio >= 0.45 || g_bodies[a].radius >= 0.74 * g_bodies[b].radius ||
+        g_bodies[b].radius >= 0.74 * g_bodies[a].radius)
         return COLLISION_VIS_MERGE;
     if (mass_ratio >= 0.08 || rel_speed >= v_escape * 1.35)
         return COLLISION_VIS_MAJOR;
@@ -356,7 +698,6 @@ static void absorb_body(int target, int impactor, double rel_speed, double colli
     Body *b = &g_bodies[impactor];
     double old_radius;
     double mass_ratio;
-    double merged_radius;
     double dir[3];
     int outcome;
 
@@ -365,58 +706,26 @@ static void absorb_body(int target, int impactor, double rel_speed, double colli
     old_radius = a->radius;
     mass_ratio = fmin(a->mass, b->mass) / fmax(fmax(a->mass, b->mass), 1.0);
     outcome = classify_collision(target, impactor, rel_speed);
+    impact_dir_for_pair(target, impactor, collision_dt, dir);
+    if (outcome == COLLISION_VIS_MERGE) {
+        begin_merge_event(target, impactor, rel_speed, dir, old_radius);
+        return;
+    }
+
     {
         double total = a->mass + b->mass;
     if (total <= 0.0) return;
 
-    impact_dir_for_pair(target, impactor, collision_dt, dir);
     add_impact(target, outcome, dir, b->radius, rel_speed, mass_ratio);
 
-    a->pos[0] = (a->pos[0] * a->mass + b->pos[0] * b->mass) / total;
-    a->pos[1] = (a->pos[1] * a->mass + b->pos[1] * b->mass) / total;
-    a->pos[2] = (a->pos[2] * a->mass + b->pos[2] * b->mass) / total;
     a->vel[0] = (a->vel[0] * a->mass + b->vel[0] * b->mass) / total;
     a->vel[1] = (a->vel[1] * a->mass + b->vel[1] * b->mass) / total;
     a->vel[2] = (a->vel[2] * a->mass + b->vel[2] * b->mass) / total;
-    merged_radius = cbrt(a->radius*a->radius*a->radius +
-                         b->radius*b->radius*b->radius);
-    if (merged_radius < old_radius) merged_radius = old_radius;
-    if (merged_radius < b->radius) merged_radius = b->radius;
-    a->radius = merged_radius;
+    a->radius = old_radius;
     a->mass = total;
     }
 
-    if (outcome == COLLISION_VIS_MERGE)
-        start_radius_transition(target, old_radius, a->radius, DAY * 12.0);
-    else if (outcome == COLLISION_VIS_MAJOR)
-        start_radius_transition(target, old_radius, a->radius, DAY * 5.0);
-    else if (a->radius > old_radius * 1.015)
-        start_radius_transition(target, old_radius, a->radius, DAY * 1.5);
-
-    for (int i = 0; i < g_nbodies; i++) {
-        if (!g_bodies[i].alive || g_bodies[i].parent != impactor) continue;
-        if (target == i || body_is_descendant_of(target, i))
-            g_bodies[i].parent = body_root_star(target);
-        else
-            g_bodies[i].parent = target;
-        labels_add_body(i);
-    }
-
-    rings_on_body_absorbed(target, impactor);
-    b->alive = 0;
-    b->mass = 0.0;
-    b->trail_count = 0;
-    a->trail_interval = trail_interval_for_body_after_merge(target);
-    trails_reset_body(target);
-    labels_add_body(target);
-    labels_remove_body(impactor);
-    trails_remove_body(impactor);
-    mark_system_dirty(body_root_star(target), SYSTEM_HOT_DURATION);
-    fprintf(stdout, "[collision] %s absorbed %s (%.0f m/s, %s, %.0f->%.0f km)\n",
-            a->name, b->name, rel_speed,
-            outcome == COLLISION_VIS_MERGE ? "merge" :
-            outcome == COLLISION_VIS_MAJOR ? "major" : "crater",
-            old_radius / 1000.0, a->radius / 1000.0);
+    finalize_absorb_body(target, impactor, rel_speed, outcome, old_radius);
 }
 
 void collision_step(double dt)
@@ -427,6 +736,8 @@ void collision_step(double dt)
     int members[MAX_BODIES][MAX_BODIES];
     int member_count[MAX_BODIES] = {0};
     int any_dirty = 0;
+
+    update_merge_events(dt);
 
     for (int i = 0; i < MAX_IMPACTS; i++) {
         if (!s_impacts[i].active) continue;
@@ -490,14 +801,14 @@ void collision_step(double dt)
         int root_had_collision = 0;
         for (int ai = 0; ai < n && !root_had_collision; ai++) {
             int a = members[root][ai];
-            if (!g_bodies[a].alive || g_bodies[a].is_star || resolved[a]) continue;
+            if (!g_bodies[a].alive || g_bodies[a].is_star || resolved[a] || body_is_in_merge(a)) continue;
             for (int bi = ai + 1; bi < n; bi++) {
                 int b = members[root][bi];
                 int lo = a < b ? a : b;
                 int hi = a < b ? b : a;
                 double speed = 0.0;
 
-                if (!g_bodies[b].alive || g_bodies[b].is_star || resolved[b]) continue;
+                if (!g_bodies[b].alive || g_bodies[b].is_star || resolved[b] || body_is_in_merge(b)) continue;
                 if (!systems_may_interact(root_of[a], root_of[b], system_radius)) continue;
 
                 if (s_system_hot[root] > 0.0) {
@@ -548,7 +859,18 @@ int collision_spots_for_body(int body_idx, CollisionSpot spots[COLLISION_MAX_SPO
             heat_curve = pow(1.0 - t, 1.45);
         else if (e->kind == COLLISION_VIS_CRATER)
             heat_curve = pow(1.0 - t, 2.35);
-        rad = e->radius0 + (e->radius1 - e->radius0) * ease_out_cubic(t);
+        {
+            double spread_t;
+            if (e->kind == COLLISION_VIS_MERGE)
+                spread_t = fast_then_slow_spread(t, 0.09);
+            else if (e->kind == COLLISION_VIS_INTERSECT)
+                spread_t = fast_then_slow_spread(t, 0.07);
+            else if (e->kind == COLLISION_VIS_MAJOR)
+                spread_t = fast_then_slow_spread(t, 0.14);
+            else
+                spread_t = fast_then_slow_spread(t, 0.18);
+            rad = e->radius0 + (e->radius1 - e->radius0) * ease_out_cubic(spread_t);
+        }
         {
         float heat = e->heat0 * (float)heat_curve;
         if (heat <= 0.01f) continue;
@@ -562,10 +884,74 @@ int collision_spots_for_body(int body_idx, CollisionSpot spots[COLLISION_MAX_SPO
         n++;
         }
     }
+
+    /* The intersection boundary scar on the target is handled as an ImpactEvent
+     * (COLLISION_VIS_INTERSECT kind) that is updated each physics step while
+     * the merge is active.  No separate per-frame recomputation needed here. */
+
     return n;
 }
 
 double collision_visual_radius(int body_idx, double physical_radius)
 {
     return current_visual_radius(body_idx, physical_radius);
+}
+
+void collision_body_heat_glow(int body_idx, float out_color[3],
+                              float *out_intensity, float *out_scale)
+{
+    float best_heat = 0.0f;
+    int has_merge = 0;
+
+    if (out_color) {
+        out_color[0] = 0.0f;
+        out_color[1] = 0.0f;
+        out_color[2] = 0.0f;
+    }
+    if (out_intensity) *out_intensity = 0.0f;
+    if (out_scale) *out_scale = 1.0f;
+    if (body_idx < 0 || body_idx >= g_nbodies) return;
+
+    for (int i = 0; i < MAX_IMPACTS; i++) {
+        ImpactEvent *e = &s_impacts[i];
+        double t, heat_curve;
+        float heat;
+
+        if (!e->active || e->body != body_idx) continue;
+        t = e->age / e->duration;
+        if (t < 0.0) t = 0.0;
+        if (t > 1.0) t = 1.0;
+        heat_curve = (1.0 - t) * (1.0 - t);
+        if (e->kind == COLLISION_VIS_MERGE)
+            heat_curve = pow(1.0 - t, 1.45);
+        else if (e->kind == COLLISION_VIS_CRATER)
+            heat_curve = pow(1.0 - t, 2.35);
+        heat = e->heat0 * (float)heat_curve;
+        if (heat > best_heat) best_heat = heat;
+        if (e->kind == COLLISION_VIS_MERGE || e->kind == COLLISION_VIS_INTERSECT)
+            has_merge = 1;
+    }
+
+    if (best_heat <= 0.01f) return;
+    best_heat = (best_heat - 0.01f) / 0.99f;
+    if (best_heat < 0.0f) best_heat = 0.0f;
+    if (best_heat > 1.0f) best_heat = 1.0f;
+    best_heat = best_heat * best_heat * (3.0f - 2.0f * best_heat);
+
+    if (out_color) {
+        out_color[0] = 0.90f;
+        out_color[1] = has_merge ? 0.34f : 0.26f;
+        out_color[2] = 0.08f;
+    }
+    if (out_intensity)
+        *out_intensity = best_heat * (has_merge ? 0.42f : 0.24f);
+    if (out_scale)
+        *out_scale = has_merge ? (1.12f + best_heat * 0.24f)
+                               : (1.05f + best_heat * 0.10f);
+}
+
+int collision_body_has_active_merge(int body_idx)
+{
+    if (body_idx < 0 || body_idx >= g_nbodies) return 0;
+    return body_is_in_merge(body_idx);
 }

--- a/src/collision.c
+++ b/src/collision.c
@@ -226,6 +226,87 @@ int collision_system_maybe_has_encounter(int root, double dt)
     return 0;
 }
 
+/* Returns a power-of-2 subdivision factor for the outer timestep.
+ * Checks time-to-closest-approach (tau) for all approaching primary pairs
+ * and for bodies approaching the star.  When tau falls below 8×dt_outer the
+ * integrator would take too coarse a step through the encounter curvature, so
+ * we request more, smaller steps:
+ *   tau > 8×dt  → 1   (no change)
+ *   tau > 4×dt  → 2
+ *   tau > 2×dt  → 4
+ *   tau ≤ 2×dt  → 8
+ */
+int collision_system_close_approach_subdivide(int root, double dt_outer)
+{
+    if (root < 0 || root >= g_nbodies || !g_bodies[root].alive) return 1;
+    if (dt_outer <= 0.0) return 1;
+
+    double min_tau = 1e30;
+
+    /* Primary–primary pairs */
+    for (int i = 0; i < g_nbodies; i++) {
+        if (!body_is_primary(i)) continue;
+        if (body_root_star(i) != root) continue;
+        for (int j = i + 1; j < g_nbodies; j++) {
+            if (!body_is_primary(j)) continue;
+            if (body_root_star(j) != root) continue;
+            if (body_is_merge_impactor(i) || body_is_merge_impactor(j)) continue;
+
+            double rx = g_bodies[j].pos[0] - g_bodies[i].pos[0];
+            double ry = g_bodies[j].pos[1] - g_bodies[i].pos[1];
+            double rz = g_bodies[j].pos[2] - g_bodies[i].pos[2];
+            double dist = sqrt(rx*rx + ry*ry + rz*rz);
+            if (dist <= 1e-9) return 8;
+
+            double vx = g_bodies[j].vel[0] - g_bodies[i].vel[0];
+            double vy = g_bodies[j].vel[1] - g_bodies[i].vel[1];
+            double vz = g_bodies[j].vel[2] - g_bodies[i].vel[2];
+            double vr = -(rx*vx + ry*vy + rz*vz) / dist; /* positive = approaching */
+            if (vr < 10.0) continue;
+
+            double rsum = current_contact_radius(i) + current_contact_radius(j);
+            double gap = dist - rsum;
+            if (gap <= 0.0) return 8;
+
+            double tau = gap / vr;
+            if (tau < min_tau) min_tau = tau;
+        }
+    }
+
+    /* Body approaching the star */
+    if (g_bodies[root].is_star) {
+        for (int i = 0; i < g_nbodies; i++) {
+            if (i == root) continue;
+            if (!g_bodies[i].alive || g_bodies[i].is_star) continue;
+            if (body_root_star(i) != root) continue;
+            if (body_is_in_merge(i)) continue;
+
+            double rx = g_bodies[i].pos[0] - g_bodies[root].pos[0];
+            double ry = g_bodies[i].pos[1] - g_bodies[root].pos[1];
+            double rz = g_bodies[i].pos[2] - g_bodies[root].pos[2];
+            double dist = sqrt(rx*rx + ry*ry + rz*rz);
+            if (dist <= 1e-9) return 8;
+
+            double vx = g_bodies[i].vel[0] - g_bodies[root].vel[0];
+            double vy = g_bodies[i].vel[1] - g_bodies[root].vel[1];
+            double vz = g_bodies[i].vel[2] - g_bodies[root].vel[2];
+            double vr = -(rx*vx + ry*vy + rz*vz) / dist;
+            if (vr < 10.0) continue;
+
+            double gap = dist - (g_bodies[root].radius + current_contact_radius(i));
+            if (gap <= 0.0) return 8;
+
+            double tau = gap / vr;
+            if (tau < min_tau) min_tau = tau;
+        }
+    }
+
+    if (min_tau > 8.0 * dt_outer) return 1;
+    if (min_tau > 4.0 * dt_outer) return 2;
+    if (min_tau > 2.0 * dt_outer) return 4;
+    return 8;
+}
+
 /* ── § MATH — geometry helpers, body surface transforms, spin physics ── */
 
 static int body_is_descendant_of(int body_idx, int ancestor_idx)

--- a/src/collision.c
+++ b/src/collision.c
@@ -891,30 +891,6 @@ static void add_permanent_crater(int body_idx, const double world_dir[3],
 
 /* ── § MERGE — merge lifecycle: begin → update → finalize ────────────── */
 
-static double trail_interval_for_body_after_merge(int body_idx)
-{
-    Body *b;
-    double dx, dy, dz, r, gm, T, interval;
-
-    if (body_idx < 0 || body_idx >= g_nbodies) return DAY;
-    b = &g_bodies[body_idx];
-    if (b->is_star) return DAY * 25.0;
-    if (b->parent < 0 || b->parent >= g_nbodies || !g_bodies[b->parent].alive)
-        return DAY;
-
-    dx = b->pos[0] - g_bodies[b->parent].pos[0];
-    dy = b->pos[1] - g_bodies[b->parent].pos[1];
-    dz = b->pos[2] - g_bodies[b->parent].pos[2];
-    r = sqrt(dx*dx + dy*dy + dz*dz);
-    gm = G_CONST * g_bodies[b->parent].mass;
-    if (r <= 0.0 || gm <= 0.0) return DAY;
-
-    T = 2.0 * PI * sqrt(r * r * r / gm);
-    interval = T / 400.0;
-    if (interval < 60.0) interval = 60.0;
-    return interval;
-}
-
 static double merge_duration_for_bodies(int target, int impactor, double rel_speed)
 {
     double radius_scale;
@@ -962,16 +938,9 @@ static void finalize_absorb_body(int target, int impactor, double rel_speed,
     }
 
     rings_on_body_absorbed(target, impactor);
-    if (b->trail && b->trail_count > 0) {
-        b->trail[b->trail_head][0] = b->pos[0] * RS;
-        b->trail[b->trail_head][1] = b->pos[1] * RS;
-        b->trail[b->trail_head][2] = b->pos[2] * RS;
-        b->trail_head = (b->trail_head + 1) % TRAIL_LEN;
-        if (b->trail_count < TRAIL_LEN) b->trail_count++;
-    }
     b->alive = 0;
     b->mass = 0.0;
-    a->trail_interval = trail_interval_for_body_after_merge(target);
+    a->trail_emitting = 1;
     labels_add_body(target);
     labels_remove_body(impactor);
     mark_system_dirty(body_root_star(target), SYSTEM_HOT_DURATION);
@@ -1220,6 +1189,7 @@ static void begin_merge_event(int target, int impactor, double rel_speed,
     Body *b = &g_bodies[impactor];
     double total = a->mass + b->mass;
     double merged_radius;
+    double touch_pos[3];
     float local_dir[3], local_t1[3];
 
     for (int i = 0; i < MAX_MERGES; i++) {
@@ -1228,13 +1198,20 @@ static void begin_merge_event(int target, int impactor, double rel_speed,
     if (slot < 0) slot = 0;
 
     if (b->trail && b->trail_count > 0) {
-        b->trail[b->trail_head][0] = b->pos[0] * RS;
-        b->trail[b->trail_head][1] = b->pos[1] * RS;
-        b->trail[b->trail_head][2] = b->pos[2] * RS;
+        touch_pos[0] = a->pos[0] + dir[0] * (old_radius + b->radius);
+        touch_pos[1] = a->pos[1] + dir[1] * (old_radius + b->radius);
+        touch_pos[2] = a->pos[2] + dir[2] * (old_radius + b->radius);
+        b->trail[b->trail_head][0] = touch_pos[0] * RS;
+        b->trail[b->trail_head][1] = touch_pos[1] * RS;
+        b->trail[b->trail_head][2] = touch_pos[2] * RS;
         b->trail_head = (b->trail_head + 1) % TRAIL_LEN;
         if (b->trail_count < TRAIL_LEN) b->trail_count++;
+        b->trail_prev_pos[0] = touch_pos[0];
+        b->trail_prev_pos[1] = touch_pos[1];
+        b->trail_prev_pos[2] = touch_pos[2];
     }
-    b->trail_interval = 0.0;
+    b->trail_emitting = 0;
+    b->trail_accum = 0.0;
 
 
     if (total <= 0.0) return;

--- a/src/collision.c
+++ b/src/collision.c
@@ -122,6 +122,7 @@ static int s_pos_before_valid = 0;
 static int body_is_merge_target(int idx);
 static int body_is_merge_impactor(int idx);
 static double current_contact_radius(int body_idx);
+static int body_is_primary(int idx);
 
 static void mark_system_dirty(int root, double hot_duration)
 {
@@ -153,11 +154,11 @@ int collision_system_maybe_has_encounter(int root, double dt)
     if (dt <= 0.0) return 0;
 
     for (int i = 0; i < g_nbodies; i++) {
-        if (!g_bodies[i].alive || g_bodies[i].is_star) continue;
+        if (!body_is_primary(i)) continue;
         if (body_root_star(i) != root) continue;
         for (int j = i + 1; j < g_nbodies; j++) {
             double rx, ry, rz, dist, vx, vy, vz, vr, rsum, gap;
-            if (!g_bodies[j].alive || g_bodies[j].is_star) continue;
+            if (!body_is_primary(j)) continue;
             if (body_root_star(j) != root) continue;
             if (body_is_merge_impactor(i) || body_is_merge_impactor(j)) continue;
 
@@ -174,10 +175,10 @@ int collision_system_maybe_has_encounter(int root, double dt)
             rsum = current_contact_radius(i) + current_contact_radius(j);
             gap = dist - rsum;
 
-            if (gap <= rsum * 6.0) return 1;
-            if (vr > 0.0) {
+            if (gap <= rsum * 3.0) return 1;
+            if (vr > 10.0) {
                 double tau = gap / vr;
-                if (tau <= dt * 2.0) return 1;
+                if (tau <= dt) return 1;
             }
         }
     }
@@ -198,6 +199,13 @@ static int body_is_satellite(int idx)
 {
     if (idx < 0 || idx >= g_nbodies || !g_bodies[idx].alive) return 0;
     return g_bodies[idx].parent >= 0 && !g_bodies[g_bodies[idx].parent].is_star;
+}
+
+static int body_is_primary(int idx)
+{
+    if (idx < 0 || idx >= g_nbodies || !g_bodies[idx].alive) return 0;
+    if (g_bodies[idx].is_star) return 0;
+    return !body_is_satellite(idx);
 }
 
 static int bodies_are_in_ancestor_chain(int a, int b)
@@ -1667,7 +1675,7 @@ void collision_step_system(int root, double dt)
 
     for (int ai = 0; ai < g_nbodies; ai++) {
         int a = ai;
-        if (!g_bodies[a].alive || g_bodies[a].is_star || resolved[a] ||
+        if (!body_is_primary(a) || resolved[a] ||
             body_is_merge_impactor(a) || body_root_star(a) != root)
             continue;
 
@@ -1678,7 +1686,7 @@ void collision_step_system(int root, double dt)
             int target, impactor;
             int a_is_merge_target, b_is_merge_target, keep_target_open;
 
-            if (!g_bodies[b].alive || g_bodies[b].is_star || resolved[b] ||
+            if (!body_is_primary(b) || resolved[b] ||
                 body_is_merge_impactor(b) || body_root_star(b) != root)
                 continue;
 

--- a/src/collision.c
+++ b/src/collision.c
@@ -41,6 +41,7 @@
 #define MAX_MERGES 16
 #define MAX_PERSISTENT_SCARS 128
 #define MAX_COLLISION_PARTICLES 768
+#define STAR_HEAT_START_SCALE 4.0
 
 typedef struct {
     int active;
@@ -121,8 +122,12 @@ static int s_pos_before_valid = 0;
 
 static int body_is_merge_target(int idx);
 static int body_is_merge_impactor(int idx);
+static int body_is_in_merge(int idx);
 static double current_contact_radius(int body_idx);
 static int body_is_primary(int idx);
+static void impact_dir_for_pair(int target, int impactor, double dt, double out_dir[3]);
+static int swept_spheres_collide(int a, int b, double dt,
+                                 double *out_speed, double *out_hit_t);
 
 static void mark_system_dirty(int root, double hot_duration)
 {
@@ -196,6 +201,26 @@ int collision_system_maybe_has_encounter(int root, double dt)
                 double tau = gap / vr;
                 if (tau <= dt) return 1;
             }
+        }
+    }
+
+    if (g_bodies[root].is_star) {
+        for (int i = 0; i < g_nbodies; i++) {
+            double rx, ry, rz, dist, glow_dist;
+            if (i == root) continue;
+            if (!g_bodies[i].alive || g_bodies[i].is_star) continue;
+            if (body_root_star(i) != root) continue;
+            if (body_is_in_merge(i)) continue;
+
+            rx = g_bodies[i].pos[0] - g_bodies[root].pos[0];
+            ry = g_bodies[i].pos[1] - g_bodies[root].pos[1];
+            rz = g_bodies[i].pos[2] - g_bodies[root].pos[2];
+            dist = sqrt(rx*rx + ry*ry + rz*rz);
+            glow_dist = g_bodies[root].radius * STAR_HEAT_START_SCALE
+                      + current_contact_radius(i);
+
+            if (dist <= glow_dist) return 1;
+            if (swept_spheres_collide(root, i, dt, NULL, NULL)) return 1;
         }
     }
     return 0;
@@ -590,6 +615,62 @@ static double current_contact_radius(int body_idx)
 {
     if (body_idx < 0 || body_idx >= g_nbodies) return 0.0;
     return current_visual_radius(body_idx, g_bodies[body_idx].radius);
+}
+
+static int nearest_star_to_body(int body_idx)
+{
+    int best = -1;
+    double best_d2 = 1e300;
+
+    if (body_idx < 0 || body_idx >= g_nbodies) return -1;
+    for (int i = 0; i < g_nbodies; i++) {
+        double dx, dy, dz, d2;
+        if (i == body_idx) continue;
+        if (!g_bodies[i].alive || !g_bodies[i].is_star) continue;
+
+        dx = g_bodies[i].pos[0] - g_bodies[body_idx].pos[0];
+        dy = g_bodies[i].pos[1] - g_bodies[body_idx].pos[1];
+        dz = g_bodies[i].pos[2] - g_bodies[body_idx].pos[2];
+        d2 = dx*dx + dy*dy + dz*dz;
+        if (d2 < best_d2) {
+            best_d2 = d2;
+            best = i;
+        }
+    }
+
+    return best;
+}
+
+static double star_heat_factor_for_body(int body_idx, int *out_star_idx)
+{
+    int star_idx;
+    double dx, dy, dz, dist;
+    double crash_dist, heat_start, t;
+
+    if (out_star_idx) *out_star_idx = -1;
+    if (body_idx < 0 || body_idx >= g_nbodies) return 0.0;
+    if (!g_bodies[body_idx].alive || g_bodies[body_idx].is_star) return 0.0;
+
+    star_idx = nearest_star_to_body(body_idx);
+    if (star_idx < 0) return 0.0;
+
+    dx = g_bodies[star_idx].pos[0] - g_bodies[body_idx].pos[0];
+    dy = g_bodies[star_idx].pos[1] - g_bodies[body_idx].pos[1];
+    dz = g_bodies[star_idx].pos[2] - g_bodies[body_idx].pos[2];
+    dist = sqrt(dx*dx + dy*dy + dz*dz);
+    crash_dist = g_bodies[star_idx].radius + current_contact_radius(body_idx);
+    heat_start = g_bodies[star_idx].radius * STAR_HEAT_START_SCALE
+               + current_contact_radius(body_idx);
+
+    if (out_star_idx) *out_star_idx = star_idx;
+    if (dist >= heat_start) return 0.0;
+    if (dist <= crash_dist) return 1.0;
+    if (heat_start <= crash_dist + 1.0) return 1.0;
+
+    t = (heat_start - dist) / (heat_start - crash_dist);
+    if (t < 0.0) t = 0.0;
+    if (t > 1.0) t = 1.0;
+    return t * t * (3.0 - 2.0 * t);
 }
 
 /* ── § PARTICLES — intersection ring geometry, particle spawning ─────── */
@@ -1004,6 +1085,7 @@ static void finalize_absorb_body(int target, int impactor, double rel_speed,
 {
     Body *a = &g_bodies[target];
     Body *b = &g_bodies[impactor];
+    const char *outcome_name = "absorb";
 
     for (int i = 0; i < g_nbodies; i++) {
         if (!g_bodies[i].alive || g_bodies[i].parent != impactor) continue;
@@ -1021,11 +1103,48 @@ static void finalize_absorb_body(int target, int impactor, double rel_speed,
     labels_add_body(target);
     labels_remove_body(impactor);
     mark_system_dirty(body_root_star(target), SYSTEM_HOT_DURATION);
+    if (outcome == COLLISION_VIS_MERGE) outcome_name = "merge";
+    else if (outcome == COLLISION_VIS_MAJOR) outcome_name = "major";
+    else if (outcome == COLLISION_VIS_CRATER) outcome_name = "crater";
     fprintf(stderr, "[collision] %s absorbed %s (%.0f m/s, %s, %.0f->%.0f km)\n",
-            a->name, b->name, rel_speed,
-            outcome == COLLISION_VIS_MERGE ? "merge" :
-            outcome == COLLISION_VIS_MAJOR ? "major" : "crater",
+            a->name, b->name, rel_speed, outcome_name,
             old_radius / 1000.0, a->radius / 1000.0);
+}
+
+static void absorb_body_into_star(int star_idx, int body_idx, double rel_speed,
+                                  double collision_dt, double frame_dt)
+{
+    Body *star = &g_bodies[star_idx];
+    Body *body = &g_bodies[body_idx];
+    double old_radius;
+    double dir[3];
+    double touch_pos[3];
+    double total;
+
+    if (!star->alive || !body->alive) return;
+    if (!star->is_star || body->is_star) return;
+    if (body_is_in_merge(body_idx)) return;
+
+    old_radius = star->radius;
+    impact_dir_for_pair(star_idx, body_idx, collision_dt, dir);
+    touch_pos[0] = star->pos[0] + dir[0] * (old_radius + body->radius);
+    touch_pos[1] = star->pos[1] + dir[1] * (old_radius + body->radius);
+    touch_pos[2] = star->pos[2] + dir[2] * (old_radius + body->radius);
+
+    if (body->trail)
+        trails_cut_body_at_time(body_idx, collision_dt, frame_dt, touch_pos);
+    body->trail_emitting = 0;
+    body->trail_accum = 0.0;
+
+    total = star->mass + body->mass;
+    if (total > 0.0) {
+        star->vel[0] = (star->vel[0] * star->mass + body->vel[0] * body->mass) / total;
+        star->vel[1] = (star->vel[1] * star->mass + body->vel[1] * body->mass) / total;
+        star->vel[2] = (star->vel[2] * star->mass + body->vel[2] * body->mass) / total;
+        star->mass = total;
+    }
+
+    finalize_absorb_body(star_idx, body_idx, rel_speed, 0, old_radius);
 }
 
 static void update_merge_events(double dt)
@@ -1726,6 +1845,23 @@ void collision_step_system(int root, double dt)
             if (impactor == a) break;
         }
     }
+
+    if (g_bodies[root].is_star) {
+        for (int i = 0; i < g_nbodies; i++) {
+            double speed = 0.0;
+            double hit_t = 0.0;
+
+            if (i == root) continue;
+            if (!g_bodies[i].alive || g_bodies[i].is_star) continue;
+            if (resolved[i] || body_root_star(i) != root) continue;
+            if (body_is_in_merge(i)) continue;
+            if (!swept_spheres_collide(root, i, dt, &speed, &hit_t))
+                continue;
+
+            absorb_body_into_star(root, i, speed, hit_t, dt);
+            resolved[i] = 1;
+        }
+    }
 }
 
 void collision_step(double dt)
@@ -1991,6 +2127,15 @@ void collision_body_heat_glow(int body_idx, float out_color[3],
     float best_heat = 0.0f;
     int has_merge = 0;
     double merge_growth = active_merge_glow_progress(body_idx);
+    float impact_color[3] = {0.0f, 0.0f, 0.0f};
+    float impact_intensity = 0.0f;
+    float impact_scale = 1.0f;
+    float star_color[3] = {0.0f, 0.0f, 0.0f};
+    float star_intensity = 0.0f;
+    float star_scale = 1.0f;
+    float sum_w;
+    int star_idx = -1;
+    double star_heat;
 
     if (out_color) {
         out_color[0] = 0.0f;
@@ -2017,23 +2162,52 @@ void collision_body_heat_glow(int body_idx, float out_color[3],
             has_merge = 1;
     }
 
-    if (best_heat <= 0.01f) return;
-    best_heat = (best_heat - 0.01f) / 0.99f;
-    if (best_heat < 0.0f) best_heat = 0.0f;
-    if (best_heat > 1.0f) best_heat = 1.0f;
-    best_heat = best_heat * best_heat * (3.0f - 2.0f * best_heat);
-    if (merge_growth > 0.0) best_heat *= (float)merge_growth;
+    if (best_heat > 0.01f) {
+        best_heat = (best_heat - 0.01f) / 0.99f;
+        if (best_heat < 0.0f) best_heat = 0.0f;
+        if (best_heat > 1.0f) best_heat = 1.0f;
+        best_heat = best_heat * best_heat * (3.0f - 2.0f * best_heat);
+        if (merge_growth > 0.0) best_heat *= (float)merge_growth;
 
+        impact_color[0] = 0.90f;
+        impact_color[1] = has_merge ? 0.34f : 0.26f;
+        impact_color[2] = 0.08f;
+        impact_intensity = best_heat * (has_merge ? 0.42f : 0.24f);
+        impact_scale = has_merge ? (1.12f + best_heat * 0.24f)
+                                 : (1.05f + best_heat * 0.10f);
+    }
+
+    star_heat = star_heat_factor_for_body(body_idx, &star_idx);
+    if (star_heat > 0.0 && star_idx >= 0) {
+        float t = (float)star_heat;
+        star_color[0] = 1.00f;
+        star_color[1] = 0.22f + 0.18f * g_bodies[star_idx].col[1];
+        star_color[2] = 0.05f + 0.06f * g_bodies[star_idx].col[2];
+        star_intensity = 0.14f + powf(t, 1.6f) * 0.95f;
+        star_scale = 1.08f + t * 0.34f;
+    }
+
+    if (impact_intensity <= 0.0f && star_intensity <= 0.0f) return;
+
+    sum_w = impact_intensity + star_intensity;
+    if (sum_w <= 1e-6f) sum_w = 1.0f;
     if (out_color) {
-        out_color[0] = 0.90f;
-        out_color[1] = has_merge ? 0.34f : 0.26f;
-        out_color[2] = 0.08f;
+        out_color[0] = (impact_color[0] * impact_intensity + star_color[0] * star_intensity) / sum_w;
+        out_color[1] = (impact_color[1] * impact_intensity + star_color[1] * star_intensity) / sum_w;
+        out_color[2] = (impact_color[2] * impact_intensity + star_color[2] * star_intensity) / sum_w;
     }
     if (out_intensity)
-        *out_intensity = best_heat * (has_merge ? 0.42f : 0.24f);
+        *out_intensity = impact_intensity + star_intensity;
     if (out_scale)
-        *out_scale = has_merge ? (1.12f + best_heat * 0.24f)
-                               : (1.05f + best_heat * 0.10f);
+        *out_scale = impact_scale > star_scale ? impact_scale : star_scale;
+}
+
+float collision_body_star_heat(int body_idx)
+{
+    double heat = star_heat_factor_for_body(body_idx, NULL);
+    if (heat < 0.0) heat = 0.0;
+    if (heat > 1.0) heat = 1.0;
+    return (float)heat;
 }
 
 int collision_body_has_active_merge(int body_idx)

--- a/src/collision.c
+++ b/src/collision.c
@@ -18,6 +18,7 @@
 #include "collision.h"
 #include "body.h"
 #include "labels.h"
+#include "physics.h"
 #include "rings.h"
 #include "trails.h"
 #include <math.h>
@@ -118,6 +119,10 @@ static unsigned int s_perm_scar_stamp = 1u;
 static double s_pos_before[MAX_BODIES][3];
 static int s_pos_before_valid = 0;
 
+static int body_is_merge_target(int idx);
+static int body_is_merge_impactor(int idx);
+static double current_contact_radius(int body_idx);
+
 static void mark_system_dirty(int root, double hot_duration)
 {
     if (root < 0 || root >= MAX_BODIES) return;
@@ -142,6 +147,43 @@ void collision_on_body_added(int body_idx)
     if (root >= 0) mark_system_dirty(root, SYSTEM_HOT_DURATION);
 }
 
+int collision_system_maybe_has_encounter(int root, double dt)
+{
+    if (root < 0 || root >= g_nbodies || !g_bodies[root].alive) return 0;
+    if (dt <= 0.0) return 0;
+
+    for (int i = 0; i < g_nbodies; i++) {
+        if (!g_bodies[i].alive || g_bodies[i].is_star) continue;
+        if (body_root_star(i) != root) continue;
+        for (int j = i + 1; j < g_nbodies; j++) {
+            double rx, ry, rz, dist, vx, vy, vz, vr, rsum, gap;
+            if (!g_bodies[j].alive || g_bodies[j].is_star) continue;
+            if (body_root_star(j) != root) continue;
+            if (body_is_merge_impactor(i) || body_is_merge_impactor(j)) continue;
+
+            rx = g_bodies[j].pos[0] - g_bodies[i].pos[0];
+            ry = g_bodies[j].pos[1] - g_bodies[i].pos[1];
+            rz = g_bodies[j].pos[2] - g_bodies[i].pos[2];
+            dist = sqrt(rx*rx + ry*ry + rz*rz);
+            if (dist <= 1e-9) return 1;
+
+            vx = g_bodies[j].vel[0] - g_bodies[i].vel[0];
+            vy = g_bodies[j].vel[1] - g_bodies[i].vel[1];
+            vz = g_bodies[j].vel[2] - g_bodies[i].vel[2];
+            vr = -(rx*vx + ry*vy + rz*vz) / dist;
+            rsum = current_contact_radius(i) + current_contact_radius(j);
+            gap = dist - rsum;
+
+            if (gap <= rsum * 6.0) return 1;
+            if (vr > 0.0) {
+                double tau = gap / vr;
+                if (tau <= dt * 2.0) return 1;
+            }
+        }
+    }
+    return 0;
+}
+
 /* ── § MATH — geometry helpers, body surface transforms, spin physics ── */
 
 static int body_is_descendant_of(int body_idx, int ancestor_idx)
@@ -150,6 +192,17 @@ static int body_is_descendant_of(int body_idx, int ancestor_idx)
     for (int p = g_bodies[body_idx].parent; p >= 0; p = g_bodies[p].parent)
         if (p == ancestor_idx) return 1;
     return 0;
+}
+
+static int body_is_satellite(int idx)
+{
+    if (idx < 0 || idx >= g_nbodies || !g_bodies[idx].alive) return 0;
+    return g_bodies[idx].parent >= 0 && !g_bodies[g_bodies[idx].parent].is_star;
+}
+
+static int bodies_are_in_ancestor_chain(int a, int b)
+{
+    return body_is_descendant_of(a, b) || body_is_descendant_of(b, a);
 }
 
 static double dot3d(const double a[3], const double b[3])
@@ -1182,7 +1235,8 @@ static void update_merge_events(double dt)
 
 static void begin_merge_event(int target, int impactor, double rel_speed,
                               const double dir[3], const double rel_vel[3],
-                              double old_radius)
+                              double old_radius, double collision_dt,
+                              double frame_dt)
 {
     int slot = -1;
     Body *a = &g_bodies[target];
@@ -1201,14 +1255,7 @@ static void begin_merge_event(int target, int impactor, double rel_speed,
         touch_pos[0] = a->pos[0] + dir[0] * (old_radius + b->radius);
         touch_pos[1] = a->pos[1] + dir[1] * (old_radius + b->radius);
         touch_pos[2] = a->pos[2] + dir[2] * (old_radius + b->radius);
-        b->trail[b->trail_head][0] = touch_pos[0] * RS;
-        b->trail[b->trail_head][1] = touch_pos[1] * RS;
-        b->trail[b->trail_head][2] = touch_pos[2] * RS;
-        b->trail_head = (b->trail_head + 1) % TRAIL_LEN;
-        if (b->trail_count < TRAIL_LEN) b->trail_count++;
-        b->trail_prev_pos[0] = touch_pos[0];
-        b->trail_prev_pos[1] = touch_pos[1];
-        b->trail_prev_pos[2] = touch_pos[2];
+        trails_cut_body_at_time(impactor, collision_dt, frame_dt, touch_pos);
     }
     b->trail_emitting = 0;
     b->trail_accum = 0.0;
@@ -1425,7 +1472,8 @@ static double pair_check_dt(int a, int b)
     }
 }
 
-static int swept_spheres_collide(int a, int b, double dt, double *out_speed)
+static int swept_spheres_collide(int a, int b, double dt, double *out_speed,
+                                 double *out_hit_t)
 {
     double rel_now[3] = {
         g_bodies[b].pos[0] - g_bodies[a].pos[0],
@@ -1461,6 +1509,40 @@ static int swept_spheres_collide(int a, int b, double dt, double *out_speed)
         double t = 0.0;
         double c[3];
         double r = current_contact_radius(a) + current_contact_radius(b);
+        double dist_now2 = dot3d(rel_now, rel_now);
+        double dist_prev2 = dot3d(rel_p, rel_p);
+        int satellite_pair = body_is_satellite(a) || body_is_satellite(b);
+
+        /* Parent/satellite chains move on curved, mostly tangential paths.
+         * Sweeping a single straight segment across a long frame can cut
+         * through the parent even when the true orbit never comes close.
+         * Only allow swept collision on these pairs once one endpoint is
+         * already near the contact radius. */
+        if (bodies_are_in_ancestor_chain(a, b)) {
+            double near_limit = r * 1.25;
+            double near_limit2 = near_limit * near_limit;
+            if (dist_now2 > near_limit2 && dist_prev2 > near_limit2) {
+                if (out_speed) *out_speed = sqrt(vv);
+                if (out_hit_t) *out_hit_t = 0.0;
+                return 0;
+            }
+        }
+
+        /* The same straight-line sweep also over-reports moon-related impacts
+         * between siblings or nearby satellites when a long frame spans a
+         * large orbital arc. For any pair involving a satellite, require at
+         * least one endpoint to already be reasonably close before we trust
+         * the swept test. */
+        if (satellite_pair) {
+            double near_limit = r * 2.0;
+            double near_limit2 = near_limit * near_limit;
+            if (dist_now2 > near_limit2 && dist_prev2 > near_limit2) {
+                if (out_speed) *out_speed = sqrt(vv);
+                if (out_hit_t) *out_hit_t = 0.0;
+                return 0;
+            }
+        }
+
         if (vv > MIN_COLLISION_SPEED * MIN_COLLISION_SPEED) {
             t = -dot3d(rel_p, rel_v) / vv;
             if (t < 0.0) t = 0.0;
@@ -1470,6 +1552,7 @@ static int swept_spheres_collide(int a, int b, double dt, double *out_speed)
         c[1] = rel_p[1] + rel_v[1] * t;
         c[2] = rel_p[2] + rel_v[2] * t;
         if (out_speed) *out_speed = sqrt(vv);
+        if (out_hit_t) *out_hit_t = t;
         return dot3d(c, c) <= r*r;
     }
 }
@@ -1524,7 +1607,8 @@ static void impact_dir_for_pair(int target, int impactor, double dt, double out_
     out_dir[2] = c[2] / len;
 }
 
-static void absorb_body(int target, int impactor, double rel_speed, double collision_dt)
+static void absorb_body(int target, int impactor, double rel_speed,
+                        double collision_dt, double frame_dt)
 {
     Body *a = &g_bodies[target];
     Body *b = &g_bodies[impactor];
@@ -1553,7 +1637,8 @@ static void absorb_body(int target, int impactor, double rel_speed, double colli
     }
     impact_dir_for_pair(target, impactor, collision_dt, dir);
     if (outcome == COLLISION_VIS_MERGE) {
-        begin_merge_event(target, impactor, rel_speed, dir, rel_vel, old_radius);
+        begin_merge_event(target, impactor, rel_speed, dir, rel_vel, old_radius,
+                          collision_dt, frame_dt);
         return;
     }
 
@@ -1571,6 +1656,52 @@ static void absorb_body(int target, int impactor, double rel_speed, double colli
     }
 
     finalize_absorb_body(target, impactor, rel_speed, outcome, old_radius);
+}
+
+void collision_step_system(int root, double dt)
+{
+    int resolved[MAX_BODIES] = {0};
+
+    if (dt <= 0.0) return;
+    if (root < 0 || root >= g_nbodies || !g_bodies[root].alive) return;
+
+    for (int ai = 0; ai < g_nbodies; ai++) {
+        int a = ai;
+        if (!g_bodies[a].alive || g_bodies[a].is_star || resolved[a] ||
+            body_is_merge_impactor(a) || body_root_star(a) != root)
+            continue;
+
+        for (int bi = ai + 1; bi < g_nbodies; bi++) {
+            int b = bi;
+            double speed = 0.0;
+            double hit_t = 0.0;
+            int target, impactor;
+            int a_is_merge_target, b_is_merge_target, keep_target_open;
+
+            if (!g_bodies[b].alive || g_bodies[b].is_star || resolved[b] ||
+                body_is_merge_impactor(b) || body_root_star(b) != root)
+                continue;
+
+            if (!swept_spheres_collide(a, b, dt, &speed, &hit_t))
+                continue;
+
+            a_is_merge_target = body_is_merge_target(a);
+            b_is_merge_target = body_is_merge_target(b);
+            if (a_is_merge_target && !b_is_merge_target)
+                target = a;
+            else if (b_is_merge_target && !a_is_merge_target)
+                target = b;
+            else
+                target = g_bodies[a].mass >= g_bodies[b].mass ? a : b;
+            impactor = target == a ? b : a;
+
+            absorb_body(target, impactor, speed, hit_t, dt);
+            keep_target_open = body_is_merge_target(target);
+            if (!keep_target_open) resolved[target] = 1;
+            resolved[impactor] = 1;
+            if (impactor == a) break;
+        }
+    }
 }
 
 void collision_step(double dt)
@@ -1690,6 +1821,7 @@ void collision_step(double dt)
                     int b = members[other_root][bi];
                     int lo, hi;
                     double speed = 0.0;
+                    double hit_t = 0.0;
 
                     if (same_root && bi <= ai) continue;
                     if (a == b) continue;
@@ -1706,7 +1838,7 @@ void collision_step(double dt)
                     }
 
                     {
-                        int hit = swept_spheres_collide(a, b, dt, &speed);
+                        int hit = swept_spheres_collide(a, b, dt, &speed, &hit_t);
                         if (!hit) {
                             double pdt = pair_check_dt(a, b);
                             s_pair_next[lo][hi] = pdt;
@@ -1734,7 +1866,7 @@ void collision_step(double dt)
                         else
                             target = g_bodies[a].mass >= g_bodies[b].mass ? a : b;
                         impactor = target == a ? b : a;
-                        absorb_body(target, impactor, speed, dt);
+                        absorb_body(target, impactor, speed, hit_t, dt);
                         keep_target_open = body_is_merge_target(target);
                         if (!keep_target_open)
                             resolved[target] = 1;

--- a/src/collision.c
+++ b/src/collision.c
@@ -2026,6 +2026,22 @@ int collision_body_has_active_merge(int body_idx)
     return body_is_in_merge(body_idx);
 }
 
+int collision_body_needs_dense_trail(int body_idx)
+{
+    int root;
+
+    if (body_idx < 0 || body_idx >= g_nbodies || !g_bodies[body_idx].alive)
+        return 0;
+    if (body_is_in_merge(body_idx))
+        return 1;
+
+    root = body_root_star(body_idx);
+    if (root < 0 || root >= MAX_BODIES)
+        return 0;
+
+    return s_system_hot[root] > 0.0;
+}
+
 int collision_particles(CollisionParticle *out, int max_particles,
                         const double cam_pos[3])
 {

--- a/src/collision.c
+++ b/src/collision.c
@@ -131,6 +131,22 @@ static void mark_system_dirty(int root, double hot_duration)
     if (hot_duration > s_system_hot[root]) s_system_hot[root] = hot_duration;
 }
 
+void collision_reset(void)
+{
+    memset(s_impacts, 0, sizeof(s_impacts));
+    memset(s_perm_scars, 0, sizeof(s_perm_scars));
+    memset(s_radius_fx, 0, sizeof(s_radius_fx));
+    memset(s_merges, 0, sizeof(s_merges));
+    memset(s_particles, 0, sizeof(s_particles));
+    memset(s_pair_next, 0, sizeof(s_pair_next));
+    memset(s_system_dirty, 0, sizeof(s_system_dirty));
+    memset(s_system_hot, 0, sizeof(s_system_hot));
+    memset(s_pos_before, 0, sizeof(s_pos_before));
+    s_particle_rng = 0x1234abcdu;
+    s_perm_scar_stamp = 1u;
+    s_pos_before_valid = 0;
+}
+
 void collision_snapshot_positions(void)
 {
     int n = g_nbodies < MAX_BODIES ? g_nbodies : MAX_BODIES;

--- a/src/collision.h
+++ b/src/collision.h
@@ -15,6 +15,7 @@ typedef enum {
 
 typedef struct {
     float dir[3];          /* body-local unit direction */
+    float tangent1[3];     /* stable body-local tangent basis for scar noise */
     float angular_radius;  /* radians on sphere */
     float heat;            /* 0..1 cooled intensity */
     float progress;        /* 0..1 event lifetime progress */

--- a/src/collision.h
+++ b/src/collision.h
@@ -21,6 +21,12 @@ typedef struct {
     int   kind;            /* CollisionVisualKind */
 } CollisionSpot;
 
+typedef struct {
+    float pos[3];          /* camera-relative render-space position */
+    float color[4];        /* rgba */
+    float size;            /* per-particle size multiplier */
+} CollisionParticle;
+
 void collision_step(double dt);
 int  collision_spots_for_body(int body_idx, CollisionSpot spots[COLLISION_MAX_SPOTS]);
 void collision_on_body_added(int body_idx);
@@ -28,3 +34,5 @@ double collision_visual_radius(int body_idx, double physical_radius);
 void collision_body_heat_glow(int body_idx, float out_color[3],
                               float *out_intensity, float *out_scale);
 int collision_body_has_active_merge(int body_idx);
+int collision_particles(CollisionParticle *out, int max_particles,
+                        const double cam_pos[3]);

--- a/src/collision.h
+++ b/src/collision.h
@@ -1,0 +1,26 @@
+/*
+ * collision.h - broadphase collision checks and simple impact heat effects.
+ */
+#pragma once
+#include "common.h"
+
+#define COLLISION_MAX_SPOTS 4
+
+typedef enum {
+    COLLISION_VIS_CRATER = 1,
+    COLLISION_VIS_MAJOR  = 2,
+    COLLISION_VIS_MERGE  = 3
+} CollisionVisualKind;
+
+typedef struct {
+    float dir[3];          /* body-local unit direction */
+    float angular_radius;  /* radians on sphere */
+    float heat;            /* 0..1 cooled intensity */
+    float progress;        /* 0..1 event lifetime progress */
+    int   kind;            /* CollisionVisualKind */
+} CollisionSpot;
+
+void collision_step(double dt);
+int  collision_spots_for_body(int body_idx, CollisionSpot spots[COLLISION_MAX_SPOTS]);
+void collision_on_body_added(int body_idx);
+double collision_visual_radius(int body_idx, double physical_radius);

--- a/src/collision.h
+++ b/src/collision.h
@@ -4,13 +4,14 @@
 #pragma once
 #include "common.h"
 
-#define COLLISION_MAX_SPOTS 16
+#define COLLISION_MAX_SPOTS 32
 
 typedef enum {
     COLLISION_VIS_CRATER    = 1,
     COLLISION_VIS_MAJOR     = 2,
     COLLISION_VIS_MERGE     = 3,
-    COLLISION_VIS_INTERSECT = 4  /* live sphere-sphere boundary during merge */
+    COLLISION_VIS_INTERSECT = 4, /* live sphere-sphere boundary during merge */
+    COLLISION_VIS_PERM_CRATER = 5
 } CollisionVisualKind;
 
 typedef struct {
@@ -19,6 +20,7 @@ typedef struct {
     float angular_radius;  /* radians on sphere */
     float heat;            /* 0..1 cooled intensity */
     float progress;        /* 0..1 event lifetime progress */
+    float seed;            /* stable shader variation seed */
     int   kind;            /* CollisionVisualKind */
 } CollisionSpot;
 

--- a/src/collision.h
+++ b/src/collision.h
@@ -27,6 +27,7 @@ typedef struct {
     float size;            /* per-particle size multiplier */
 } CollisionParticle;
 
+void collision_snapshot_positions(void);
 void collision_step(double dt);
 int  collision_spots_for_body(int body_idx, CollisionSpot spots[COLLISION_MAX_SPOTS]);
 void collision_on_body_added(int body_idx);

--- a/src/collision.h
+++ b/src/collision.h
@@ -4,12 +4,13 @@
 #pragma once
 #include "common.h"
 
-#define COLLISION_MAX_SPOTS 4
+#define COLLISION_MAX_SPOTS 16
 
 typedef enum {
-    COLLISION_VIS_CRATER = 1,
-    COLLISION_VIS_MAJOR  = 2,
-    COLLISION_VIS_MERGE  = 3
+    COLLISION_VIS_CRATER    = 1,
+    COLLISION_VIS_MAJOR     = 2,
+    COLLISION_VIS_MERGE     = 3,
+    COLLISION_VIS_INTERSECT = 4  /* live sphere-sphere boundary during merge */
 } CollisionVisualKind;
 
 typedef struct {
@@ -24,3 +25,6 @@ void collision_step(double dt);
 int  collision_spots_for_body(int body_idx, CollisionSpot spots[COLLISION_MAX_SPOTS]);
 void collision_on_body_added(int body_idx);
 double collision_visual_radius(int body_idx, double physical_radius);
+void collision_body_heat_glow(int body_idx, float out_color[3],
+                              float *out_intensity, float *out_scale);
+int collision_body_has_active_merge(int body_idx);

--- a/src/collision.h
+++ b/src/collision.h
@@ -31,6 +31,7 @@ typedef struct {
 } CollisionParticle;
 
 void collision_snapshot_positions(void);
+void collision_reset(void);
 void collision_step(double dt);
 int  collision_system_maybe_has_encounter(int root, double dt);
 void collision_step_system(int root, double dt);

--- a/src/collision.h
+++ b/src/collision.h
@@ -40,5 +40,6 @@ double collision_visual_radius(int body_idx, double physical_radius);
 void collision_body_heat_glow(int body_idx, float out_color[3],
                               float *out_intensity, float *out_scale);
 int collision_body_has_active_merge(int body_idx);
+int collision_body_needs_dense_trail(int body_idx);
 int collision_particles(CollisionParticle *out, int max_particles,
                         const double cam_pos[3]);

--- a/src/collision.h
+++ b/src/collision.h
@@ -40,6 +40,7 @@ void collision_on_body_added(int body_idx);
 double collision_visual_radius(int body_idx, double physical_radius);
 void collision_body_heat_glow(int body_idx, float out_color[3],
                               float *out_intensity, float *out_scale);
+float collision_body_star_heat(int body_idx);
 int collision_body_has_active_merge(int body_idx);
 int collision_body_needs_dense_trail(int body_idx);
 int collision_particles(CollisionParticle *out, int max_particles,

--- a/src/collision.h
+++ b/src/collision.h
@@ -32,6 +32,8 @@ typedef struct {
 
 void collision_snapshot_positions(void);
 void collision_step(double dt);
+int  collision_system_maybe_has_encounter(int root, double dt);
+void collision_step_system(int root, double dt);
 int  collision_spots_for_body(int body_idx, CollisionSpot spots[COLLISION_MAX_SPOTS]);
 void collision_on_body_added(int body_idx);
 double collision_visual_radius(int body_idx, double physical_radius);

--- a/src/collision.h
+++ b/src/collision.h
@@ -34,6 +34,7 @@ void collision_snapshot_positions(void);
 void collision_reset(void);
 void collision_step(double dt);
 int  collision_system_maybe_has_encounter(int root, double dt);
+int  collision_system_close_approach_subdivide(int root, double dt_outer);
 void collision_step_system(int root, double dt);
 int  collision_spots_for_body(int body_idx, CollisionSpot spots[COLLISION_MAX_SPOTS]);
 void collision_on_body_added(int body_idx);

--- a/src/common.h
+++ b/src/common.h
@@ -46,11 +46,15 @@ extern int g_win_h;
 #define TRAIL_LEN  4096   /* trail circular buffer size (per body, all bodies) */
 #define NUM_STARS          4000
 
-/* Trail sampling: acceleration-driven with hard interval clamps. */
-#define TRAIL_MIN_INTERVAL          60.0         /* sim-seconds */
-#define TRAIL_MAX_INTERVAL     (DAY * 25.0)      /* sim-seconds */
-#define TRAIL_ACCEL_SCALE        1200.0          /* interval = scale / sqrt(|a|) */
+/* Trail sampling: acceleration chooses a target spatial segment length. */
+#define TRAIL_MIN_SEGMENT_LEN       2.5e4        /* m */
+#define TRAIL_MAX_SEGMENT_LEN       6.0e8        /* m */
+#define TRAIL_SEGMENT_SCALE         1.2e7        /* segment = scale / sqrt(|a|) */
 #define TRAIL_ACCEL_EPS             1e-12        /* m/s^2, avoids div-by-zero */
+#define TRAIL_CURVE_ERROR_RATIO     0.22         /* allowed chord error vs segment length */
+#define TRAIL_CURVE_MIN_ERROR       5.0e3        /* m */
+#define TRAIL_CURVE_MAX_ERROR       2.0e7        /* m */
+#define TRAIL_CURVE_MAX_DEPTH       6
 
 /* 1 AU → 1.0 GL unit */
 #define RS  (1.0 / AU)

--- a/src/common.h
+++ b/src/common.h
@@ -50,6 +50,7 @@ extern int g_win_h;
 #define TRAIL_MIN_SEGMENT_LEN       2.0e4        /* m */
 #define TRAIL_MAX_SEGMENT_LEN       4.5e8        /* m */
 #define TRAIL_BASE_SEGMENT_LEN      1.0e8        /* m */
+#define TRAIL_SATELLITE_SEGMENT_LEN  1.0e6       /* m */
 #define TRAIL_TARGET_WORLD_LEN     (128.0 * AU)  /* fixed retained trail length */
 #define TRAIL_SATELLITE_WORLD_LEN   (0.3 * AU)
 #define TRAIL_CURVE_ERROR_RATIO     0.22         /* allowed chord error vs segment length */

--- a/src/common.h
+++ b/src/common.h
@@ -44,15 +44,16 @@ extern int g_win_h;
 /* ------------------------------------------------------------------ sim */
 #define MAX_BODIES         128
 #define TRAIL_LEN          16384   /* trail circular buffer size (per body, all bodies) */
+#define TRAIL_MASK         (TRAIL_LEN - 1)  /* for fast power-of-2 modulo */
 #define NUM_STARS          4000
 
 /* Trail sampling: fixed global spatial resolution. */
 #define TRAIL_MIN_SEGMENT_LEN       2.0e4        /* m */
 #define TRAIL_MAX_SEGMENT_LEN       4.5e8        /* m */
 #define TRAIL_BASE_SEGMENT_LEN      1.0e8        /* m */
-#define TRAIL_SATELLITE_SEGMENT_LEN  1.0e6       /* m */
+#define TRAIL_SATELLITE_SEGMENT_LEN  4.0e6       /* m */
 #define TRAIL_TARGET_WORLD_LEN     (128.0 * AU)  /* fixed retained trail length */
-#define TRAIL_SATELLITE_WORLD_LEN   (0.3 * AU)
+#define TRAIL_SATELLITE_WORLD_LEN   (1.0 * AU)
 #define TRAIL_CURVE_ERROR_RATIO     0.22         /* allowed chord error vs segment length */
 #define TRAIL_CURVE_MIN_ERROR       5.0e3        /* m */
 #define TRAIL_CURVE_MAX_ERROR       2.0e7        /* m */

--- a/src/common.h
+++ b/src/common.h
@@ -54,7 +54,7 @@ extern int g_win_h;
 #define TRAIL_SATELLITE_SEGMENT_LEN  2.0e6       /* m */
 #define TRAIL_CLOSE_APPROACH_FACTOR  0.35        /* denser sampling only near collisions */
 #define TRAIL_TARGET_WORLD_LEN     (128.0 * AU)  /* fixed retained trail length */
-#define TRAIL_SATELLITE_WORLD_LEN   (1.0 * AU)
+#define TRAIL_SATELLITE_WORLD_LEN   (1.75 * AU)
 #define TRAIL_CURVE_ERROR_RATIO     0.22         /* allowed chord error vs segment length */
 #define TRAIL_CURVE_MIN_ERROR       5.0e3        /* m */
 #define TRAIL_CURVE_MAX_ERROR       2.0e7        /* m */

--- a/src/common.h
+++ b/src/common.h
@@ -43,14 +43,15 @@ extern int g_win_h;
 
 /* ------------------------------------------------------------------ sim */
 #define MAX_BODIES         128
-#define TRAIL_LEN  4096   /* trail circular buffer size (per body, all bodies) */
+#define TRAIL_LEN          16384   /* trail circular buffer size (per body, all bodies) */
 #define NUM_STARS          4000
 
-/* Trail sampling: acceleration chooses a target spatial segment length. */
+/* Trail sampling: fixed global spatial resolution. */
 #define TRAIL_MIN_SEGMENT_LEN       2.0e4        /* m */
 #define TRAIL_MAX_SEGMENT_LEN       4.5e8        /* m */
-#define TRAIL_SEGMENT_SCALE         9.0e6        /* segment = scale / sqrt(|a|) */
-#define TRAIL_ACCEL_EPS             1e-12        /* m/s^2, avoids div-by-zero */
+#define TRAIL_BASE_SEGMENT_LEN      1.0e8        /* m */
+#define TRAIL_TARGET_WORLD_LEN     (128.0 * AU)  /* fixed retained trail length */
+#define TRAIL_SATELLITE_WORLD_LEN   (0.3 * AU)
 #define TRAIL_CURVE_ERROR_RATIO     0.22         /* allowed chord error vs segment length */
 #define TRAIL_CURVE_MIN_ERROR       5.0e3        /* m */
 #define TRAIL_CURVE_MAX_ERROR       2.0e7        /* m */

--- a/src/common.h
+++ b/src/common.h
@@ -51,7 +51,8 @@ extern int g_win_h;
 #define TRAIL_MIN_SEGMENT_LEN       2.0e4        /* m */
 #define TRAIL_MAX_SEGMENT_LEN       4.5e8        /* m */
 #define TRAIL_BASE_SEGMENT_LEN      1.0e8        /* m */
-#define TRAIL_SATELLITE_SEGMENT_LEN  4.0e6       /* m */
+#define TRAIL_SATELLITE_SEGMENT_LEN  2.0e6       /* m */
+#define TRAIL_CLOSE_APPROACH_FACTOR  0.35        /* denser sampling only near collisions */
 #define TRAIL_TARGET_WORLD_LEN     (128.0 * AU)  /* fixed retained trail length */
 #define TRAIL_SATELLITE_WORLD_LEN   (1.0 * AU)
 #define TRAIL_CURVE_ERROR_RATIO     0.22         /* allowed chord error vs segment length */

--- a/src/common.h
+++ b/src/common.h
@@ -46,6 +46,12 @@ extern int g_win_h;
 #define TRAIL_LEN  4096   /* trail circular buffer size (per body, all bodies) */
 #define NUM_STARS          4000
 
+/* Trail sampling: acceleration-driven with hard interval clamps. */
+#define TRAIL_MIN_INTERVAL          60.0         /* sim-seconds */
+#define TRAIL_MAX_INTERVAL     (DAY * 25.0)      /* sim-seconds */
+#define TRAIL_ACCEL_SCALE        1200.0          /* interval = scale / sqrt(|a|) */
+#define TRAIL_ACCEL_EPS             1e-12        /* m/s^2, avoids div-by-zero */
+
 /* 1 AU → 1.0 GL unit */
 #define RS  (1.0 / AU)
 

--- a/src/common.h
+++ b/src/common.h
@@ -47,9 +47,9 @@ extern int g_win_h;
 #define NUM_STARS          4000
 
 /* Trail sampling: acceleration chooses a target spatial segment length. */
-#define TRAIL_MIN_SEGMENT_LEN       2.5e4        /* m */
-#define TRAIL_MAX_SEGMENT_LEN       6.0e8        /* m */
-#define TRAIL_SEGMENT_SCALE         1.2e7        /* segment = scale / sqrt(|a|) */
+#define TRAIL_MIN_SEGMENT_LEN       2.0e4        /* m */
+#define TRAIL_MAX_SEGMENT_LEN       4.5e8        /* m */
+#define TRAIL_SEGMENT_SCALE         9.0e6        /* segment = scale / sqrt(|a|) */
 #define TRAIL_ACCEL_EPS             1e-12        /* m/s^2, avoids div-by-zero */
 #define TRAIL_CURVE_ERROR_RATIO     0.22         /* allowed chord error vs segment length */
 #define TRAIL_CURVE_MIN_ERROR       5.0e3        /* m */

--- a/src/labels.c
+++ b/src/labels.c
@@ -163,7 +163,7 @@ void labels_init(void) {
     memset(s_hide_accum, 0, sizeof(s_hide_accum));
     memset(s_active,     0, sizeof(s_active));
     for (int i = 0; i < g_nbodies; i++)
-        build_label_texture(i);
+        if (g_bodies[i].alive) build_label_texture(i);
 }
 
 void labels_add_body(int body_idx)
@@ -173,6 +173,20 @@ void labels_add_body(int body_idx)
     s_hide_accum[body_idx] = 0.0f;
     s_active[body_idx] = 0;
     build_label_texture(body_idx);
+}
+
+void labels_remove_body(int body_idx)
+{
+    if (body_idx < 0 || body_idx >= MAX_BODIES) return;
+    s_show_accum[body_idx] = 0.0f;
+    s_hide_accum[body_idx] = 0.0f;
+    s_active[body_idx] = 0;
+    if (s_tex[body_idx]) {
+        glDeleteTextures(1, &s_tex[body_idx]);
+        s_tex[body_idx] = 0;
+    }
+    s_tex_w[body_idx] = 0;
+    s_tex_h[body_idx] = 0;
 }
 
 void labels_render(const float view[16], const float proj[16],
@@ -199,6 +213,7 @@ void labels_render(const float view[16], const float proj[16],
     for (int i = 0; i < g_nbodies; i++) {
         order[i]   = i;
         lvis[i]    = 0;
+        if (!g_bodies[i].alive) continue;
         if (!s_tex[i]) continue;
         /* Far cutoff: non-star labels are local-system annotations. */
         if (!g_bodies[i].is_star && info[i].dcam > MAX_LABEL_DIST) continue;
@@ -247,6 +262,7 @@ void labels_render(const float view[16], const float proj[16],
         int ns = 0, np = 0, nm = 0;
         int stars[MAX_BODIES], planets[MAX_BODIES], moons[MAX_BODIES];
         for (int i = 0; i < g_nbodies; i++) {
+            if (!g_bodies[i].alive) continue;
             if      (g_bodies[i].is_star)       stars  [ns++] = i;
             /* planet: no parent, or parent is a star (not a moon of a planet) */
             else if (g_bodies[i].parent < 0 ||
@@ -275,14 +291,17 @@ void labels_render(const float view[16], const float proj[16],
         for (int i = 0; i < ns; i++) order[i]              = stars[i];
         for (int i = 0; i < np; i++) order[ns + i]          = planets[i];
         for (int i = 0; i < nm; i++) order[ns + np + i]     = moons[i];
+        for (int i = ns + np + nm; i < g_nbodies; i++) order[i] = -1;
     }
 
     /* ---- Step 3: greedy AABB overlap removal ---- */
     for (int i = 0; i < g_nbodies; i++) {
         int idx = order[i];
+        if (idx < 0) continue;
         if (!lvis[idx]) continue;
         for (int j = 0; j < i; j++) {
             int jdx = order[j];
+            if (jdx < 0) continue;
             if (!lvis[jdx]) continue;
             if (lsx[idx]          < lsx[jdx]+lsw[jdx] &&
                 lsx[idx]+lsw[idx] > lsx[jdx]           &&
@@ -295,6 +314,7 @@ void labels_render(const float view[16], const float proj[16],
 
     /* ---- Step 4: hysteresis — debounce lvis into s_active ---- */
     for (int i = 0; i < g_nbodies; i++) {
+        if (!g_bodies[i].alive) continue;
         if (lvis[i]) {
             s_show_accum[i] += dt;
             s_hide_accum[i]  = 0.0f;
@@ -322,6 +342,7 @@ void labels_render(const float view[16], const float proj[16],
     glBindVertexArray(s_vao);
 
     for (int i = 0; i < g_nbodies; i++) {
+        if (!g_bodies[i].alive) continue;
         if (!s_active[i]) continue;
         if (!s_tex[i])    continue;
 

--- a/src/labels.c
+++ b/src/labels.c
@@ -15,6 +15,7 @@
 #include "camera.h"
 #include "gl_utils.h"
 #include "math3d.h"
+#include "ui_theme.h"
 
 #define MAX_LABEL_DIST   55.0f  /* AU — hard far cutoff for non-star labels    */
 /* Hide label once camera is closer than this many body-radii to the centre.
@@ -53,23 +54,6 @@ static int   s_active[MAX_BODIES];       /* current visible state (0/1)        *
 /* anchor is recomputed from g_bodies[i].pos each frame — no float32 cache needed */
 
 static TTF_Font *s_font = NULL;
-
-/* ------------------------------------------------------------------ font */
-static const char *FONT_PATHS[] = {
-    "C:/Windows/Fonts/segoeui.ttf",
-    "C:/Windows/Fonts/arial.ttf",
-    "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf",
-    "/usr/share/fonts/TTF/DejaVuSans.ttf",
-    NULL
-};
-
-static TTF_Font *find_font(int size) {
-    for (int i = 0; FONT_PATHS[i]; i++) {
-        TTF_Font *f = TTF_OpenFont(FONT_PATHS[i], size);
-        if (f) return f;
-    }
-    return NULL;
-}
 
 /* ------------------------------------------------------------------ texture */
 static GLuint surface_to_texture(SDL_Surface *surf, int *w, int *h) {
@@ -149,7 +133,7 @@ void labels_init(void) {
         fprintf(stderr, "[Labels] TTF_Init: %s\n", TTF_GetError());
         return;
     }
-    s_font = find_font(16);
+    s_font = ui_theme_open_font(16);
     if (!s_font) {
         fprintf(stderr, "[Labels] no usable font found — labels disabled\n");
         return;

--- a/src/labels.h
+++ b/src/labels.h
@@ -18,6 +18,9 @@ void labels_init(void);
 /* Create/update the cached text texture for a runtime-added body. */
 void labels_add_body(int body_idx);
 
+/* Disable and release the cached label for a removed/absorbed body. */
+void labels_remove_body(int body_idx);
+
 /*
  * Render labels for all bodies.
  *   view  — view matrix (for extracting camera right/up)

--- a/src/main.c
+++ b/src/main.c
@@ -417,6 +417,7 @@ int main(int argc, char **argv) {
                         effective_sim_dt = sys_cap;
                 }
 
+                collision_snapshot_positions();
 #ifdef _OPENMP
 #pragma omp parallel for schedule(dynamic)
 #endif

--- a/src/main.c
+++ b/src/main.c
@@ -31,6 +31,10 @@
 #include "asteroids.h"
 #include "ui.h"
 #include "build.h"
+#include "collision.h"
+#ifdef _OPENMP
+#include <omp.h>
+#endif
 
 /* ------------------------------------------------------------------ globals */
 static SDL_Window   *s_win = NULL;
@@ -51,7 +55,7 @@ static const double SPEED_TABLE[] = {
     0.0,
     0.1, 0.25, 0.5,
     1.0, 2.0, 5.0, 10.0, 30.0, 60.0, 100.0,
-    365.0, 730.0, 1825.0, 3650.0
+    365.0
 };
 #define SPEED_TABLE_LEN (int)(sizeof(SPEED_TABLE)/sizeof(SPEED_TABLE[0]))
 static int s_speed_idx = 4;   /* start at 1.0 days/s */
@@ -330,24 +334,36 @@ int main(int argc, char **argv) {
     labels_init();
     ui_init();
     build_init();
+    physics_refresh_timestep_model();
 
     /* Trail warm-up: pre-simulate 2 years using RESPA.
      * 730 outer steps × 50 inner steps = 36 500 inner steps total —
      * identical resolution to the old 0.02-day loop but ~20× faster
      * because slow forces are only evaluated at the outer (1-day) rate. */
     {
-        const double STEP_OUTER  = DAY * 1.0;
-        const double STEP_INNER  = DAY * 0.02;
-        const int    N_INNER     = 50;
-        const int    OUTER_TOTAL = (int)(365.0 * 2.0 / 1.0);
-        for (int o = 0; o < OUTER_TOTAL; o++) {
-            physics_respa_begin(STEP_OUTER);
-            for (int i = 0; i < N_INNER; i++) {
-                physics_respa_inner(STEP_INNER);
-                trails_tick(STEP_INNER);
+        const double WARMUP_DT = 365.0 * 2.0 * DAY;
+        int sys_n = physics_system_count();
+#ifdef _OPENMP
+#pragma omp parallel for schedule(dynamic)
+#endif
+        for (int s = 0; s < sys_n; s++) {
+            double step_outer = physics_system_outer_dt_limit(s);
+            double step_inner = physics_system_inner_dt_limit(s);
+            int n_inner = (int)(step_outer / step_inner) + 1;
+            int outer_total = (int)(WARMUP_DT / step_outer);
+            int root = physics_system_root(s);
+            for (int o = 0; o < outer_total; o++) {
+                double dt_outer = WARMUP_DT / outer_total;
+                double dt_inner = dt_outer / n_inner;
+                physics_respa_begin_system(root, dt_outer);
+                for (int i = 0; i < n_inner; i++) {
+                    physics_respa_inner_system(root, dt_inner);
+                    trails_tick_system(root, dt_inner);
+                }
+                physics_respa_end_system(root, dt_outer);
             }
-            physics_respa_end(STEP_OUTER);
         }
+        physics_advance_time(WARMUP_DT);
     }
 
     /* Timing */
@@ -387,29 +403,48 @@ int main(int argc, char **argv) {
          * total distance is identical whether we call it N×(dt/N) or 1×dt —
          * this gives ~50× fewer sqrt calls with no change in sample spacing. */
         if (!g_paused && g_sim_speed > 0.0) {
-            const double DT_OUTER     = DAY * 1.0;
-            const double DT_INNER_MAX = DAY * 0.02;
-            const int    MAX_OUTER_STEPS = 120;   /* cap: ~120 sim-days / frame */
+            const int    MAX_OUTER_STEPS = 120;   /* per system cap */
+            physics_refresh_timestep_model();
+            {
+                int sys_n = physics_system_count();
+                double sim_dt = g_sim_speed * dt;
+                double effective_sim_dt = sim_dt;
 
-            double sim_dt = g_sim_speed * dt;
-            if (sim_dt > DT_OUTER * MAX_OUTER_STEPS)
-                sim_dt = DT_OUTER * MAX_OUTER_STEPS;
-
-            int    outer_steps = (int)(sim_dt / DT_OUTER) + 1;
-            double dt_outer    = sim_dt / outer_steps;
-            int    n_inner     = (int)(dt_outer / DT_INNER_MAX) + 1;
-            double dt_inner    = dt_outer / n_inner;
-
-            for (int o = 0; o < outer_steps; o++) {
-                physics_respa_begin(dt_outer);
-                for (int i = 0; i < n_inner; i++) {
-                    physics_respa_inner(dt_inner);
-                    trails_tick(dt_inner);   /* per inner step: captures intermediate positions */
+                for (int s = 0; s < sys_n; s++) {
+                    double dt_outer_max = physics_system_outer_dt_limit(s);
+                    double sys_cap = dt_outer_max * MAX_OUTER_STEPS;
+                    if (effective_sim_dt > sys_cap)
+                        effective_sim_dt = sys_cap;
                 }
-                physics_respa_end(dt_outer);
-                asteroids_step(dt_outer);   /* test-particle gravity */
+
+#ifdef _OPENMP
+#pragma omp parallel for schedule(dynamic)
+#endif
+                for (int s = 0; s < sys_n; s++) {
+                    double dt_outer_max = physics_system_outer_dt_limit(s);
+                    double dt_inner_max = physics_system_inner_dt_limit(s);
+                    int root = physics_system_root(s);
+                    double sys_dt = effective_sim_dt;
+
+                    int outer_steps = (int)(sys_dt / dt_outer_max) + 1;
+                    double dt_outer = sys_dt / outer_steps;
+                    int n_inner = (int)(dt_outer / dt_inner_max) + 1;
+                    double dt_inner = dt_outer / n_inner;
+
+                    for (int o = 0; o < outer_steps; o++) {
+                        physics_respa_begin_system(root, dt_outer);
+                        for (int i = 0; i < n_inner; i++) {
+                            physics_respa_inner_system(root, dt_inner);
+                            trails_tick_system(root, dt_inner);
+                        }
+                        physics_respa_end_system(root, dt_outer);
+                    }
+                }
+                physics_advance_time(effective_sim_dt);
+                collision_step(effective_sim_dt);
+                asteroids_step(effective_sim_dt);
+                rings_tick(effective_sim_dt);
             }
-            rings_tick(sim_dt);
         }
 
         /* Build matrices */

--- a/src/main.c
+++ b/src/main.c
@@ -121,7 +121,7 @@ static int app_init(void) {
         return 0;
     }
 
-    SDL_GL_SetSwapInterval(0);   /* vsync deactivated for debugging purpose - activate for production*/
+    SDL_GL_SetSwapInterval(0);  /* uncapped — no vsync */
 
     /* GLEW */
     glewExperimental = GL_TRUE;
@@ -358,9 +358,9 @@ int main(int argc, char **argv) {
                 physics_respa_begin_system(root, dt_outer);
                 for (int i = 0; i < n_inner; i++) {
                     physics_respa_inner_system(root, dt_inner);
-                    trails_tick_system(root, dt_inner);
                 }
                 physics_respa_end_system(root, dt_outer);
+                trails_tick_system(root, dt_outer);
             }
         }
         physics_advance_time(WARMUP_DT);
@@ -437,9 +437,14 @@ int main(int argc, char **argv) {
                         physics_respa_begin_system(root, dt_outer);
                         for (int i = 0; i < n_inner; i++) {
                             physics_respa_inner_system(root, dt_inner);
-                            trails_tick_system(root, dt_inner);
                         }
                         physics_respa_end_system(root, dt_outer);
+                        /* Trail tick once per outer step instead of every inner step.
+                         * n_inner was typically 50, so this is ~50x fewer calls.
+                         * The Hermite curve over dt_outer correctly captures orbital
+                         * curvature for satellites; planets are flat enough at this
+                         * scale that subdivision terminates immediately. */
+                        trails_tick_system(root, dt_outer);
                         if (local_encounter) {
                             collision_step_system(root, dt_outer);
                         }

--- a/src/main.c
+++ b/src/main.c
@@ -611,6 +611,9 @@ int main(int argc, char **argv) {
 
                     int outer_steps = (int)(sys_dt / dt_outer_max) + 1;
                     double dt_outer = sys_dt / outer_steps;
+                    int ca_factor = collision_system_close_approach_subdivide(root, dt_outer);
+                    outer_steps *= ca_factor;
+                    dt_outer    /= ca_factor;
                     int n_inner = (int)(dt_outer / dt_inner_max) + 1;
                     double dt_inner = dt_outer / n_inner;
 

--- a/src/main.c
+++ b/src/main.c
@@ -398,10 +398,8 @@ int main(int argc, char **argv) {
          * lag-spiral).  At extreme sim speeds the simulation runs at a
          * reduced rate rather than making the UI unresponsive.
          *
-         * trails_tick is called once per outer step (not every inner step).
-         * The distance-based accumulator in trails_tick sums |v|*dt, so the
-         * total distance is identical whether we call it N×(dt/N) or 1×dt —
-         * this gives ~50× fewer sqrt calls with no change in sample spacing. */
+         * trails_tick is called every inner step so the acceleration-driven
+         * sampler sees the same local dynamics as the integrator itself. */
         if (!g_paused && g_sim_speed > 0.0) {
             const int    MAX_OUTER_STEPS = 120;   /* per system cap */
             physics_refresh_timestep_model();

--- a/src/main.c
+++ b/src/main.c
@@ -81,6 +81,11 @@ static int s_speed_idx = 4;   /* start at 1.0 days/s */
 int s_warp = 0;
 int g_warp = 0;
 
+static void boot_log(const char *msg) {
+    fprintf(stdout, "[Boot] %s\n", msg);
+    fflush(stdout);
+}
+
 static void clear_movement_keys(void) {
     s_key_w = s_key_s = s_key_a = s_key_d = s_key_q = s_key_e = 0;
 }
@@ -134,6 +139,10 @@ static void move_pause_menu_selection(int delta) {
 static void warmup_universe(void) {
     const double WARMUP_DT = 365.0 * 2.0 * DAY;
     int sys_n = physics_system_count();
+    int completed = 0;
+    fprintf(stdout, "[Boot] Warm-up: pre-simulating %.0f days across %d system%s\n",
+            WARMUP_DT / DAY, sys_n, sys_n == 1 ? "" : "s");
+    fflush(stdout);
 #ifdef _OPENMP
 #pragma omp parallel for schedule(dynamic)
 #endif
@@ -153,22 +162,43 @@ static void warmup_universe(void) {
             physics_respa_end_system(root, dt_outer);
             trails_tick_system(root, dt_outer);
         }
+#ifdef _OPENMP
+#pragma omp critical
+#endif
+        {
+            completed++;
+            fprintf(stdout, "[Boot] Warm-up progress: %d/%d systems (%s)\n",
+                    completed, sys_n, g_bodies[root].name);
+            fflush(stdout);
+        }
     }
     physics_advance_time(WARMUP_DT);
+    boot_log("Warm-up complete");
 }
 
 static void init_runtime_world(void) {
+    boot_log("Preparing runtime world");
     universe_load("assets/universe.json");
+    boot_log("Resetting camera");
     cam_reset();
+    boot_log("Initializing starfield");
     starfield_init();
+    boot_log("Initializing trails");
     trails_gl_init();
+    boot_log("Initializing renderer");
     render_init();
+    boot_log("Initializing rings");
     rings_init("assets/universe.json");
+    boot_log("Initializing asteroid belts");
     asteroids_init("assets/universe.json");
+    boot_log("Initializing labels");
     labels_init();
+    boot_log("Initializing build mode");
     build_init();
+    boot_log("Refreshing physics timestep model");
     physics_refresh_timestep_model();
     warmup_universe();
+    boot_log("Runtime world ready");
 }
 
 static void shutdown_runtime_world(void) {
@@ -223,6 +253,7 @@ static void toggle_fullscreen(void) {
 }
 
 static int app_init(void) {
+    boot_log("Initializing SDL");
     if (SDL_Init(SDL_INIT_VIDEO) < 0) {
         fprintf(stderr, "[Main] SDL_Init: %s\n", SDL_GetError());
         return 0;
@@ -252,9 +283,11 @@ static int app_init(void) {
         return 0;
     }
 
+    boot_log("Configuring swap interval");
     set_vsync(0);
 
     /* GLEW */
+    boot_log("Initializing GLEW");
     glewExperimental = GL_TRUE;
     GLenum err = glewInit();
     if (err != GLEW_OK) {
@@ -271,6 +304,7 @@ static int app_init(void) {
     glEnable(GL_MULTISAMPLE);
     glClearColor(0.0f, 0.0f, 0.02f, 1.0f);
     update_viewport_size();
+    boot_log("OpenGL context ready");
 
     return 1;
 }
@@ -524,7 +558,9 @@ int main(int argc, char **argv) {
 
     if (!app_init()) return 1;
 
+    boot_log("Resetting collision state");
     collision_reset();
+    boot_log("Initializing UI");
     ui_init();
     sync_pause_menu_ui();
     init_runtime_world();

--- a/src/main.c
+++ b/src/main.c
@@ -415,10 +415,8 @@ int main(int argc, char **argv) {
                         effective_sim_dt = sys_cap;
                 }
 
+                trails_begin_frame_snapshot();
                 collision_snapshot_positions();
-#ifdef _OPENMP
-#pragma omp parallel for schedule(dynamic)
-#endif
                 for (int s = 0; s < sys_n; s++) {
                     double dt_outer_max = physics_system_outer_dt_limit(s);
                     double dt_inner_max = physics_system_inner_dt_limit(s);
@@ -431,12 +429,20 @@ int main(int argc, char **argv) {
                     double dt_inner = dt_outer / n_inner;
 
                     for (int o = 0; o < outer_steps; o++) {
+                        int local_encounter = collision_system_maybe_has_encounter(root, dt_outer);
+                        if (local_encounter) {
+                            trails_begin_frame_snapshot();
+                            collision_snapshot_positions();
+                        }
                         physics_respa_begin_system(root, dt_outer);
                         for (int i = 0; i < n_inner; i++) {
                             physics_respa_inner_system(root, dt_inner);
                             trails_tick_system(root, dt_inner);
                         }
                         physics_respa_end_system(root, dt_outer);
+                        if (local_encounter) {
+                            collision_step_system(root, dt_outer);
+                        }
                     }
                 }
                 physics_advance_time(effective_sim_dt);

--- a/src/main.c
+++ b/src/main.c
@@ -368,7 +368,7 @@ static void handle_event(const SDL_Event *e, float dt, int *running) {
         case SDL_MOUSEMOTION:
         {
             int hover = ui_pause_menu_hit_test(e->motion.x, e->motion.y);
-            if (hover >= 0 && hover != s_pause_menu_selected) {
+            if (hover != s_pause_menu_selected) {
                 s_pause_menu_selected = hover;
                 sync_pause_menu_ui();
             }

--- a/src/main.c
+++ b/src/main.c
@@ -1,5 +1,5 @@
 /*
- * main.c — application entry point
+ * main.c - application entry point
  *
  * Responsibilities:
  *   - SDL2 window + OpenGL 3.3 Core context
@@ -8,14 +8,14 @@
  *   - Main loop: event handling, physics step, camera update, render
  *
  * Camera controls:
- *   W/S        — move forward / backward
- *   A/D        — strafe left / right
- *   Q/E        — move down / up
- *   Mouse drag — look (yaw/pitch)
- *   Scroll     — speed multiplier
- *   Space      — pause / resume simulation
- *   R          — reset camera
- *   +/-        — simulation speed × 2 / ÷ 2
+ *   W/S        - move forward / backward
+ *   A/D        - strafe left / right
+ *   Q/E        - move down / up
+ *   Mouse drag - look (yaw/pitch)
+ *   Scroll     - speed multiplier
+ *   Space      - pause / resume simulation
+ *   R          - reset camera
+ *   +/-        - simulation speed up / down
  */
 #include "common.h"
 #include "math3d.h"
@@ -44,13 +44,26 @@ int g_win_h = DEFAULT_WIN_H;
 static int s_fullscreen = 0;
 
 /* Mouse state */
-static int   s_freelook   = 0;       /* 1 = Tab toggled free-look, mouse captured */
+static int   s_freelook   = 0;       /* 1 = free-look active, mouse captured */
 static float s_mouse_sens = 0.25f;   /* degrees per pixel */
+static int   s_vsync_enabled = 0;
+
+static int s_pause_menu_open = 0;
+static int s_pause_menu_selected = 0;
+static int s_pause_menu_prev_paused = 0;
+
+enum {
+    PAUSE_MENU_CONTINUE = 0,
+    PAUSE_MENU_RESET_UNIVERSE,
+    PAUSE_MENU_TOGGLE_VSYNC,
+    PAUSE_MENU_LEAVE,
+    PAUSE_MENU_COUNT
+};
 
 /* Movement keys held */
 static int s_key_w, s_key_s, s_key_a, s_key_d, s_key_q, s_key_e;
 
-/* Sim-speed table — clean display values, 0.1 days/s as first non-zero step */
+/* Sim-speed table - clean display values, 0.1 days/s as first non-zero step */
 static const double SPEED_TABLE[] = {
     0.0,
     0.1, 0.25, 0.5,
@@ -60,14 +73,132 @@ static const double SPEED_TABLE[] = {
 #define SPEED_TABLE_LEN (int)(sizeof(SPEED_TABLE)/sizeof(SPEED_TABLE[0]))
 static int s_speed_idx = 4;   /* start at 1.0 days/s */
 
-/* Warp mode (T key) — variable interstellar speed, adjustable via scroll wheel.
+/* Warp mode (T key) - variable interstellar speed, adjustable via scroll wheel.
  * The speed range shifts from the normal [0.00001, 200] AU/s to the warp
  * range [200, 63241] AU/s (= [0.0032 ly/s, 1 ly/s]).                        */
-#define WARP_SPEED_MIN_AU    200.0f   /* AU/s — lowest warp speed  (normal max) */
-#define WARP_SPEED_MAX_AU  63241.0f   /* AU/s — highest warp speed (1 ly/s)     */
-int s_warp = 0;            /* 0 = normal, 1 = warp engaged */
-int g_warp = 0;            /* public mirror of s_warp for UI/other modules */
+#define WARP_SPEED_MIN_AU    200.0f
+#define WARP_SPEED_MAX_AU  63241.0f
+int s_warp = 0;
+int g_warp = 0;
 
+static void clear_movement_keys(void) {
+    s_key_w = s_key_s = s_key_a = s_key_d = s_key_q = s_key_e = 0;
+}
+
+static int set_vsync(int enabled) {
+    int interval = enabled ? 1 : 0;
+    if (SDL_GL_SetSwapInterval(interval) != 0) {
+        fprintf(stderr, "[Main] vsync toggle: %s\n", SDL_GetError());
+        return 0;
+    }
+    s_vsync_enabled = enabled ? 1 : 0;
+    fprintf(stdout, "[Main] V-Sync %s\n", s_vsync_enabled ? "ON" : "OFF");
+    return 1;
+}
+
+static void sync_pause_menu_ui(void) {
+    ui_set_pause_menu(s_pause_menu_open, s_pause_menu_selected, s_vsync_enabled);
+}
+
+static void close_pause_menu(int resume_freelook) {
+    s_pause_menu_open = 0;
+    g_paused = s_pause_menu_prev_paused;
+    if (resume_freelook) {
+        s_freelook = 1;
+        SDL_SetRelativeMouseMode(SDL_TRUE);
+    } else {
+        s_freelook = 0;
+        SDL_SetRelativeMouseMode(SDL_FALSE);
+    }
+    sync_pause_menu_ui();
+}
+
+static void open_pause_menu(void) {
+    s_pause_menu_prev_paused = g_paused;
+    s_pause_menu_open = 1;
+    s_pause_menu_selected = PAUSE_MENU_CONTINUE;
+    g_paused = 1;
+    s_freelook = 0;
+    SDL_SetRelativeMouseMode(SDL_FALSE);
+    clear_movement_keys();
+    sync_pause_menu_ui();
+}
+
+static void move_pause_menu_selection(int delta) {
+    s_pause_menu_selected += delta;
+    while (s_pause_menu_selected < 0) s_pause_menu_selected += PAUSE_MENU_COUNT;
+    while (s_pause_menu_selected >= PAUSE_MENU_COUNT) s_pause_menu_selected -= PAUSE_MENU_COUNT;
+    sync_pause_menu_ui();
+}
+
+static void warmup_universe(void) {
+    const double WARMUP_DT = 365.0 * 2.0 * DAY;
+    int sys_n = physics_system_count();
+#ifdef _OPENMP
+#pragma omp parallel for schedule(dynamic)
+#endif
+    for (int s = 0; s < sys_n; s++) {
+        double step_outer = physics_system_outer_dt_limit(s);
+        double step_inner = physics_system_inner_dt_limit(s);
+        int n_inner = (int)(step_outer / step_inner) + 1;
+        int outer_total = (int)(WARMUP_DT / step_outer);
+        int root = physics_system_root(s);
+        for (int o = 0; o < outer_total; o++) {
+            double dt_outer = WARMUP_DT / outer_total;
+            double dt_inner = dt_outer / n_inner;
+            physics_respa_begin_system(root, dt_outer);
+            for (int i = 0; i < n_inner; i++) {
+                physics_respa_inner_system(root, dt_inner);
+            }
+            physics_respa_end_system(root, dt_outer);
+            trails_tick_system(root, dt_outer);
+        }
+    }
+    physics_advance_time(WARMUP_DT);
+}
+
+static void init_runtime_world(void) {
+    universe_load("assets/universe.json");
+    cam_reset();
+    starfield_init();
+    trails_gl_init();
+    render_init();
+    rings_init("assets/universe.json");
+    asteroids_init("assets/universe.json");
+    labels_init();
+    build_init();
+    physics_refresh_timestep_model();
+    warmup_universe();
+}
+
+static void shutdown_runtime_world(void) {
+    asteroids_shutdown();
+    rings_shutdown();
+    render_shutdown();
+    labels_shutdown();
+    trails_gl_shutdown();
+    starfield_shutdown();
+    universe_shutdown();
+}
+
+static void reset_universe_state(void) {
+    shutdown_runtime_world();
+    collision_reset();
+    clear_movement_keys();
+    s_freelook = 0;
+    s_warp = 0;
+    g_warp = 0;
+    s_speed_idx = 4;
+    g_sim_time = 0.0;
+    g_sim_speed = SPEED_TABLE[s_speed_idx] * DAY;
+    g_paused = 0;
+    s_pause_menu_open = 0;
+    s_pause_menu_selected = PAUSE_MENU_CONTINUE;
+    s_pause_menu_prev_paused = 0;
+    SDL_SetRelativeMouseMode(SDL_FALSE);
+    sync_pause_menu_ui();
+    init_runtime_world();
+}
 
 /* ------------------------------------------------------------------ init / quit */
 static void update_viewport_size(void) {
@@ -121,7 +252,7 @@ static int app_init(void) {
         return 0;
     }
 
-    SDL_GL_SetSwapInterval(0);  /* uncapped — no vsync */
+    set_vsync(0);
 
     /* GLEW */
     glewExperimental = GL_TRUE;
@@ -146,20 +277,94 @@ static int app_init(void) {
 
 static void app_quit(void) {
     ui_shutdown();
-    asteroids_shutdown();
-    rings_shutdown();
-    render_shutdown();
-    labels_shutdown();
-    trails_gl_shutdown();
-    starfield_shutdown();
-    universe_shutdown();
+    shutdown_runtime_world();
     SDL_GL_DeleteContext(s_ctx);
     SDL_DestroyWindow(s_win);
     SDL_Quit();
 }
 
 /* ------------------------------------------------------------------ event handling */
-static void handle_event(const SDL_Event *e, float dt) {
+static void activate_pause_menu_action(int *running) {
+    switch (s_pause_menu_selected) {
+    case PAUSE_MENU_CONTINUE:
+        close_pause_menu(1);
+        break;
+    case PAUSE_MENU_RESET_UNIVERSE:
+        reset_universe_state();
+        break;
+    case PAUSE_MENU_TOGGLE_VSYNC:
+        set_vsync(!s_vsync_enabled);
+        sync_pause_menu_ui();
+        break;
+    case PAUSE_MENU_LEAVE:
+        *running = 0;
+        break;
+    }
+}
+
+static void handle_event(const SDL_Event *e, float dt, int *running) {
+    if (s_pause_menu_open) {
+        switch (e->type) {
+        case SDL_QUIT:
+            break;
+
+        case SDL_KEYDOWN:
+            switch (e->key.keysym.sym) {
+            case SDLK_ESCAPE:
+                close_pause_menu(1);
+                break;
+            case SDLK_UP:
+            case SDLK_w:
+                if (!e->key.repeat) move_pause_menu_selection(-1);
+                break;
+            case SDLK_DOWN:
+            case SDLK_s:
+                if (!e->key.repeat) move_pause_menu_selection(1);
+                break;
+            case SDLK_RETURN:
+            case SDLK_KP_ENTER:
+            case SDLK_SPACE:
+                if (!e->key.repeat) activate_pause_menu_action(running);
+                break;
+            default:
+                break;
+            }
+            break;
+
+        case SDL_MOUSEMOTION:
+        {
+            int hover = ui_pause_menu_hit_test(e->motion.x, e->motion.y);
+            if (hover >= 0 && hover != s_pause_menu_selected) {
+                s_pause_menu_selected = hover;
+                sync_pause_menu_ui();
+            }
+        }   break;
+
+        case SDL_MOUSEBUTTONDOWN:
+            if (e->button.button == SDL_BUTTON_LEFT) {
+                int hover = ui_pause_menu_hit_test(e->button.x, e->button.y);
+                if (hover >= 0) {
+                    s_pause_menu_selected = hover;
+                    sync_pause_menu_ui();
+                    activate_pause_menu_action(running);
+                }
+            }
+            break;
+
+        case SDL_WINDOWEVENT:
+            if (e->window.event == SDL_WINDOWEVENT_SIZE_CHANGED ||
+                e->window.event == SDL_WINDOWEVENT_RESIZED) {
+                update_viewport_size();
+            }
+            break;
+
+        default:
+            break;
+        }
+        (void)dt;
+        return;
+    }
+
     switch (e->type) {
     case SDL_QUIT:
         /* handled in main loop */
@@ -191,11 +396,9 @@ static void handle_event(const SDL_Event *e, float dt) {
             s_warp = !s_warp;
             g_warp = s_warp;
             if (s_warp) {
-                /* Entering warp: clamp speed into the warp range */
                 if (g_cam.speed < WARP_SPEED_MIN_AU) g_cam.speed = WARP_SPEED_MIN_AU;
                 if (g_cam.speed > WARP_SPEED_MAX_AU) g_cam.speed = WARP_SPEED_MAX_AU;
             } else {
-                /* Leaving warp: clamp back to normal range */
                 if (g_cam.speed > WARP_SPEED_MIN_AU) g_cam.speed = WARP_SPEED_MIN_AU;
             }
             fprintf(stdout, "[Cam] warp %s (%.0f AU/s = %.4f ly/s)\n",
@@ -203,18 +406,19 @@ static void handle_event(const SDL_Event *e, float dt) {
                     (double)g_cam.speed,
                     (double)(g_cam.speed / WARP_SPEED_MAX_AU));
             break;
-        case SDLK_SPACE: g_paused = !g_paused; break;
+        case SDLK_SPACE:
+            g_paused = !g_paused;
+            break;
         case SDLK_ESCAPE:
             if (g_build_mode) {
                 build_toggle();
                 break;
             }
             if (s_freelook) {
-                s_freelook = 0;
-                SDL_SetRelativeMouseMode(SDL_FALSE);
+                open_pause_menu();
             }
             break;
-        case SDLK_EQUALS: /* + key */
+        case SDLK_EQUALS:
         case SDLK_PLUS:
             if (s_speed_idx < SPEED_TABLE_LEN - 1) s_speed_idx++;
             g_sim_speed = SPEED_TABLE[s_speed_idx] * DAY;
@@ -255,8 +459,6 @@ static void handle_event(const SDL_Event *e, float dt) {
 
     case SDL_MOUSEMOTION:
         if (s_freelook) {
-            /* xrel>0 = Maus nach rechts  → Kamera nach rechts → yaw steigt  */
-            /* yrel>0 = Maus nach unten   → Kamera nach unten  → pitch sinkt  */
             g_cam.yaw   += e->motion.xrel * s_mouse_sens;
             g_cam.pitch -= e->motion.yrel * s_mouse_sens;
             if (g_cam.pitch >  89.0f) g_cam.pitch =  89.0f;
@@ -271,7 +473,6 @@ static void handle_event(const SDL_Event *e, float dt) {
         }
         g_cam.speed *= (e->wheel.y > 0) ? 1.3f : (1.0f / 1.3f);
         if (s_warp) {
-            /* Warp range: 200 AU/s (0.003 ly/s) … 63 241 AU/s (1 ly/s) */
             if (g_cam.speed < WARP_SPEED_MIN_AU) g_cam.speed = WARP_SPEED_MIN_AU;
             if (g_cam.speed > WARP_SPEED_MAX_AU) g_cam.speed = WARP_SPEED_MAX_AU;
         } else {
@@ -323,48 +524,10 @@ int main(int argc, char **argv) {
 
     if (!app_init()) return 1;
 
-    /* Module initialisation */
-    universe_load("assets/universe.json");
-    cam_reset();
-    starfield_init();
-    trails_gl_init();
-    render_init();
-    rings_init("assets/universe.json");
-    asteroids_init("assets/universe.json");
-    labels_init();
+    collision_reset();
     ui_init();
-    build_init();
-    physics_refresh_timestep_model();
-
-    /* Trail warm-up: pre-simulate 2 years using RESPA.
-     * 730 outer steps × 50 inner steps = 36 500 inner steps total —
-     * identical resolution to the old 0.02-day loop but ~20× faster
-     * because slow forces are only evaluated at the outer (1-day) rate. */
-    {
-        const double WARMUP_DT = 365.0 * 2.0 * DAY;
-        int sys_n = physics_system_count();
-#ifdef _OPENMP
-#pragma omp parallel for schedule(dynamic)
-#endif
-        for (int s = 0; s < sys_n; s++) {
-            double step_outer = physics_system_outer_dt_limit(s);
-            double step_inner = physics_system_inner_dt_limit(s);
-            int n_inner = (int)(step_outer / step_inner) + 1;
-            int outer_total = (int)(WARMUP_DT / step_outer);
-            int root = physics_system_root(s);
-            for (int o = 0; o < outer_total; o++) {
-                double dt_outer = WARMUP_DT / outer_total;
-                double dt_inner = dt_outer / n_inner;
-                physics_respa_begin_system(root, dt_outer);
-                for (int i = 0; i < n_inner; i++) {
-                    physics_respa_inner_system(root, dt_inner);
-                }
-                physics_respa_end_system(root, dt_outer);
-                trails_tick_system(root, dt_outer);
-            }
-        }
-        physics_advance_time(WARMUP_DT);
-    }
+    sync_pause_menu_ui();
+    init_runtime_world();
 
     /* Timing */
     Uint64 freq    = SDL_GetPerformanceFrequency();
@@ -372,36 +535,23 @@ int main(int argc, char **argv) {
     int    running = 1;
 
     while (running) {
-        /* Delta time */
         Uint64 now = SDL_GetPerformanceCounter();
         float  dt  = (float)((double)(now - prev) / (double)freq);
-        if (dt > 0.1f) dt = 0.1f;   /* clamp huge frames on breakpoint */
+        if (dt > 0.1f) dt = 0.1f;
         prev = now;
 
-        /* Events */
         SDL_Event e;
         while (SDL_PollEvent(&e)) {
             if (e.type == SDL_QUIT) running = 0;
-            handle_event(&e, dt);
+            handle_event(&e, dt, &running);
         }
 
-        /* Camera */
-        camera_move(dt);
+        if (!s_pause_menu_open)
+            camera_move(dt);
 
-        /* Physics — RESPA hierarchical integrator
-         * Outer step ~1 day: slow forces (primary-primary + tidal).
-         * Inner step 0.02 days: fast forces (parent-satellite dominant).
-         * ~32× fewer pair evaluations than uniform 0.02-day stepping.
-         *
-         * sim_dt is capped to MAX_OUTER_STEPS outer steps so that a slow
-         * frame cannot snowball into even-slower subsequent frames (the
-         * lag-spiral).  At extreme sim speeds the simulation runs at a
-         * reduced rate rather than making the UI unresponsive.
-         *
-         * trails_tick is called every inner step so the acceleration-driven
-         * sampler sees the same local dynamics as the integrator itself. */
+        /* Physics - RESPA hierarchical integrator */
         if (!g_paused && g_sim_speed > 0.0) {
-            const int    MAX_OUTER_STEPS = 120;   /* per system cap */
+            const int MAX_OUTER_STEPS = 120;
             physics_refresh_timestep_model();
             {
                 int sys_n = physics_system_count();
@@ -439,11 +589,6 @@ int main(int argc, char **argv) {
                             physics_respa_inner_system(root, dt_inner);
                         }
                         physics_respa_end_system(root, dt_outer);
-                        /* Trail tick once per outer step instead of every inner step.
-                         * n_inner was typically 50, so this is ~50x fewer calls.
-                         * The Hermite curve over dt_outer correctly captures orbital
-                         * curvature for satellites; planets are flat enough at this
-                         * scale that subdivision terminates immediately. */
                         trails_tick_system(root, dt_outer);
                         if (local_encounter) {
                             collision_step_system(root, dt_outer);
@@ -467,32 +612,17 @@ int main(int argc, char **argv) {
         cam_get_dir(&fdx, &fdy, &fdz);
 
         float up[3] = { 0.0f, 1.0f, 0.0f };
-
-        /* Rotation-only view matrix built with a ZERO origin.
-         *
-         * The naive approach (eye = (float)g_cam.pos, ctr = eye + dir) suffers
-         * catastrophic cancellation at interstellar distances: at Barnard's Star
-         * eye[1] ≈ −365 000 AU and the float32 ULP is 0.031 AU, larger than the
-         * small direction component fdy = sin(1°) = 0.017.  The addition
-         * fl32(−365 000 + 0.017) rounds back to −365 000, so (ctr − eye).y = 0
-         * for several mouse pixels, then jumps a full ULP → stepwise rotation
-         * jitter in ALL axes wherever the camera offset is large.
-         *
-         * Fix: use eye = [0,0,0] so the forward vector is computed directly from
-         * [fdx, fdy, fdz] without any large-offset subtraction.  All body
-         * rendering is already camera-relative (body_pos − g_cam.pos in double),
-         * so no translation term is needed in this VP matrix anyway. */
         float dir[3]  = { fdx, fdy, fdz };
         float zero3[3] = { 0.0f, 0.0f, 0.0f };
         mat4_lookAt(view_rot, zero3, dir, up);
 
-        /* Full view matrix with float eye — kept for ring rendering.
-         * Rings are always near Sol so float32 is accurate enough there. */
-        float eye[3] = { (float)g_cam.pos[0], (float)g_cam.pos[1], (float)g_cam.pos[2] };
-        float ctr[3] = { eye[0]+fdx,          eye[1]+fdy,          eye[2]+fdz          };
-        mat4_lookAt(view, eye, ctr, up);
+        /* Full view matrix with float eye - kept for ring rendering. */
+        {
+            float eye[3] = { (float)g_cam.pos[0], (float)g_cam.pos[1], (float)g_cam.pos[2] };
+            float ctr[3] = { eye[0]+fdx,          eye[1]+fdy,          eye[2]+fdz          };
+            mat4_lookAt(view, eye, ctr, up);
+        }
 
-        /* Render */
         glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
         render_frame(view, proj, view_rot, dt);
         ui_render();

--- a/src/physics.c
+++ b/src/physics.c
@@ -21,18 +21,181 @@ double g_sim_time  = 0.0;
 double g_sim_speed = DAY;
 int    g_paused    = 0;
 
+#define OUTER_PERIOD_DIVISOR 24.0
+#define INNER_PERIOD_DIVISOR 96.0
+#define OUTER_DT_MIN (DAY * 0.05)
+#define INNER_DT_MIN 60.0
+#define INNER_DT_MAX (DAY * 0.02)
+#define OUTER_DT_DEFAULT DAY
+
+static double s_outer_dt_limit = OUTER_DT_DEFAULT;
+static double s_inner_dt_limit = INNER_DT_MAX;
+static int    s_system_roots[MAX_BODIES];
+static double s_system_outer_dt[MAX_BODIES];
+static double s_system_inner_dt[MAX_BODIES];
+static int    s_nsystems = 0;
+
+static int in_system(int i, int root)
+{
+    return root < 0 || body_root_star(i) == root;
+}
+
+static int ensure_system_slot(int root)
+{
+    for (int i = 0; i < s_nsystems; i++)
+        if (s_system_roots[i] == root) return i;
+    if (s_nsystems >= MAX_BODIES) return -1;
+    s_system_roots[s_nsystems] = root;
+    s_system_outer_dt[s_nsystems] = OUTER_DT_DEFAULT;
+    s_system_inner_dt[s_nsystems] = INNER_DT_MAX;
+    return s_nsystems++;
+}
+
+static int timestep_anchor(int i)
+{
+    if (i < 0 || i >= g_nbodies || !g_bodies[i].alive) return -1;
+    if (g_bodies[i].parent >= 0 && g_bodies[g_bodies[i].parent].alive)
+        return g_bodies[i].parent;
+
+    int best = -1;
+    double best_score = 1e300;
+    for (int j = 0; j < g_nbodies; j++) {
+        if (j == i || !g_bodies[j].alive) continue;
+        if (g_bodies[j].mass <= 0.0) continue;
+        double dx = g_bodies[j].pos[0] - g_bodies[i].pos[0];
+        double dy = g_bodies[j].pos[1] - g_bodies[i].pos[1];
+        double dz = g_bodies[j].pos[2] - g_bodies[i].pos[2];
+        double r2 = dx*dx + dy*dy + dz*dz;
+        if (r2 <= 0.0) continue;
+        double score = r2 / g_bodies[j].mass;
+        if (score < best_score) {
+            best_score = score;
+            best = j;
+        }
+    }
+    return best;
+}
+
+static double estimate_period_about(int i, int anchor)
+{
+    if (i < 0 || anchor < 0 || i >= g_nbodies || anchor >= g_nbodies) return 0.0;
+    if (!g_bodies[i].alive || !g_bodies[anchor].alive) return 0.0;
+    double dx = g_bodies[i].pos[0] - g_bodies[anchor].pos[0];
+    double dy = g_bodies[i].pos[1] - g_bodies[anchor].pos[1];
+    double dz = g_bodies[i].pos[2] - g_bodies[anchor].pos[2];
+    double r = sqrt(dx*dx + dy*dy + dz*dz);
+    double gm = G_CONST * (g_bodies[i].mass + g_bodies[anchor].mass);
+    if (r <= 0.0 || gm <= 0.0) return 0.0;
+    return 2.0 * PI * sqrt(r * r * r / gm);
+}
+
 /* ── helpers ─────────────────────────────────────────────────────────── */
 /* A body is a satellite (moon) if it has a parent and that parent is not a star.
  * Stars   (parent=-1)          → false  — primary body
  * Planets (parent=star_idx)    → false  — primary body, fast forces not used
  * Moons   (parent=planet_idx)  → true   — handled by fast forces */
 static int is_satellite(int i) {
+    if (!g_bodies[i].alive) return 0;
     return g_bodies[i].parent >= 0 && !g_bodies[g_bodies[i].parent].is_star;
 }
 
 /* Any explicit parent-child pair is integrated at the inner cadence. */
 static int has_fast_parent(int i) {
+    if (!g_bodies[i].alive) return 0;
     return g_bodies[i].parent >= 0;
+}
+
+void physics_refresh_timestep_model(void)
+{
+    double best_outer = OUTER_DT_DEFAULT;
+    double best_inner = INNER_DT_MAX;
+    s_nsystems = 0;
+
+    for (int i = 0; i < g_nbodies; i++) {
+        if (g_bodies[i].alive && g_bodies[i].is_star)
+            ensure_system_slot(i);
+    }
+
+    for (int i = 0; i < g_nbodies; i++) {
+        Body *b = &g_bodies[i];
+        b->dyn_period = 0.0;
+        b->dyn_dt_outer = OUTER_DT_DEFAULT;
+        b->dyn_dt_inner = INNER_DT_MAX;
+        b->dyn_bucket = 0;
+
+        if (!b->alive || b->is_star) continue;
+
+        int anchor = timestep_anchor(i);
+        double T = estimate_period_about(i, anchor);
+        if (T <= 0.0) continue;
+
+        double dt_outer = T / OUTER_PERIOD_DIVISOR;
+        double dt_inner = T / INNER_PERIOD_DIVISOR;
+        if (dt_outer < OUTER_DT_MIN) dt_outer = OUTER_DT_MIN;
+        if (dt_outer > OUTER_DT_DEFAULT) dt_outer = OUTER_DT_DEFAULT;
+        if (dt_inner < INNER_DT_MIN) dt_inner = INNER_DT_MIN;
+        if (dt_inner > INNER_DT_MAX) dt_inner = INNER_DT_MAX;
+
+        b->dyn_period = T;
+        b->dyn_dt_outer = dt_outer;
+        b->dyn_dt_inner = dt_inner;
+        if (dt_inner <= 10.0 * 60.0) b->dyn_bucket = 3;
+        else if (dt_inner <= 60.0 * 60.0) b->dyn_bucket = 2;
+        else if (dt_inner <= 6.0 * 60.0 * 60.0) b->dyn_bucket = 1;
+
+        {
+            int root = body_root_star(i);
+            int slot = ensure_system_slot(root);
+            if (slot >= 0) {
+                if (dt_outer < s_system_outer_dt[slot]) s_system_outer_dt[slot] = dt_outer;
+                if (b->parent >= 0 && dt_inner < s_system_inner_dt[slot]) s_system_inner_dt[slot] = dt_inner;
+            }
+        }
+
+        if (dt_outer < best_outer) best_outer = dt_outer;
+        if (b->parent >= 0 && dt_inner < best_inner) best_inner = dt_inner;
+    }
+
+    s_outer_dt_limit = best_outer;
+    s_inner_dt_limit = best_inner;
+}
+
+double physics_outer_dt_limit(void)
+{
+    return s_outer_dt_limit;
+}
+
+double physics_inner_dt_limit(void)
+{
+    return s_inner_dt_limit;
+}
+
+int physics_system_count(void)
+{
+    return s_nsystems;
+}
+
+int physics_system_root(int idx)
+{
+    if (idx < 0 || idx >= s_nsystems) return -1;
+    return s_system_roots[idx];
+}
+
+double physics_system_outer_dt_limit(int idx)
+{
+    if (idx < 0 || idx >= s_nsystems) return OUTER_DT_DEFAULT;
+    return s_system_outer_dt[idx];
+}
+
+double physics_system_inner_dt_limit(int idx)
+{
+    if (idx < 0 || idx >= s_nsystems) return INNER_DT_MAX;
+    return s_system_inner_dt[idx];
+}
+
+void physics_advance_time(double dt)
+{
+    g_sim_time += dt;
 }
 
 static int is_ancestor_of(int ancestor, int child) {
@@ -45,51 +208,63 @@ static int is_ancestor_of(int ancestor, int child) {
 }
 
 /* ── slow forces: primary-primary + non-parent tidal on satellites ───── */
-static void compute_acc_slow(void) {
+static void compute_acc_slow_system(int root) {
     int i, j;
     for (i = 0; i < g_nbodies; i++)
-        g_bodies[i].acc[0] = g_bodies[i].acc[1] = g_bodies[i].acc[2] = 0.0;
+        if (in_system(i, root))
+            g_bodies[i].acc[0] = g_bodies[i].acc[1] = g_bodies[i].acc[2] = 0.0;
 
     for (i = 0; i < g_nbodies; i++) {
-        for (j = i + 1; j < g_nbodies; j++) {
+        if (!g_bodies[i].alive || !in_system(i, root)) continue;
+        for (j = 0; j < g_nbodies; j++) {
+            int same_system;
+            double dx, dy, dz, r2, r, f;
+
+            if (j == i || !g_bodies[j].alive) continue;
+
+            same_system = in_system(j, root);
+            if (same_system && j < i) continue;
+
             /* skip satellite-satellite (negligible and expensive) */
             if (is_satellite(i) && is_satellite(j)) continue;
             /* skip parent-satellite pair — handled by fast forces */
-            if (is_ancestor_of(i, j) || is_ancestor_of(j, i)) continue;
+            if (same_system && (is_ancestor_of(i, j) || is_ancestor_of(j, i))) continue;
 
-            double dx = g_bodies[j].pos[0] - g_bodies[i].pos[0];
-            double dy = g_bodies[j].pos[1] - g_bodies[i].pos[1];
-            double dz = g_bodies[j].pos[2] - g_bodies[i].pos[2];
-            double r2 = dx*dx + dy*dy + dz*dz + SOFTENING*SOFTENING;
-            /* Skip negligible cross-system pairs (e.g. Sol's gravity on Alpha Cen planets) */
+            dx = g_bodies[j].pos[0] - g_bodies[i].pos[0];
+            dy = g_bodies[j].pos[1] - g_bodies[i].pos[1];
+            dz = g_bodies[j].pos[2] - g_bodies[i].pos[2];
+            r2 = dx*dx + dy*dy + dz*dz + SOFTENING*SOFTENING;
             if (G_CONST * g_bodies[j].mass / r2 < GRAV_EPSILON &&
                 G_CONST * g_bodies[i].mass / r2 < GRAV_EPSILON) continue;
-            double r  = sqrt(r2);
-            double f  = G_CONST / (r2 * r);
+            r  = sqrt(r2);
+            f  = G_CONST / (r2 * r);
 
-            double ai = f * g_bodies[j].mass;
-            double aj = f * g_bodies[i].mass;
+            g_bodies[i].acc[0] += f * g_bodies[j].mass * dx;
+            g_bodies[i].acc[1] += f * g_bodies[j].mass * dy;
+            g_bodies[i].acc[2] += f * g_bodies[j].mass * dz;
 
-            g_bodies[i].acc[0] += ai * dx;
-            g_bodies[i].acc[1] += ai * dy;
-            g_bodies[i].acc[2] += ai * dz;
-            g_bodies[j].acc[0] -= aj * dx;
-            g_bodies[j].acc[1] -= aj * dy;
-            g_bodies[j].acc[2] -= aj * dz;
+            if (same_system) {
+                g_bodies[j].acc[0] -= f * g_bodies[i].mass * dx;
+                g_bodies[j].acc[1] -= f * g_bodies[i].mass * dy;
+                g_bodies[j].acc[2] -= f * g_bodies[i].mass * dz;
+            }
         }
     }
 }
 
 /* ── fast forces: dominant parent → satellite (+ Newton 3rd reaction) ── */
-static void compute_acc_fast(void) {
+static void compute_acc_fast_system(int root) {
     int i;
     for (i = 0; i < g_nbodies; i++)
-        g_bodies[i].fast_acc[0] = g_bodies[i].fast_acc[1] =
-        g_bodies[i].fast_acc[2] = 0.0;
+        if (in_system(i, root))
+            g_bodies[i].fast_acc[0] = g_bodies[i].fast_acc[1] =
+            g_bodies[i].fast_acc[2] = 0.0;
 
     for (i = 0; i < g_nbodies; i++) {
+        if (!g_bodies[i].alive || !in_system(i, root)) continue;
         if (!has_fast_parent(i)) continue;
         for (int p = g_bodies[i].parent; p >= 0; p = g_bodies[p].parent) {
+            if (!g_bodies[p].alive || !in_system(p, root)) continue;
             double dx = g_bodies[p].pos[0] - g_bodies[i].pos[0];
             double dy = g_bodies[p].pos[1] - g_bodies[i].pos[1];
             double dz = g_bodies[p].pos[2] - g_bodies[i].pos[2];
@@ -118,16 +293,21 @@ static void compute_acc_fast(void) {
  * for the carry-over into the first inner step.
  */
 void physics_respa_begin(double dt_outer) {
+    physics_respa_begin_system(-1, dt_outer);
+}
+
+void physics_respa_begin_system(int root, double dt_outer) {
     int i;
-    compute_acc_slow();
+    compute_acc_slow_system(root);
     for (i = 0; i < g_nbodies; i++) {
+        if (!g_bodies[i].alive || !in_system(i, root)) continue;
         g_bodies[i].vel[0] += 0.5 * g_bodies[i].acc[0] * dt_outer;
         g_bodies[i].vel[1] += 0.5 * g_bodies[i].acc[1] * dt_outer;
         g_bodies[i].vel[2] += 0.5 * g_bodies[i].acc[2] * dt_outer;
     }
     /* Pre-compute fast forces so physics_respa_inner can use them
      * immediately without an extra evaluation (carry-over trick). */
-    compute_acc_fast();
+    compute_acc_fast_system(root);
 }
 
 /*
@@ -136,22 +316,29 @@ void physics_respa_begin(double dt_outer) {
  * Leaves fast_acc valid for the next call (carry-over).
  */
 void physics_respa_inner(double dt_inner) {
+    physics_respa_inner_system(-1, dt_inner);
+}
+
+void physics_respa_inner_system(int root, double dt_inner) {
     int i;
     /* fast half-kick (uses fast_acc from previous compute_acc_fast) */
     for (i = 0; i < g_nbodies; i++) {
+        if (!g_bodies[i].alive || !in_system(i, root)) continue;
         g_bodies[i].vel[0] += 0.5 * g_bodies[i].fast_acc[0] * dt_inner;
         g_bodies[i].vel[1] += 0.5 * g_bodies[i].fast_acc[1] * dt_inner;
         g_bodies[i].vel[2] += 0.5 * g_bodies[i].fast_acc[2] * dt_inner;
     }
     /* drift all bodies */
     for (i = 0; i < g_nbodies; i++) {
+        if (!g_bodies[i].alive || !in_system(i, root)) continue;
         g_bodies[i].pos[0] += g_bodies[i].vel[0] * dt_inner;
         g_bodies[i].pos[1] += g_bodies[i].vel[1] * dt_inner;
         g_bodies[i].pos[2] += g_bodies[i].vel[2] * dt_inner;
     }
     /* recompute fast forces at new positions, then fast half-kick */
-    compute_acc_fast();
+    compute_acc_fast_system(root);
     for (i = 0; i < g_nbodies; i++) {
+        if (!g_bodies[i].alive || !in_system(i, root)) continue;
         g_bodies[i].vel[0] += 0.5 * g_bodies[i].fast_acc[0] * dt_inner;
         g_bodies[i].vel[1] += 0.5 * g_bodies[i].fast_acc[1] * dt_inner;
         g_bodies[i].vel[2] += 0.5 * g_bodies[i].fast_acc[2] * dt_inner;
@@ -163,20 +350,26 @@ void physics_respa_inner(double dt_inner) {
  * sim-time advance.
  */
 void physics_respa_end(double dt_outer) {
+    physics_respa_end_system(-1, dt_outer);
+    physics_advance_time(dt_outer);
+}
+
+void physics_respa_end_system(int root, double dt_outer) {
     int i;
-    compute_acc_slow();
+    compute_acc_slow_system(root);
     for (i = 0; i < g_nbodies; i++) {
+        if (!g_bodies[i].alive || !in_system(i, root)) continue;
         g_bodies[i].vel[0] += 0.5 * g_bodies[i].acc[0] * dt_outer;
         g_bodies[i].vel[1] += 0.5 * g_bodies[i].acc[1] * dt_outer;
         g_bodies[i].vel[2] += 0.5 * g_bodies[i].acc[2] * dt_outer;
     }
     /* axial rotation */
     for (i = 0; i < g_nbodies; i++) {
+        if (!g_bodies[i].alive || !in_system(i, root)) continue;
         g_bodies[i].rotation_angle = fmod(
             g_bodies[i].rotation_angle + g_bodies[i].rotation_rate * dt_outer,
             2.0 * PI);
     }
-    g_sim_time += dt_outer;
 }
 
 /* ── legacy single-step KDK (not used in main loop) ─────────────────── */
@@ -185,7 +378,9 @@ static void compute_acc(void) {
     for (i = 0; i < g_nbodies; i++)
         g_bodies[i].acc[0] = g_bodies[i].acc[1] = g_bodies[i].acc[2] = 0.0;
     for (i = 0; i < g_nbodies; i++) {
+        if (!g_bodies[i].alive) continue;
         for (j = i + 1; j < g_nbodies; j++) {
+            if (!g_bodies[j].alive) continue;
             double dx = g_bodies[j].pos[0] - g_bodies[i].pos[0];
             double dy = g_bodies[j].pos[1] - g_bodies[i].pos[1];
             double dz = g_bodies[j].pos[2] - g_bodies[i].pos[2];
@@ -204,22 +399,26 @@ void physics_step(double dt) {
     int i;
     compute_acc();
     for (i = 0; i < g_nbodies; i++) {
+        if (!g_bodies[i].alive) continue;
         g_bodies[i].vel[0] += 0.5 * g_bodies[i].acc[0] * dt;
         g_bodies[i].vel[1] += 0.5 * g_bodies[i].acc[1] * dt;
         g_bodies[i].vel[2] += 0.5 * g_bodies[i].acc[2] * dt;
     }
     for (i = 0; i < g_nbodies; i++) {
+        if (!g_bodies[i].alive) continue;
         g_bodies[i].pos[0] += g_bodies[i].vel[0] * dt;
         g_bodies[i].pos[1] += g_bodies[i].vel[1] * dt;
         g_bodies[i].pos[2] += g_bodies[i].vel[2] * dt;
     }
     compute_acc();
     for (i = 0; i < g_nbodies; i++) {
+        if (!g_bodies[i].alive) continue;
         g_bodies[i].vel[0] += 0.5 * g_bodies[i].acc[0] * dt;
         g_bodies[i].vel[1] += 0.5 * g_bodies[i].acc[1] * dt;
         g_bodies[i].vel[2] += 0.5 * g_bodies[i].acc[2] * dt;
     }
     for (i = 0; i < g_nbodies; i++) {
+        if (!g_bodies[i].alive) continue;
         g_bodies[i].rotation_angle = fmod(
             g_bodies[i].rotation_angle + g_bodies[i].rotation_rate * dt,
             2.0 * PI);
@@ -246,10 +445,14 @@ static void sample_body(Body *b) {
  * buffer faster at high speeds, naturally showing more orbital history.
  */
 void trails_tick(double dt) {
+    trails_tick_system(-1, dt);
+}
+
+void trails_tick_system(int root, double dt) {
     int i;
     for (i = 0; i < g_nbodies; i++) {
         Body *b = &g_bodies[i];
-        if (!b->trail || b->trail_interval <= 0.0) continue;
+        if (!b->alive || !in_system(i, root) || !b->trail || b->trail_interval <= 0.0) continue;
         b->trail_accum += dt;
         while (b->trail_accum >= b->trail_interval) {
             b->trail_accum -= b->trail_interval;

--- a/src/physics.c
+++ b/src/physics.c
@@ -101,8 +101,7 @@ static int is_satellite(int i) {
 
 /* Any explicit parent-child pair is integrated at the inner cadence. */
 static int has_fast_parent(int i) {
-    if (!g_bodies[i].alive) return 0;
-    return g_bodies[i].parent >= 0;
+    return is_satellite(i);
 }
 
 void physics_refresh_timestep_model(void)
@@ -148,12 +147,12 @@ void physics_refresh_timestep_model(void)
             int slot = ensure_system_slot(root);
             if (slot >= 0) {
                 if (dt_outer < s_system_outer_dt[slot]) s_system_outer_dt[slot] = dt_outer;
-                if (b->parent >= 0 && dt_inner < s_system_inner_dt[slot]) s_system_inner_dt[slot] = dt_inner;
+                if (is_satellite(i) && dt_inner < s_system_inner_dt[slot]) s_system_inner_dt[slot] = dt_inner;
             }
         }
 
         if (dt_outer < best_outer) best_outer = dt_outer;
-        if (b->parent >= 0 && dt_inner < best_inner) best_inner = dt_inner;
+        if (is_satellite(i) && dt_inner < best_inner) best_inner = dt_inner;
     }
 
     s_outer_dt_limit = best_outer;
@@ -227,8 +226,10 @@ static void compute_acc_slow_system(int root) {
 
             /* skip satellite-satellite (negligible and expensive) */
             if (is_satellite(i) && is_satellite(j)) continue;
-            /* skip parent-satellite pair — handled by fast forces */
-            if (same_system && (is_ancestor_of(i, j) || is_ancestor_of(j, i))) continue;
+            /* skip only true moon-parent chains here — planet-star stays slow */
+            if (same_system &&
+                ((is_satellite(j) && is_ancestor_of(i, j)) ||
+                 (is_satellite(i) && is_ancestor_of(j, i)))) continue;
 
             dx = g_bodies[j].pos[0] - g_bodies[i].pos[0];
             dy = g_bodies[j].pos[1] - g_bodies[i].pos[1];

--- a/src/physics.c
+++ b/src/physics.c
@@ -483,24 +483,53 @@ void physics_step(double dt) {
 
 /* ── trail helpers ───────────────────────────────────────────────────── */
 static void sample_body_pos(Body *b, const double pos[3]) {
+    int write_idx = b->trail_head;
+    double seg_len = 0.0;
+    double target_world_len = TRAIL_TARGET_WORLD_LEN;
+    int body_idx = (int)(b - g_bodies);
+
+    if (body_idx >= 0 && body_idx < g_nbodies && is_satellite(body_idx))
+        target_world_len = TRAIL_SATELLITE_WORLD_LEN;
+
+    if (b->trail_count > 0) {
+        int prev_idx = (b->trail_head - 1 + TRAIL_LEN) % TRAIL_LEN;
+        double dx = pos[0] * RS - b->trail[prev_idx][0];
+        double dy = pos[1] * RS - b->trail[prev_idx][1];
+        double dz = pos[2] * RS - b->trail[prev_idx][2];
+        seg_len = sqrt(dx*dx + dy*dy + dz*dz) * AU;
+    }
+
     b->trail[b->trail_head][0] = pos[0] * RS;
     b->trail[b->trail_head][1] = pos[1] * RS;
     b->trail[b->trail_head][2] = pos[2] * RS;
+    if (b->trail_seg_len) b->trail_seg_len[write_idx] = seg_len;
     b->trail_head = (b->trail_head + 1) % TRAIL_LEN;
-    if (b->trail_count < TRAIL_LEN) b->trail_count++;
+    if (b->trail_count < TRAIL_LEN) {
+        b->trail_count++;
+        b->trail_total_len += seg_len;
+    } else {
+        int oldest_idx = b->trail_head;
+        int next_oldest_idx = (oldest_idx + 1) % TRAIL_LEN;
+        if (b->trail_seg_len)
+            b->trail_total_len += seg_len - b->trail_seg_len[next_oldest_idx];
+        else
+            b->trail_total_len += seg_len;
+    }
+
+    while (b->trail_count > 2 && b->trail_total_len > target_world_len) {
+        int oldest_idx = (b->trail_head - b->trail_count + TRAIL_LEN) % TRAIL_LEN;
+        int next_oldest_idx = (oldest_idx + 1) % TRAIL_LEN;
+        double drop_len = b->trail_seg_len ? b->trail_seg_len[next_oldest_idx] : 0.0;
+        b->trail_total_len -= drop_len;
+        if (b->trail_total_len < 0.0) b->trail_total_len = 0.0;
+        b->trail_count--;
+    }
 }
 
 static double trail_segment_len_for_accel(const Body *b)
 {
-    double ax = b->acc[0] + b->fast_acc[0];
-    double ay = b->acc[1] + b->fast_acc[1];
-    double az = b->acc[2] + b->fast_acc[2];
-    double amag = sqrt(ax*ax + ay*ay + az*az);
-    double segment_len = TRAIL_SEGMENT_SCALE / sqrt(amag + TRAIL_ACCEL_EPS);
-    int body_idx = (int)(b - g_bodies);
-
-    if (body_idx >= 0 && body_idx < g_nbodies && is_satellite(body_idx))
-        segment_len *= (1.0 / 3.0);
+    double segment_len = TRAIL_BASE_SEGMENT_LEN;
+    (void)b;
 
     if (segment_len < TRAIL_MIN_SEGMENT_LEN) segment_len = TRAIL_MIN_SEGMENT_LEN;
     if (segment_len > TRAIL_MAX_SEGMENT_LEN) segment_len = TRAIL_MAX_SEGMENT_LEN;
@@ -641,6 +670,7 @@ void trails_begin_frame_snapshot(void)
         b->trail_frame_accum = b->trail_accum;
         b->trail_frame_head = b->trail_head;
         b->trail_frame_count = b->trail_count;
+        b->trail_frame_total_len = b->trail_total_len;
         b->trail_frame_pos[0] = b->pos[0];
         b->trail_frame_pos[1] = b->pos[1];
         b->trail_frame_pos[2] = b->pos[2];
@@ -670,6 +700,7 @@ void trails_cut_body_at_time(int body_idx, double hit_dt, double frame_dt,
     b->trail_head = b->trail_frame_head;
     b->trail_count = b->trail_frame_count;
     b->trail_accum = b->trail_frame_accum;
+    b->trail_total_len = b->trail_frame_total_len;
     b->trail_prev_pos[0] = b->trail_frame_prev_pos[0];
     b->trail_prev_pos[1] = b->trail_frame_prev_pos[1];
     b->trail_prev_pos[2] = b->trail_frame_prev_pos[2];

--- a/src/physics.c
+++ b/src/physics.c
@@ -529,7 +529,10 @@ static void sample_body_pos(Body *b, const double pos[3]) {
 static double trail_segment_len_for_accel(const Body *b)
 {
     double segment_len = TRAIL_BASE_SEGMENT_LEN;
-    (void)b;
+    int body_idx = (int)(b - g_bodies);
+
+    if (body_idx >= 0 && body_idx < g_nbodies && is_satellite(body_idx))
+        segment_len = TRAIL_SATELLITE_SEGMENT_LEN;
 
     if (segment_len < TRAIL_MIN_SEGMENT_LEN) segment_len = TRAIL_MIN_SEGMENT_LEN;
     if (segment_len > TRAIL_MAX_SEGMENT_LEN) segment_len = TRAIL_MAX_SEGMENT_LEN;

--- a/src/physics.c
+++ b/src/physics.c
@@ -15,6 +15,7 @@
  */
 #include "physics.h"
 #include "body.h"
+#include "collision.h"
 #include <math.h>
 
 double g_sim_time  = 0.0;
@@ -35,6 +36,10 @@ static double s_inner_dt_limit = INNER_DT_MAX;
 static int    s_system_roots[MAX_BODIES];
 static double s_system_outer_dt[MAX_BODIES];
 static double s_system_inner_dt[MAX_BODIES];
+static int    s_root_to_slot[MAX_BODIES];
+static int    s_body_system_slot[MAX_BODIES];
+static int    s_system_members[MAX_BODIES][MAX_BODIES];
+static int    s_system_member_count[MAX_BODIES];
 static int    s_nsystems = 0;
 
 static int is_satellite(int i);
@@ -42,17 +47,27 @@ static int is_ancestor_of(int ancestor, int child);
 
 static int in_system(int i, int root)
 {
-    return root < 0 || body_root_star(i) == root;
+    int slot;
+
+    if (root < 0) return 1;
+    if (i < 0 || i >= g_nbodies || i >= MAX_BODIES) return 0;
+    if (root >= MAX_BODIES) return 0;
+    slot = s_root_to_slot[root];
+    return slot >= 0 && s_body_system_slot[i] == slot;
 }
 
 static int ensure_system_slot(int root)
 {
+    if (root < 0 || root >= MAX_BODIES) return -1;
+    if (s_root_to_slot[root] >= 0) return s_root_to_slot[root];
     for (int i = 0; i < s_nsystems; i++)
         if (s_system_roots[i] == root) return i;
     if (s_nsystems >= MAX_BODIES) return -1;
     s_system_roots[s_nsystems] = root;
     s_system_outer_dt[s_nsystems] = OUTER_DT_DEFAULT;
     s_system_inner_dt[s_nsystems] = INNER_DT_MAX;
+    s_system_member_count[s_nsystems] = 0;
+    s_root_to_slot[root] = s_nsystems;
     return s_nsystems++;
 }
 
@@ -150,9 +165,28 @@ void physics_refresh_timestep_model(void)
     double best_inner = INNER_DT_MAX;
     s_nsystems = 0;
 
+    for (int i = 0; i < MAX_BODIES; i++) {
+        s_root_to_slot[i] = -1;
+        s_body_system_slot[i] = -1;
+        s_system_member_count[i] = 0;
+    }
+
     for (int i = 0; i < g_nbodies; i++) {
         if (g_bodies[i].alive && g_bodies[i].is_star)
             ensure_system_slot(i);
+    }
+
+    for (int i = 0; i < g_nbodies && i < MAX_BODIES; i++) {
+        int root, slot;
+
+        if (!g_bodies[i].alive) continue;
+        root = body_root_star(i);
+        slot = ensure_system_slot(root);
+        if (slot < 0) continue;
+
+        s_body_system_slot[i] = slot;
+        if (s_system_member_count[slot] < MAX_BODIES)
+            s_system_members[slot][s_system_member_count[slot]++] = i;
     }
 
     for (int i = 0; i < g_nbodies; i++) {
@@ -198,9 +232,8 @@ void physics_refresh_timestep_model(void)
         else if (dt_inner <= 60.0 * 60.0) b->dyn_bucket = 2;
         else if (dt_inner <= 6.0 * 60.0 * 60.0) b->dyn_bucket = 1;
 
-        {
-            int root = body_root_star(i);
-            int slot = ensure_system_slot(root);
+        if (i < MAX_BODIES) {
+            int slot = s_body_system_slot[i];
             if (slot >= 0) {
                 if (dt_outer < s_system_outer_dt[slot]) s_system_outer_dt[slot] = dt_outer;
                 if (is_satellite(i) && dt_inner < s_system_inner_dt[slot]) s_system_inner_dt[slot] = dt_inner;
@@ -265,19 +298,71 @@ static int is_ancestor_of(int ancestor, int child) {
 /* ── slow forces: primary-primary + non-parent tidal on satellites ───── */
 static void compute_acc_slow_system(int root) {
     int i, j;
-    for (i = 0; i < g_nbodies; i++)
-        if (in_system(i, root))
-            g_bodies[i].acc[0] = g_bodies[i].acc[1] = g_bodies[i].acc[2] = 0.0;
+    int slot = (root >= 0 && root < MAX_BODIES) ? s_root_to_slot[root] : -1;
 
-    for (i = 0; i < g_nbodies; i++) {
-        if (!g_bodies[i].alive || !in_system(i, root)) continue;
+    if (root < 0 || slot < 0) {
+        for (i = 0; i < g_nbodies; i++)
+            if (in_system(i, root))
+                g_bodies[i].acc[0] = g_bodies[i].acc[1] = g_bodies[i].acc[2] = 0.0;
+    } else {
+        for (int mi = 0; mi < s_system_member_count[slot]; mi++) {
+            i = s_system_members[slot][mi];
+            g_bodies[i].acc[0] = g_bodies[i].acc[1] = g_bodies[i].acc[2] = 0.0;
+        }
+    }
+
+    if (root < 0 || slot < 0) {
+        for (i = 0; i < g_nbodies; i++) {
+            if (!g_bodies[i].alive || !in_system(i, root)) continue;
+            for (j = 0; j < g_nbodies; j++) {
+                int same_system;
+                double dx, dy, dz, r2, r, f;
+
+                if (j == i || !g_bodies[j].alive) continue;
+
+                same_system = in_system(j, root);
+                if (same_system && j < i) continue;
+
+                /* skip satellite-satellite (negligible and expensive) */
+                if (is_satellite(i) && is_satellite(j)) continue;
+                /* skip only true moon-parent chains here — planet-star stays slow */
+                if (same_system &&
+                    ((is_satellite(j) && is_ancestor_of(i, j)) ||
+                     (is_satellite(i) && is_ancestor_of(j, i)))) continue;
+
+                dx = g_bodies[j].pos[0] - g_bodies[i].pos[0];
+                dy = g_bodies[j].pos[1] - g_bodies[i].pos[1];
+                dz = g_bodies[j].pos[2] - g_bodies[i].pos[2];
+                r2 = dx*dx + dy*dy + dz*dz + SOFTENING*SOFTENING;
+                if (G_CONST * g_bodies[j].mass / r2 < GRAV_EPSILON &&
+                    G_CONST * g_bodies[i].mass / r2 < GRAV_EPSILON) continue;
+                r  = sqrt(r2);
+                f  = G_CONST / (r2 * r);
+
+                g_bodies[i].acc[0] += f * g_bodies[j].mass * dx;
+                g_bodies[i].acc[1] += f * g_bodies[j].mass * dy;
+                g_bodies[i].acc[2] += f * g_bodies[j].mass * dz;
+
+                if (same_system) {
+                    g_bodies[j].acc[0] -= f * g_bodies[i].mass * dx;
+                    g_bodies[j].acc[1] -= f * g_bodies[i].mass * dy;
+                    g_bodies[j].acc[2] -= f * g_bodies[i].mass * dz;
+                }
+            }
+        }
+        return;
+    }
+
+    for (int mi = 0; mi < s_system_member_count[slot]; mi++) {
+        i = s_system_members[slot][mi];
+        if (!g_bodies[i].alive) continue;
         for (j = 0; j < g_nbodies; j++) {
             int same_system;
             double dx, dy, dz, r2, r, f;
 
             if (j == i || !g_bodies[j].alive) continue;
 
-            same_system = in_system(j, root);
+            same_system = (j >= 0 && j < MAX_BODIES && s_body_system_slot[j] == slot);
             if (same_system && j < i) continue;
 
             /* skip satellite-satellite (negligible and expensive) */
@@ -312,13 +397,50 @@ static void compute_acc_slow_system(int root) {
 /* ── fast forces: dominant parent → satellite (+ Newton 3rd reaction) ── */
 static void compute_acc_fast_system(int root) {
     int i;
-    for (i = 0; i < g_nbodies; i++)
-        if (in_system(i, root))
-            g_bodies[i].fast_acc[0] = g_bodies[i].fast_acc[1] =
-            g_bodies[i].fast_acc[2] = 0.0;
+    int slot = (root >= 0 && root < MAX_BODIES) ? s_root_to_slot[root] : -1;
 
-    for (i = 0; i < g_nbodies; i++) {
-        if (!g_bodies[i].alive || !in_system(i, root)) continue;
+    if (root < 0 || slot < 0) {
+        for (i = 0; i < g_nbodies; i++)
+            if (in_system(i, root))
+                g_bodies[i].fast_acc[0] = g_bodies[i].fast_acc[1] =
+                g_bodies[i].fast_acc[2] = 0.0;
+
+        for (i = 0; i < g_nbodies; i++) {
+            if (!g_bodies[i].alive || !in_system(i, root)) continue;
+            if (!has_fast_parent(i)) continue;
+            for (int p = g_bodies[i].parent; p >= 0; p = g_bodies[p].parent) {
+                if (!g_bodies[p].alive || !in_system(p, root)) continue;
+                double dx = g_bodies[p].pos[0] - g_bodies[i].pos[0];
+                double dy = g_bodies[p].pos[1] - g_bodies[i].pos[1];
+                double dz = g_bodies[p].pos[2] - g_bodies[i].pos[2];
+                double r2 = dx*dx + dy*dy + dz*dz + SOFTENING*SOFTENING;
+                if (G_CONST * g_bodies[p].mass / r2 < GRAV_EPSILON) continue;
+                double r  = sqrt(r2);
+                double f  = G_CONST / (r2 * r);
+
+            /* satellite accelerated toward parent */
+                g_bodies[i].fast_acc[0] += f * g_bodies[p].mass * dx;
+                g_bodies[i].fast_acc[1] += f * g_bodies[p].mass * dy;
+                g_bodies[i].fast_acc[2] += f * g_bodies[p].mass * dz;
+
+            /* reaction on parent (Newton 3rd — small but correct) */
+                g_bodies[p].fast_acc[0] -= f * g_bodies[i].mass * dx;
+                g_bodies[p].fast_acc[1] -= f * g_bodies[i].mass * dy;
+                g_bodies[p].fast_acc[2] -= f * g_bodies[i].mass * dz;
+            }
+        }
+        return;
+    }
+
+    for (int mi = 0; mi < s_system_member_count[slot]; mi++) {
+        i = s_system_members[slot][mi];
+        g_bodies[i].fast_acc[0] = g_bodies[i].fast_acc[1] =
+        g_bodies[i].fast_acc[2] = 0.0;
+    }
+
+    for (int mi = 0; mi < s_system_member_count[slot]; mi++) {
+        i = s_system_members[slot][mi];
+        if (!g_bodies[i].alive) continue;
         if (!has_fast_parent(i)) continue;
         for (int p = g_bodies[i].parent; p >= 0; p = g_bodies[p].parent) {
             if (!g_bodies[p].alive || !in_system(p, root)) continue;
@@ -355,12 +477,23 @@ void physics_respa_begin(double dt_outer) {
 
 void physics_respa_begin_system(int root, double dt_outer) {
     int i;
+    int slot = (root >= 0 && root < MAX_BODIES) ? s_root_to_slot[root] : -1;
     compute_acc_slow_system(root);
-    for (i = 0; i < g_nbodies; i++) {
-        if (!g_bodies[i].alive || !in_system(i, root)) continue;
-        g_bodies[i].vel[0] += 0.5 * g_bodies[i].acc[0] * dt_outer;
-        g_bodies[i].vel[1] += 0.5 * g_bodies[i].acc[1] * dt_outer;
-        g_bodies[i].vel[2] += 0.5 * g_bodies[i].acc[2] * dt_outer;
+    if (root < 0 || slot < 0) {
+        for (i = 0; i < g_nbodies; i++) {
+            if (!g_bodies[i].alive || !in_system(i, root)) continue;
+            g_bodies[i].vel[0] += 0.5 * g_bodies[i].acc[0] * dt_outer;
+            g_bodies[i].vel[1] += 0.5 * g_bodies[i].acc[1] * dt_outer;
+            g_bodies[i].vel[2] += 0.5 * g_bodies[i].acc[2] * dt_outer;
+        }
+    } else {
+        for (int mi = 0; mi < s_system_member_count[slot]; mi++) {
+            i = s_system_members[slot][mi];
+            if (!g_bodies[i].alive) continue;
+            g_bodies[i].vel[0] += 0.5 * g_bodies[i].acc[0] * dt_outer;
+            g_bodies[i].vel[1] += 0.5 * g_bodies[i].acc[1] * dt_outer;
+            g_bodies[i].vel[2] += 0.5 * g_bodies[i].acc[2] * dt_outer;
+        }
     }
     /* Pre-compute fast forces so physics_respa_inner can use them
      * immediately without an extra evaluation (carry-over trick). */
@@ -378,27 +511,56 @@ void physics_respa_inner(double dt_inner) {
 
 void physics_respa_inner_system(int root, double dt_inner) {
     int i;
+    int slot = (root >= 0 && root < MAX_BODIES) ? s_root_to_slot[root] : -1;
     /* fast half-kick (uses fast_acc from previous compute_acc_fast) */
-    for (i = 0; i < g_nbodies; i++) {
-        if (!g_bodies[i].alive || !in_system(i, root)) continue;
-        g_bodies[i].vel[0] += 0.5 * g_bodies[i].fast_acc[0] * dt_inner;
-        g_bodies[i].vel[1] += 0.5 * g_bodies[i].fast_acc[1] * dt_inner;
-        g_bodies[i].vel[2] += 0.5 * g_bodies[i].fast_acc[2] * dt_inner;
-    }
-    /* drift all bodies */
-    for (i = 0; i < g_nbodies; i++) {
-        if (!g_bodies[i].alive || !in_system(i, root)) continue;
-        g_bodies[i].pos[0] += g_bodies[i].vel[0] * dt_inner;
-        g_bodies[i].pos[1] += g_bodies[i].vel[1] * dt_inner;
-        g_bodies[i].pos[2] += g_bodies[i].vel[2] * dt_inner;
+    if (root < 0 || slot < 0) {
+        for (i = 0; i < g_nbodies; i++) {
+            if (!g_bodies[i].alive || !in_system(i, root)) continue;
+            g_bodies[i].vel[0] += 0.5 * g_bodies[i].fast_acc[0] * dt_inner;
+            g_bodies[i].vel[1] += 0.5 * g_bodies[i].fast_acc[1] * dt_inner;
+            g_bodies[i].vel[2] += 0.5 * g_bodies[i].fast_acc[2] * dt_inner;
+        }
+        /* drift all bodies */
+        for (i = 0; i < g_nbodies; i++) {
+            if (!g_bodies[i].alive || !in_system(i, root)) continue;
+            g_bodies[i].pos[0] += g_bodies[i].vel[0] * dt_inner;
+            g_bodies[i].pos[1] += g_bodies[i].vel[1] * dt_inner;
+            g_bodies[i].pos[2] += g_bodies[i].vel[2] * dt_inner;
+        }
+    } else {
+        for (int mi = 0; mi < s_system_member_count[slot]; mi++) {
+            i = s_system_members[slot][mi];
+            if (!g_bodies[i].alive) continue;
+            g_bodies[i].vel[0] += 0.5 * g_bodies[i].fast_acc[0] * dt_inner;
+            g_bodies[i].vel[1] += 0.5 * g_bodies[i].fast_acc[1] * dt_inner;
+            g_bodies[i].vel[2] += 0.5 * g_bodies[i].fast_acc[2] * dt_inner;
+        }
+        /* drift all bodies */
+        for (int mi = 0; mi < s_system_member_count[slot]; mi++) {
+            i = s_system_members[slot][mi];
+            if (!g_bodies[i].alive) continue;
+            g_bodies[i].pos[0] += g_bodies[i].vel[0] * dt_inner;
+            g_bodies[i].pos[1] += g_bodies[i].vel[1] * dt_inner;
+            g_bodies[i].pos[2] += g_bodies[i].vel[2] * dt_inner;
+        }
     }
     /* recompute fast forces at new positions, then fast half-kick */
     compute_acc_fast_system(root);
-    for (i = 0; i < g_nbodies; i++) {
-        if (!g_bodies[i].alive || !in_system(i, root)) continue;
-        g_bodies[i].vel[0] += 0.5 * g_bodies[i].fast_acc[0] * dt_inner;
-        g_bodies[i].vel[1] += 0.5 * g_bodies[i].fast_acc[1] * dt_inner;
-        g_bodies[i].vel[2] += 0.5 * g_bodies[i].fast_acc[2] * dt_inner;
+    if (root < 0 || slot < 0) {
+        for (i = 0; i < g_nbodies; i++) {
+            if (!g_bodies[i].alive || !in_system(i, root)) continue;
+            g_bodies[i].vel[0] += 0.5 * g_bodies[i].fast_acc[0] * dt_inner;
+            g_bodies[i].vel[1] += 0.5 * g_bodies[i].fast_acc[1] * dt_inner;
+            g_bodies[i].vel[2] += 0.5 * g_bodies[i].fast_acc[2] * dt_inner;
+        }
+    } else {
+        for (int mi = 0; mi < s_system_member_count[slot]; mi++) {
+            i = s_system_members[slot][mi];
+            if (!g_bodies[i].alive) continue;
+            g_bodies[i].vel[0] += 0.5 * g_bodies[i].fast_acc[0] * dt_inner;
+            g_bodies[i].vel[1] += 0.5 * g_bodies[i].fast_acc[1] * dt_inner;
+            g_bodies[i].vel[2] += 0.5 * g_bodies[i].fast_acc[2] * dt_inner;
+        }
     }
 }
 
@@ -413,19 +575,38 @@ void physics_respa_end(double dt_outer) {
 
 void physics_respa_end_system(int root, double dt_outer) {
     int i;
+    int slot = (root >= 0 && root < MAX_BODIES) ? s_root_to_slot[root] : -1;
     compute_acc_slow_system(root);
-    for (i = 0; i < g_nbodies; i++) {
-        if (!g_bodies[i].alive || !in_system(i, root)) continue;
-        g_bodies[i].vel[0] += 0.5 * g_bodies[i].acc[0] * dt_outer;
-        g_bodies[i].vel[1] += 0.5 * g_bodies[i].acc[1] * dt_outer;
-        g_bodies[i].vel[2] += 0.5 * g_bodies[i].acc[2] * dt_outer;
-    }
-    /* axial rotation */
-    for (i = 0; i < g_nbodies; i++) {
-        if (!g_bodies[i].alive || !in_system(i, root)) continue;
-        g_bodies[i].rotation_angle = fmod(
-            g_bodies[i].rotation_angle + g_bodies[i].rotation_rate * dt_outer,
-            2.0 * PI);
+    if (root < 0 || slot < 0) {
+        for (i = 0; i < g_nbodies; i++) {
+            if (!g_bodies[i].alive || !in_system(i, root)) continue;
+            g_bodies[i].vel[0] += 0.5 * g_bodies[i].acc[0] * dt_outer;
+            g_bodies[i].vel[1] += 0.5 * g_bodies[i].acc[1] * dt_outer;
+            g_bodies[i].vel[2] += 0.5 * g_bodies[i].acc[2] * dt_outer;
+        }
+        /* axial rotation */
+        for (i = 0; i < g_nbodies; i++) {
+            if (!g_bodies[i].alive || !in_system(i, root)) continue;
+            g_bodies[i].rotation_angle = fmod(
+                g_bodies[i].rotation_angle + g_bodies[i].rotation_rate * dt_outer,
+                2.0 * PI);
+        }
+    } else {
+        for (int mi = 0; mi < s_system_member_count[slot]; mi++) {
+            i = s_system_members[slot][mi];
+            if (!g_bodies[i].alive) continue;
+            g_bodies[i].vel[0] += 0.5 * g_bodies[i].acc[0] * dt_outer;
+            g_bodies[i].vel[1] += 0.5 * g_bodies[i].acc[1] * dt_outer;
+            g_bodies[i].vel[2] += 0.5 * g_bodies[i].acc[2] * dt_outer;
+        }
+        /* axial rotation */
+        for (int mi = 0; mi < s_system_member_count[slot]; mi++) {
+            i = s_system_members[slot][mi];
+            if (!g_bodies[i].alive) continue;
+            g_bodies[i].rotation_angle = fmod(
+                g_bodies[i].rotation_angle + g_bodies[i].rotation_rate * dt_outer,
+                2.0 * PI);
+        }
     }
 }
 
@@ -535,6 +716,10 @@ static double trail_segment_len_for_accel(const Body *b)
 
     if (body_idx >= 0 && body_idx < g_nbodies && is_satellite(body_idx))
         segment_len = TRAIL_SATELLITE_SEGMENT_LEN;
+
+    if (body_idx >= 0 && body_idx < g_nbodies &&
+        collision_body_needs_dense_trail(body_idx))
+        segment_len *= TRAIL_CLOSE_APPROACH_FACTOR;
 
     if (segment_len < TRAIL_MIN_SEGMENT_LEN) segment_len = TRAIL_MIN_SEGMENT_LEN;
     if (segment_len > TRAIL_MAX_SEGMENT_LEN) segment_len = TRAIL_MAX_SEGMENT_LEN;
@@ -763,13 +948,52 @@ void trails_tick(double dt) {
 
 void trails_tick_system(int root, double dt) {
     int i;
+    int slot = (root >= 0 && root < MAX_BODIES) ? s_root_to_slot[root] : -1;
     if (dt <= 0.0) return;
 
-    for (i = 0; i < g_nbodies; i++) {
+    if (root < 0 || slot < 0) {
+        for (i = 0; i < g_nbodies; i++) {
+            Body *b = &g_bodies[i];
+            double segment_len, max_err, start[3], start_vel[3], end[3], end_vel[3];
+
+            if (!b->alive || !in_system(i, root) || !b->trail || !b->trail_emitting) {
+                continue;
+            }
+            segment_len = trail_segment_len_for_accel(b);
+            max_err = segment_len * TRAIL_CURVE_ERROR_RATIO;
+            if (max_err < TRAIL_CURVE_MIN_ERROR) max_err = TRAIL_CURVE_MIN_ERROR;
+            if (max_err > TRAIL_CURVE_MAX_ERROR) max_err = TRAIL_CURVE_MAX_ERROR;
+            start[0] = b->trail_prev_pos[0];
+            start[1] = b->trail_prev_pos[1];
+            start[2] = b->trail_prev_pos[2];
+            start_vel[0] = b->trail_prev_vel[0];
+            start_vel[1] = b->trail_prev_vel[1];
+            start_vel[2] = b->trail_prev_vel[2];
+            end[0] = b->pos[0];
+            end[1] = b->pos[1];
+            end[2] = b->pos[2];
+            end_vel[0] = b->vel[0];
+            end_vel[1] = b->vel[1];
+            end_vel[2] = b->vel[2];
+            trail_rebuild_segment(b, start, start_vel, end, end_vel,
+                                  dt, segment_len, max_err);
+
+            b->trail_prev_pos[0] = end[0];
+            b->trail_prev_pos[1] = end[1];
+            b->trail_prev_pos[2] = end[2];
+            b->trail_prev_vel[0] = end_vel[0];
+            b->trail_prev_vel[1] = end_vel[1];
+            b->trail_prev_vel[2] = end_vel[2];
+        }
+        return;
+    }
+
+    for (int mi = 0; mi < s_system_member_count[slot]; mi++) {
+        i = s_system_members[slot][mi];
         Body *b = &g_bodies[i];
         double segment_len, max_err, start[3], start_vel[3], end[3], end_vel[3];
 
-        if (!b->alive || !in_system(i, root) || !b->trail || !b->trail_emitting) {
+        if (!b->alive || !b->trail || !b->trail_emitting) {
             continue;
         }
         segment_len = trail_segment_len_for_accel(b);

--- a/src/physics.c
+++ b/src/physics.c
@@ -492,7 +492,7 @@ static void sample_body_pos(Body *b, const double pos[3]) {
         target_world_len = TRAIL_SATELLITE_WORLD_LEN;
 
     if (b->trail_count > 0) {
-        int prev_idx = (b->trail_head - 1 + TRAIL_LEN) % TRAIL_LEN;
+        int prev_idx = (b->trail_head - 1 + TRAIL_LEN) & TRAIL_MASK;
         double dx = pos[0] * RS - b->trail[prev_idx][0];
         double dy = pos[1] * RS - b->trail[prev_idx][1];
         double dz = pos[2] * RS - b->trail[prev_idx][2];
@@ -503,13 +503,13 @@ static void sample_body_pos(Body *b, const double pos[3]) {
     b->trail[b->trail_head][1] = pos[1] * RS;
     b->trail[b->trail_head][2] = pos[2] * RS;
     if (b->trail_seg_len) b->trail_seg_len[write_idx] = seg_len;
-    b->trail_head = (b->trail_head + 1) % TRAIL_LEN;
+    b->trail_head = (b->trail_head + 1) & TRAIL_MASK;
     if (b->trail_count < TRAIL_LEN) {
         b->trail_count++;
         b->trail_total_len += seg_len;
     } else {
         int oldest_idx = b->trail_head;
-        int next_oldest_idx = (oldest_idx + 1) % TRAIL_LEN;
+        int next_oldest_idx = (oldest_idx + 1) & TRAIL_MASK;
         if (b->trail_seg_len)
             b->trail_total_len += seg_len - b->trail_seg_len[next_oldest_idx];
         else
@@ -517,8 +517,8 @@ static void sample_body_pos(Body *b, const double pos[3]) {
     }
 
     while (b->trail_count > 2 && b->trail_total_len > target_world_len) {
-        int oldest_idx = (b->trail_head - b->trail_count + TRAIL_LEN) % TRAIL_LEN;
-        int next_oldest_idx = (oldest_idx + 1) % TRAIL_LEN;
+        int oldest_idx = (b->trail_head - b->trail_count + TRAIL_LEN) & TRAIL_MASK;
+        int next_oldest_idx = (oldest_idx + 1) & TRAIL_MASK;
         double drop_len = b->trail_seg_len ? b->trail_seg_len[next_oldest_idx] : 0.0;
         b->trail_total_len -= drop_len;
         if (b->trail_total_len < 0.0) b->trail_total_len = 0.0;
@@ -731,7 +731,7 @@ void trails_cut_body_at_time(int body_idx, double hit_dt, double frame_dt,
     }
 
     if (b->trail_count > 0) {
-        int last_idx = (b->trail_head - 1 + TRAIL_LEN) % TRAIL_LEN;
+        int last_idx = (b->trail_head - 1 + TRAIL_LEN) & TRAIL_MASK;
         dx = b->trail[last_idx][0] - cut_pos[0] * RS;
         dy = b->trail[last_idx][1] - cut_pos[1] * RS;
         dz = b->trail[last_idx][2] - cut_pos[2] * RS;

--- a/src/physics.c
+++ b/src/physics.c
@@ -23,7 +23,7 @@ int    g_paused    = 0;
 
 #define OUTER_PERIOD_DIVISOR 24.0
 #define INNER_PERIOD_DIVISOR 96.0
-#define OUTER_DT_MIN (DAY * 0.05)
+#define OUTER_DT_MIN 60.0
 #define INNER_DT_MIN 60.0
 #define INNER_DT_MAX (DAY * 0.02)
 #define OUTER_DT_DEFAULT DAY
@@ -34,6 +34,9 @@ static int    s_system_roots[MAX_BODIES];
 static double s_system_outer_dt[MAX_BODIES];
 static double s_system_inner_dt[MAX_BODIES];
 static int    s_nsystems = 0;
+
+static int is_satellite(int i);
+static int is_ancestor_of(int ancestor, int child);
 
 static int in_system(int i, int root)
 {
@@ -89,6 +92,41 @@ static double estimate_period_about(int i, int anchor)
     return 2.0 * PI * sqrt(r * r * r / gm);
 }
 
+static double satellite_perturbation_ratio(int i)
+{
+    int parent;
+    double pdx, pdy, pdz, pr2, parent_acc;
+    double max_other_acc = 0.0;
+
+    if (i < 0 || i >= g_nbodies || !is_satellite(i)) return 0.0;
+    parent = g_bodies[i].parent;
+    if (parent < 0 || parent >= g_nbodies || !g_bodies[parent].alive) return 0.0;
+
+    pdx = g_bodies[parent].pos[0] - g_bodies[i].pos[0];
+    pdy = g_bodies[parent].pos[1] - g_bodies[i].pos[1];
+    pdz = g_bodies[parent].pos[2] - g_bodies[i].pos[2];
+    pr2 = pdx*pdx + pdy*pdy + pdz*pdz + SOFTENING*SOFTENING;
+    if (pr2 <= 0.0) return 0.0;
+    parent_acc = G_CONST * g_bodies[parent].mass / pr2;
+    if (parent_acc <= 0.0) return 0.0;
+
+    for (int j = 0; j < g_nbodies; j++) {
+        double dx, dy, dz, r2, acc;
+        if (j == i || j == parent || !g_bodies[j].alive) continue;
+        if (is_ancestor_of(i, j)) continue;
+
+        dx = g_bodies[j].pos[0] - g_bodies[i].pos[0];
+        dy = g_bodies[j].pos[1] - g_bodies[i].pos[1];
+        dz = g_bodies[j].pos[2] - g_bodies[i].pos[2];
+        r2 = dx*dx + dy*dy + dz*dz + SOFTENING*SOFTENING;
+        if (r2 <= 0.0) continue;
+        acc = G_CONST * g_bodies[j].mass / r2;
+        if (acc > max_other_acc) max_other_acc = acc;
+    }
+
+    return max_other_acc / parent_acc;
+}
+
 /* ── helpers ─────────────────────────────────────────────────────────── */
 /* A body is a satellite (moon) if it has a parent and that parent is not a star.
  * Stars   (parent=-1)          → false  — primary body
@@ -130,10 +168,26 @@ void physics_refresh_timestep_model(void)
 
         double dt_outer = T / OUTER_PERIOD_DIVISOR;
         double dt_inner = T / INNER_PERIOD_DIVISOR;
+        double perturb = 0.0;
         if (dt_outer < OUTER_DT_MIN) dt_outer = OUTER_DT_MIN;
         if (dt_outer > OUTER_DT_DEFAULT) dt_outer = OUTER_DT_DEFAULT;
         if (dt_inner < INNER_DT_MIN) dt_inner = INNER_DT_MIN;
         if (dt_inner > INNER_DT_MAX) dt_inner = INNER_DT_MAX;
+
+        if (is_satellite(i)) {
+            perturb = satellite_perturbation_ratio(i);
+
+            /* Strong third-body forcing means the "slow" component is no longer
+             * truly slow for this moon, so tighten the outer cadence toward the
+             * inner cadence before the orbit can numerically collapse. */
+            if (perturb > 0.20) dt_outer = fmin(dt_outer, dt_inner * 1.5);
+            else if (perturb > 0.10) dt_outer = fmin(dt_outer, dt_inner * 2.0);
+            else if (perturb > 0.05) dt_outer = fmin(dt_outer, dt_inner * 3.0);
+            else if (perturb > 0.02) dt_outer = fmin(dt_outer, dt_inner * 4.0);
+            else if (perturb > 0.01) dt_outer = fmin(dt_outer, dt_inner * 6.0);
+
+            if (dt_outer < OUTER_DT_MIN) dt_outer = OUTER_DT_MIN;
+        }
 
         b->dyn_period = T;
         b->dyn_dt_outer = dt_outer;
@@ -436,17 +490,231 @@ static void sample_body_pos(Body *b, const double pos[3]) {
     if (b->trail_count < TRAIL_LEN) b->trail_count++;
 }
 
-static double trail_interval_for_accel(const Body *b)
+static double trail_segment_len_for_accel(const Body *b)
 {
     double ax = b->acc[0] + b->fast_acc[0];
     double ay = b->acc[1] + b->fast_acc[1];
     double az = b->acc[2] + b->fast_acc[2];
     double amag = sqrt(ax*ax + ay*ay + az*az);
-    double interval = TRAIL_ACCEL_SCALE / sqrt(amag + TRAIL_ACCEL_EPS);
+    double segment_len = TRAIL_SEGMENT_SCALE / sqrt(amag + TRAIL_ACCEL_EPS);
 
-    if (interval < TRAIL_MIN_INTERVAL) interval = TRAIL_MIN_INTERVAL;
-    if (interval > TRAIL_MAX_INTERVAL) interval = TRAIL_MAX_INTERVAL;
-    return interval;
+    if (segment_len < TRAIL_MIN_SEGMENT_LEN) segment_len = TRAIL_MIN_SEGMENT_LEN;
+    if (segment_len > TRAIL_MAX_SEGMENT_LEN) segment_len = TRAIL_MAX_SEGMENT_LEN;
+    return segment_len;
+}
+
+static void trail_curve_eval(const double p0[3], const double v0[3],
+                             const double p1[3], const double v1[3],
+                             double dt, double t, double out[3])
+{
+    double t2 = t * t;
+    double t3 = t2 * t;
+    double h00 = 2.0 * t3 - 3.0 * t2 + 1.0;
+    double h10 = t3 - 2.0 * t2 + t;
+    double h01 = -2.0 * t3 + 3.0 * t2;
+    double h11 = t3 - t2;
+
+    out[0] = h00 * p0[0] + h10 * dt * v0[0] + h01 * p1[0] + h11 * dt * v1[0];
+    out[1] = h00 * p0[1] + h10 * dt * v0[1] + h01 * p1[1] + h11 * dt * v1[1];
+    out[2] = h00 * p0[2] + h10 * dt * v0[2] + h01 * p1[2] + h11 * dt * v1[2];
+}
+
+static void trail_curve_eval_vel(const double p0[3], const double v0[3],
+                                 const double p1[3], const double v1[3],
+                                 double dt, double t, double out[3])
+{
+    double t2 = t * t;
+    double dh00 = 6.0 * t2 - 6.0 * t;
+    double dh10 = 3.0 * t2 - 4.0 * t + 1.0;
+    double dh01 = -6.0 * t2 + 6.0 * t;
+    double dh11 = 3.0 * t2 - 2.0 * t;
+    double inv_dt = (dt > 0.0) ? (1.0 / dt) : 0.0;
+
+    out[0] = (dh00 * p0[0] + dh10 * dt * v0[0] + dh01 * p1[0] + dh11 * dt * v1[0]) * inv_dt;
+    out[1] = (dh00 * p0[1] + dh10 * dt * v0[1] + dh01 * p1[1] + dh11 * dt * v1[1]) * inv_dt;
+    out[2] = (dh00 * p0[2] + dh10 * dt * v0[2] + dh01 * p1[2] + dh11 * dt * v1[2]) * inv_dt;
+}
+
+static void trail_curve_append_point(double points[][3], int *count,
+                                     const double p[3])
+{
+    if (*count >= (1 << TRAIL_CURVE_MAX_DEPTH) + 1) return;
+    points[*count][0] = p[0];
+    points[*count][1] = p[1];
+    points[*count][2] = p[2];
+    (*count)++;
+}
+
+static void trail_curve_flatten_recursive(const double p0[3], const double v0[3],
+                                          const double p1[3], const double v1[3],
+                                          double dt, double max_err, int depth,
+                                          double points[][3], int *count)
+{
+    double mid_curve[3], mid_line[3], diff[3], err;
+
+    trail_curve_eval(p0, v0, p1, v1, dt, 0.5, mid_curve);
+    mid_line[0] = 0.5 * (p0[0] + p1[0]);
+    mid_line[1] = 0.5 * (p0[1] + p1[1]);
+    mid_line[2] = 0.5 * (p0[2] + p1[2]);
+    diff[0] = mid_curve[0] - mid_line[0];
+    diff[1] = mid_curve[1] - mid_line[1];
+    diff[2] = mid_curve[2] - mid_line[2];
+    err = sqrt(diff[0]*diff[0] + diff[1]*diff[1] + diff[2]*diff[2]);
+
+    if (depth >= TRAIL_CURVE_MAX_DEPTH || err <= max_err) {
+        trail_curve_append_point(points, count, p1);
+        return;
+    }
+
+    {
+        double mid_vel[3];
+        trail_curve_eval_vel(p0, v0, p1, v1, dt, 0.5, mid_vel);
+        trail_curve_flatten_recursive(p0, v0, mid_curve, mid_vel,
+                                      dt * 0.5, max_err, depth + 1,
+                                      points, count);
+        trail_curve_flatten_recursive(mid_curve, mid_vel, p1, v1,
+                                      dt * 0.5, max_err, depth + 1,
+                                      points, count);
+    }
+}
+
+static void trail_rebuild_segment(Body *b,
+                                  const double start[3], const double start_vel[3],
+                                  const double end[3], const double end_vel[3],
+                                  double dt, double segment_len, double max_err)
+{
+    double curve_points[(1 << TRAIL_CURVE_MAX_DEPTH) + 1][3];
+    int curve_count = 0;
+
+    trail_curve_append_point(curve_points, &curve_count, start);
+    trail_curve_flatten_recursive(start, start_vel, end, end_vel,
+                                  dt, max_err, 0,
+                                  curve_points, &curve_count);
+
+    for (int k = 1; k < curve_count; k++) {
+        double seg_start[3], seg_end[3];
+        double dx, dy, dz, seg_dist, traveled;
+
+        seg_start[0] = curve_points[k - 1][0];
+        seg_start[1] = curve_points[k - 1][1];
+        seg_start[2] = curve_points[k - 1][2];
+        seg_end[0] = curve_points[k][0];
+        seg_end[1] = curve_points[k][1];
+        seg_end[2] = curve_points[k][2];
+        dx = seg_end[0] - seg_start[0];
+        dy = seg_end[1] - seg_start[1];
+        dz = seg_end[2] - seg_start[2];
+        seg_dist = sqrt(dx*dx + dy*dy + dz*dz);
+        traveled = 0.0;
+
+        while (b->trail_accum + (seg_dist - traveled) >= segment_len) {
+            double need = segment_len - b->trail_accum;
+            double u;
+            double sample_pos[3];
+
+            if (need < 0.0) need = 0.0;
+            if (seg_dist <= 0.0) break;
+            u = (traveled + need) / seg_dist;
+            if (u < 0.0) u = 0.0;
+            if (u > 1.0) u = 1.0;
+            sample_pos[0] = seg_start[0] + (seg_end[0] - seg_start[0]) * u;
+            sample_pos[1] = seg_start[1] + (seg_end[1] - seg_start[1]) * u;
+            sample_pos[2] = seg_start[2] + (seg_end[2] - seg_start[2]) * u;
+            sample_body_pos(b, sample_pos);
+            traveled += need;
+            if (traveled > seg_dist) traveled = seg_dist;
+            b->trail_accum = 0.0;
+        }
+
+        b->trail_accum += seg_dist - traveled;
+    }
+}
+
+void trails_begin_frame_snapshot(void)
+{
+    for (int i = 0; i < g_nbodies; i++) {
+        Body *b = &g_bodies[i];
+        b->trail_frame_accum = b->trail_accum;
+        b->trail_frame_head = b->trail_head;
+        b->trail_frame_count = b->trail_count;
+        b->trail_frame_pos[0] = b->pos[0];
+        b->trail_frame_pos[1] = b->pos[1];
+        b->trail_frame_pos[2] = b->pos[2];
+        b->trail_frame_vel[0] = b->vel[0];
+        b->trail_frame_vel[1] = b->vel[1];
+        b->trail_frame_vel[2] = b->vel[2];
+        b->trail_frame_prev_pos[0] = b->trail_prev_pos[0];
+        b->trail_frame_prev_pos[1] = b->trail_prev_pos[1];
+        b->trail_frame_prev_pos[2] = b->trail_prev_pos[2];
+        b->trail_frame_prev_vel[0] = b->trail_prev_vel[0];
+        b->trail_frame_prev_vel[1] = b->trail_prev_vel[1];
+        b->trail_frame_prev_vel[2] = b->trail_prev_vel[2];
+    }
+}
+
+void trails_cut_body_at_time(int body_idx, double hit_dt, double frame_dt,
+                             const double cut_pos[3])
+{
+    Body *b;
+    double tau, cut_vel[3], segment_len, max_err;
+    double dx, dy, dz, dist2;
+
+    if (body_idx < 0 || body_idx >= g_nbodies || !cut_pos) return;
+    b = &g_bodies[body_idx];
+    if (!b->trail) return;
+
+    b->trail_head = b->trail_frame_head;
+    b->trail_count = b->trail_frame_count;
+    b->trail_accum = b->trail_frame_accum;
+    b->trail_prev_pos[0] = b->trail_frame_prev_pos[0];
+    b->trail_prev_pos[1] = b->trail_frame_prev_pos[1];
+    b->trail_prev_pos[2] = b->trail_frame_prev_pos[2];
+    b->trail_prev_vel[0] = b->trail_frame_prev_vel[0];
+    b->trail_prev_vel[1] = b->trail_frame_prev_vel[1];
+    b->trail_prev_vel[2] = b->trail_frame_prev_vel[2];
+
+    if (frame_dt <= 0.0 || hit_dt <= 0.0) {
+        cut_vel[0] = b->trail_frame_prev_vel[0];
+        cut_vel[1] = b->trail_frame_prev_vel[1];
+        cut_vel[2] = b->trail_frame_prev_vel[2];
+    } else {
+        tau = hit_dt / frame_dt;
+        if (tau < 0.0) tau = 0.0;
+        if (tau > 1.0) tau = 1.0;
+        trail_curve_eval_vel(b->trail_frame_pos, b->trail_frame_vel,
+                             b->pos, b->vel, frame_dt, tau, cut_vel);
+        segment_len = trail_segment_len_for_accel(b);
+        max_err = segment_len * TRAIL_CURVE_ERROR_RATIO;
+        if (max_err < TRAIL_CURVE_MIN_ERROR) max_err = TRAIL_CURVE_MIN_ERROR;
+        if (max_err > TRAIL_CURVE_MAX_ERROR) max_err = TRAIL_CURVE_MAX_ERROR;
+        trail_rebuild_segment(b,
+                              b->trail_frame_prev_pos, b->trail_frame_prev_vel,
+                              cut_pos, cut_vel, hit_dt, segment_len, max_err);
+    }
+
+    if (b->trail_count > 0) {
+        int last_idx = (b->trail_head - 1 + TRAIL_LEN) % TRAIL_LEN;
+        dx = b->trail[last_idx][0] - cut_pos[0] * RS;
+        dy = b->trail[last_idx][1] - cut_pos[1] * RS;
+        dz = b->trail[last_idx][2] - cut_pos[2] * RS;
+        dist2 = dx*dx + dy*dy + dz*dz;
+        if (dist2 <= (TRAIL_MIN_SEGMENT_LEN * RS) * (TRAIL_MIN_SEGMENT_LEN * RS)) {
+            b->trail[last_idx][0] = cut_pos[0] * RS;
+            b->trail[last_idx][1] = cut_pos[1] * RS;
+            b->trail[last_idx][2] = cut_pos[2] * RS;
+        } else {
+            sample_body_pos(b, cut_pos);
+        }
+    } else {
+        sample_body_pos(b, cut_pos);
+    }
+
+    b->trail_prev_pos[0] = cut_pos[0];
+    b->trail_prev_pos[1] = cut_pos[1];
+    b->trail_prev_pos[2] = cut_pos[2];
+    b->trail_prev_vel[0] = cut_vel[0];
+    b->trail_prev_vel[1] = cut_vel[1];
+    b->trail_prev_vel[2] = cut_vel[2];
 }
 
 void trails_tick(double dt) {
@@ -459,41 +727,35 @@ void trails_tick_system(int root, double dt) {
 
     for (i = 0; i < g_nbodies; i++) {
         Body *b = &g_bodies[i];
-        double interval, elapsed, start[3], end[3];
+        double segment_len, max_err, start[3], start_vel[3], end[3], end_vel[3];
 
         if (!b->alive || !in_system(i, root) || !b->trail || !b->trail_emitting) {
             continue;
         }
-        interval = trail_interval_for_accel(b);
+        segment_len = trail_segment_len_for_accel(b);
+        max_err = segment_len * TRAIL_CURVE_ERROR_RATIO;
+        if (max_err < TRAIL_CURVE_MIN_ERROR) max_err = TRAIL_CURVE_MIN_ERROR;
+        if (max_err > TRAIL_CURVE_MAX_ERROR) max_err = TRAIL_CURVE_MAX_ERROR;
         start[0] = b->trail_prev_pos[0];
         start[1] = b->trail_prev_pos[1];
         start[2] = b->trail_prev_pos[2];
+        start_vel[0] = b->trail_prev_vel[0];
+        start_vel[1] = b->trail_prev_vel[1];
+        start_vel[2] = b->trail_prev_vel[2];
         end[0] = b->pos[0];
         end[1] = b->pos[1];
         end[2] = b->pos[2];
-        elapsed = 0.0;
+        end_vel[0] = b->vel[0];
+        end_vel[1] = b->vel[1];
+        end_vel[2] = b->vel[2];
+        trail_rebuild_segment(b, start, start_vel, end, end_vel,
+                              dt, segment_len, max_err);
 
-        while (b->trail_accum + (dt - elapsed) >= interval) {
-            double need = interval - b->trail_accum;
-            double t;
-            double sample_pos[3];
-
-            if (need < 0.0) need = 0.0;
-            t = (elapsed + need) / dt;
-            if (t < 0.0) t = 0.0;
-            if (t > 1.0) t = 1.0;
-            sample_pos[0] = start[0] + (end[0] - start[0]) * t;
-            sample_pos[1] = start[1] + (end[1] - start[1]) * t;
-            sample_pos[2] = start[2] + (end[2] - start[2]) * t;
-            sample_body_pos(b, sample_pos);
-            elapsed += need;
-            if (elapsed > dt) elapsed = dt;
-            b->trail_accum = 0.0;
-        }
-
-        b->trail_accum += dt - elapsed;
         b->trail_prev_pos[0] = end[0];
         b->trail_prev_pos[1] = end[1];
         b->trail_prev_pos[2] = end[2];
+        b->trail_prev_vel[0] = end_vel[0];
+        b->trail_prev_vel[1] = end_vel[1];
+        b->trail_prev_vel[2] = end_vel[2];
     }
 }

--- a/src/physics.c
+++ b/src/physics.c
@@ -23,7 +23,9 @@ int    g_paused    = 0;
 
 #define OUTER_PERIOD_DIVISOR 24.0
 #define INNER_PERIOD_DIVISOR 96.0
-#define OUTER_DT_MIN 60.0
+/* Keep a reasonably large outer-step floor so one very short-period moon does
+ * not throttle the global sim-speed cap for every system in the scene. */
+#define OUTER_DT_MIN (DAY * 0.05)
 #define INNER_DT_MIN 60.0
 #define INNER_DT_MAX (DAY * 0.02)
 #define OUTER_DT_DEFAULT DAY

--- a/src/physics.c
+++ b/src/physics.c
@@ -497,6 +497,10 @@ static double trail_segment_len_for_accel(const Body *b)
     double az = b->acc[2] + b->fast_acc[2];
     double amag = sqrt(ax*ax + ay*ay + az*az);
     double segment_len = TRAIL_SEGMENT_SCALE / sqrt(amag + TRAIL_ACCEL_EPS);
+    int body_idx = (int)(b - g_bodies);
+
+    if (body_idx >= 0 && body_idx < g_nbodies && is_satellite(body_idx))
+        segment_len *= (1.0 / 3.0);
 
     if (segment_len < TRAIL_MIN_SEGMENT_LEN) segment_len = TRAIL_MIN_SEGMENT_LEN;
     if (segment_len > TRAIL_MAX_SEGMENT_LEN) segment_len = TRAIL_MAX_SEGMENT_LEN;

--- a/src/physics.c
+++ b/src/physics.c
@@ -428,36 +428,72 @@ void physics_step(double dt) {
 }
 
 /* ── trail helpers ───────────────────────────────────────────────────── */
-static void sample_body(Body *b) {
-    b->trail[b->trail_head][0] = b->pos[0] * RS;
-    b->trail[b->trail_head][1] = b->pos[1] * RS;
-    b->trail[b->trail_head][2] = b->pos[2] * RS;
+static void sample_body_pos(Body *b, const double pos[3]) {
+    b->trail[b->trail_head][0] = pos[0] * RS;
+    b->trail[b->trail_head][1] = pos[1] * RS;
+    b->trail[b->trail_head][2] = pos[2] * RS;
     b->trail_head = (b->trail_head + 1) % TRAIL_LEN;
     if (b->trail_count < TRAIL_LEN) b->trail_count++;
 }
 
-/*
- * trails_tick — time-based trail sampling.
- *
- * Each body accumulates sim-time; once trail_interval is exceeded a sample
- * is recorded.  The while-loop handles multiple samples per tick (fast
- * moons or high sim speeds).  trail_interval ≈ T/200 gives ~200 evenly
- * spaced samples per orbit regardless of sim speed — the trail fills the
- * buffer faster at high speeds, naturally showing more orbital history.
- */
+static double trail_interval_for_accel(const Body *b)
+{
+    double ax = b->acc[0] + b->fast_acc[0];
+    double ay = b->acc[1] + b->fast_acc[1];
+    double az = b->acc[2] + b->fast_acc[2];
+    double amag = sqrt(ax*ax + ay*ay + az*az);
+    double interval = TRAIL_ACCEL_SCALE / sqrt(amag + TRAIL_ACCEL_EPS);
+
+    if (interval < TRAIL_MIN_INTERVAL) interval = TRAIL_MIN_INTERVAL;
+    if (interval > TRAIL_MAX_INTERVAL) interval = TRAIL_MAX_INTERVAL;
+    return interval;
+}
+
 void trails_tick(double dt) {
     trails_tick_system(-1, dt);
 }
 
 void trails_tick_system(int root, double dt) {
     int i;
+    if (dt <= 0.0) return;
+
     for (i = 0; i < g_nbodies; i++) {
         Body *b = &g_bodies[i];
-        if (!b->alive || !in_system(i, root) || !b->trail || b->trail_interval <= 0.0) continue;
-        b->trail_accum += dt;
-        while (b->trail_accum >= b->trail_interval) {
-            b->trail_accum -= b->trail_interval;
-            sample_body(b);
+        double interval, elapsed, start[3], end[3];
+
+        if (!b->alive || !in_system(i, root) || !b->trail || !b->trail_emitting) {
+            continue;
         }
+        interval = trail_interval_for_accel(b);
+        start[0] = b->trail_prev_pos[0];
+        start[1] = b->trail_prev_pos[1];
+        start[2] = b->trail_prev_pos[2];
+        end[0] = b->pos[0];
+        end[1] = b->pos[1];
+        end[2] = b->pos[2];
+        elapsed = 0.0;
+
+        while (b->trail_accum + (dt - elapsed) >= interval) {
+            double need = interval - b->trail_accum;
+            double t;
+            double sample_pos[3];
+
+            if (need < 0.0) need = 0.0;
+            t = (elapsed + need) / dt;
+            if (t < 0.0) t = 0.0;
+            if (t > 1.0) t = 1.0;
+            sample_pos[0] = start[0] + (end[0] - start[0]) * t;
+            sample_pos[1] = start[1] + (end[1] - start[1]) * t;
+            sample_pos[2] = start[2] + (end[2] - start[2]) * t;
+            sample_body_pos(b, sample_pos);
+            elapsed += need;
+            if (elapsed > dt) elapsed = dt;
+            b->trail_accum = 0.0;
+        }
+
+        b->trail_accum += dt - elapsed;
+        b->trail_prev_pos[0] = end[0];
+        b->trail_prev_pos[1] = end[1];
+        b->trail_prev_pos[2] = end[2];
     }
 }

--- a/src/physics.h
+++ b/src/physics.h
@@ -27,6 +27,20 @@ extern int    g_paused;
 void physics_respa_begin(double dt_outer);  /* slow half-kick + prime fast acc  */
 void physics_respa_inner(double dt_inner);  /* fast KDK + drift all bodies      */
 void physics_respa_end  (double dt_outer);  /* slow half-kick + rotation + time */
+void physics_respa_begin_system(int root, double dt_outer);
+void physics_respa_inner_system(int root, double dt_inner);
+void physics_respa_end_system(int root, double dt_outer);
+
+void physics_refresh_timestep_model(void);
+
+/* Recommended maximum outer-step for slow-force stability. */
+double physics_outer_dt_limit(void);
+double physics_inner_dt_limit(void);
+int    physics_system_count(void);
+int    physics_system_root(int idx);
+double physics_system_outer_dt_limit(int idx);
+double physics_system_inner_dt_limit(int idx);
+void   physics_advance_time(double dt);
 
 /* Legacy single-step KDK (kept for reference / one-off use) */
 void physics_step(double dt);
@@ -34,3 +48,4 @@ void physics_step(double dt);
 /* Trail helpers */
 void trails_sample(void);
 void trails_tick(double dt);
+void trails_tick_system(int root, double dt);

--- a/src/physics.h
+++ b/src/physics.h
@@ -46,5 +46,8 @@ void   physics_advance_time(double dt);
 void physics_step(double dt);
 
 /* Trail helpers */
+void trails_begin_frame_snapshot(void);
 void trails_tick(double dt);
 void trails_tick_system(int root, double dt);
+void trails_cut_body_at_time(int body_idx, double hit_dt, double frame_dt,
+                             const double cut_pos[3]);

--- a/src/physics.h
+++ b/src/physics.h
@@ -13,7 +13,7 @@
  *       physics_respa_begin(dt_outer);
  *       for each inner step:
  *           physics_respa_inner(dt_inner);
- *           trails_tick(dt_inner);
+ *           trails_tick(dt_inner);   // acceleration-driven trail sampling
  *       physics_respa_end(dt_outer);
  */
 #pragma once
@@ -46,6 +46,5 @@ void   physics_advance_time(double dt);
 void physics_step(double dt);
 
 /* Trail helpers */
-void trails_sample(void);
 void trails_tick(double dt);
 void trails_tick_system(int root, double dt);

--- a/src/render.c
+++ b/src/render.c
@@ -884,7 +884,7 @@ void render_frame(const float view[16], const float proj[16],
         glUniform1f(s_sp_ambient,  b->is_star ? 1.0f : 0.05f);
 
         /* Procedural surface texture — name-based lookup, index-independent */
-        glUniform1f(s_sp_rotation,  (float)b->rotation_angle);
+        glUniform1f(s_sp_rotation,  (float)fmod(b->rotation_angle, 2.0 * PI));
         glUniform1f(s_sp_obliquity, (float)(b->obliquity * (PI / 180.0)));
         glUniform1i(s_sp_ptype,     get_planet_type(b->name));
         {

--- a/src/render.c
+++ b/src/render.c
@@ -867,11 +867,11 @@ void render_frame(const float view[16], const float proj[16],
                 kinds[k] = spots[k].kind;
             }
             glUniform1i(s_sp_impact_count, nspots);
-            glUniform3fv(s_sp_impact_dir, COLLISION_MAX_SPOTS, dirs);
-            glUniform1fv(s_sp_impact_rad, COLLISION_MAX_SPOTS, radii);
-            glUniform1fv(s_sp_impact_heat, COLLISION_MAX_SPOTS, heats);
-            glUniform1fv(s_sp_impact_prog, COLLISION_MAX_SPOTS, progress);
-            glUniform1iv(s_sp_impact_kind, COLLISION_MAX_SPOTS, kinds);
+            glUniform3fv(s_sp_impact_dir, nspots, dirs);
+            glUniform1fv(s_sp_impact_rad, nspots, radii);
+            glUniform1fv(s_sp_impact_heat, nspots, heats);
+            glUniform1fv(s_sp_impact_prog, nspots, progress);
+            glUniform1iv(s_sp_impact_kind, nspots, kinds);
         }
 
         glDrawElements(GL_TRIANGLES, 6, GL_UNSIGNED_INT, 0);
@@ -899,9 +899,28 @@ void render_frame(const float view[16], const float proj[16],
         for (int i = 0; i < g_nbodies; i++) {
             if (!g_bodies[i].alive) continue;
             if (info[i].show) continue;     /* sub-pixel body — skip */
+            if (collision_body_has_active_merge(i)) continue;
             float intensity = g_bodies[i].atm_intensity;
             float scale     = g_bodies[i].atm_scale;
-            if (intensity <= 0.0f) continue;
+            float glow_color[3];
+            float glow_intensity = 0.0f;
+            float glow_scale = 1.0f;
+            float final_color[3];
+            float final_intensity;
+            float final_scale;
+            collision_body_heat_glow(i, glow_color, &glow_intensity, &glow_scale);
+            final_intensity = intensity + glow_intensity;
+            final_scale = glow_scale > scale ? glow_scale : scale;
+            if (final_intensity <= 0.0f) continue;
+            {
+                float base_w = intensity;
+                float glow_w = glow_intensity;
+                float sum_w = base_w + glow_w;
+                if (sum_w <= 1e-6f) sum_w = 1.0f;
+                final_color[0] = (g_bodies[i].atm_color[0] * base_w + glow_color[0] * glow_w) / sum_w;
+                final_color[1] = (g_bodies[i].atm_color[1] * base_w + glow_color[1] * glow_w) / sum_w;
+                final_color[2] = (g_bodies[i].atm_color[2] * base_w + glow_color[2] * glow_w) / sum_w;
+            }
 
             Body *b = &g_bodies[i];
             double cam_mx = (double)g_cam.pos[0] * AU;
@@ -921,15 +940,15 @@ void render_frame(const float view[16], const float proj[16],
             }
 
             float planet_r = info[i].dr;
-            float atm_r    = planet_r * scale;
+            float atm_r    = planet_r * final_scale;
 
             glUniform3f(s_at_center,   -oc_x, -oc_y, -oc_z);
             glUniform1f(s_at_radius,    atm_r);
             glUniform1f(s_at_planet_r,  planet_r);
             glUniform3f(s_at_oc,        oc_x, oc_y, oc_z);
             glUniform3f(s_at_sun_rel,   sr_x, sr_y, sr_z);
-            glUniform3f(s_at_color,     g_bodies[i].atm_color[0], g_bodies[i].atm_color[1], g_bodies[i].atm_color[2]);
-            glUniform1f(s_at_intensity, intensity);
+            glUniform3f(s_at_color,     final_color[0], final_color[1], final_color[2]);
+            glUniform1f(s_at_intensity, final_intensity);
             glDrawElements(GL_TRIANGLES, 6, GL_UNSIGNED_INT, 0);
         }
 

--- a/src/render.c
+++ b/src/render.c
@@ -97,6 +97,12 @@ static GLuint s_dot_shader  = 0;
 static GLuint s_dot_vao     = 0;
 static GLuint s_dot_vbo     = 0;
 static GLint  s_dot_vp      = -1;
+static GLuint s_impact_particle_shader = 0;
+static GLint  s_impact_particle_vp = -1;
+static GLuint s_impact_particle_vao = 0;
+static GLuint s_impact_particle_vbo = 0;
+
+#define RENDER_MAX_COLLISION_PARTICLES 768
 
 /* ------------------------------------------------------------------ star glare */
 static GLuint s_glare_shader = 0;
@@ -470,6 +476,14 @@ void render_init(void) {
     }
     s_dot_vp = glGetUniformLocation(s_dot_shader, "u_vp");
 
+    s_impact_particle_shader = gl_shader_load("assets/shaders/impact_particle.vert",
+                                              "assets/shaders/impact_particle.frag");
+    if (!s_impact_particle_shader) {
+        fprintf(stderr, "[Render] impact particle shader failed\n");
+        return;
+    }
+    s_impact_particle_vp = glGetUniformLocation(s_impact_particle_shader, "u_vp");
+
     /* Dynamic VBO for dot positions + colors */
     s_dot_vao = gl_vao_create();
     s_dot_vbo = gl_vbo_create(MAX_BODIES * 7 * sizeof(float),
@@ -479,6 +493,19 @@ void render_init(void) {
     glEnableVertexAttribArray(1);
     glVertexAttribPointer(1, 4, GL_FLOAT, GL_FALSE, 7*sizeof(float),
                           (void*)(3*sizeof(float)));
+    glBindVertexArray(0);
+
+    s_impact_particle_vao = gl_vao_create();
+    s_impact_particle_vbo = gl_vbo_create(RENDER_MAX_COLLISION_PARTICLES * 8 * sizeof(float),
+                                          NULL, GL_DYNAMIC_DRAW);
+    glEnableVertexAttribArray(0);
+    glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, 8*sizeof(float), (void*)0);
+    glEnableVertexAttribArray(1);
+    glVertexAttribPointer(1, 4, GL_FLOAT, GL_FALSE, 8*sizeof(float),
+                          (void*)(3*sizeof(float)));
+    glEnableVertexAttribArray(2);
+    glVertexAttribPointer(2, 1, GL_FLOAT, GL_FALSE, 8*sizeof(float),
+                          (void*)(7*sizeof(float)));
     glBindVertexArray(0);
 
     /* --- Build-mode preview lines --- */
@@ -994,6 +1021,44 @@ void render_frame(const float view[16], const float proj[16],
         glDisable(GL_BLEND);
     }
 
+    /* ------------------------------------------------------------------ 3. Collision particles */
+    {
+        CollisionParticle particles[RENDER_MAX_COLLISION_PARTICLES];
+        float particle_data[RENDER_MAX_COLLISION_PARTICLES * 8];
+        int particle_count = collision_particles(particles, RENDER_MAX_COLLISION_PARTICLES,
+                                                 g_cam.pos);
+
+        for (int i = 0; i < particle_count; i++) {
+            particle_data[i*8+0] = particles[i].pos[0];
+            particle_data[i*8+1] = particles[i].pos[1];
+            particle_data[i*8+2] = particles[i].pos[2];
+            particle_data[i*8+3] = particles[i].color[0];
+            particle_data[i*8+4] = particles[i].color[1];
+            particle_data[i*8+5] = particles[i].color[2];
+            particle_data[i*8+6] = particles[i].color[3];
+            particle_data[i*8+7] = particles[i].size;
+        }
+
+        if (particle_count > 0) {
+            glUseProgram(s_impact_particle_shader);
+            glUniformMatrix4fv(s_impact_particle_vp, 1, GL_FALSE, vp_camrel);
+            glBindVertexArray(s_impact_particle_vao);
+            glBindBuffer(GL_ARRAY_BUFFER, s_impact_particle_vbo);
+            glBufferSubData(GL_ARRAY_BUFFER, 0,
+                            particle_count * 8 * sizeof(float), particle_data);
+            glEnable(GL_BLEND);
+            glBlendFunc(GL_SRC_ALPHA, GL_ONE);
+            glDepthMask(GL_FALSE);
+            glEnable(GL_DEPTH_TEST);
+            glEnable(GL_PROGRAM_POINT_SIZE);
+            glDrawArrays(GL_POINTS, 0, particle_count);
+            glDisable(GL_PROGRAM_POINT_SIZE);
+            glDepthMask(GL_TRUE);
+            glDisable(GL_BLEND);
+            glBindVertexArray(0);
+        }
+    }
+
     /* ------------------------------------------------------------------ 3. Center dots
      * Priority: Sun(0) > planets > moons. Within each tier: closer first.
      * Overlap check in screen space: two dots clash if their centres are
@@ -1284,6 +1349,7 @@ void render_shutdown(void) {
     glDeleteProgram(s_sphere_shader);
     glDeleteProgram(s_atm_shader);
     glDeleteProgram(s_dot_shader);
+    glDeleteProgram(s_impact_particle_shader);
     glDeleteProgram(s_glare_shader);
     glDeleteProgram(s_build_line_shader);
     glDeleteProgram(s_build_ui_shader);
@@ -1292,11 +1358,14 @@ void render_shutdown(void) {
     glDeleteVertexArrays(1, &s_sphere_vao);
     glDeleteBuffers(1, &s_dot_vbo);
     glDeleteVertexArrays(1, &s_dot_vao);
+    glDeleteBuffers(1, &s_impact_particle_vbo);
+    glDeleteVertexArrays(1, &s_impact_particle_vao);
     glDeleteBuffers(1, &s_build_line_vbo);
     glDeleteVertexArrays(1, &s_build_line_vao);
     glDeleteBuffers(1, &s_build_ui_vbo);
     glDeleteVertexArrays(1, &s_build_ui_vao);
     s_sphere_shader = s_dot_shader = 0;
+    s_impact_particle_shader = 0;
     s_build_line_shader = s_build_ui_shader = 0;
     s_build_font = NULL;
 }

--- a/src/render.c
+++ b/src/render.c
@@ -54,6 +54,7 @@ static GLint  s_sp_impact_t1    = -1;
 static GLint  s_sp_impact_rad   = -1;
 static GLint  s_sp_impact_heat  = -1;
 static GLint  s_sp_impact_prog  = -1;
+static GLint  s_sp_impact_seed  = -1;
 static GLint  s_sp_impact_kind  = -1;
 
 /* Planet-type lookup by body name — robust against loader order changes.
@@ -402,6 +403,7 @@ void render_init(void) {
     s_sp_impact_rad   = glGetUniformLocation(s_sphere_shader, "u_impact_radius[0]");
     s_sp_impact_heat  = glGetUniformLocation(s_sphere_shader, "u_impact_heat[0]");
     s_sp_impact_prog  = glGetUniformLocation(s_sphere_shader, "u_impact_progress[0]");
+    s_sp_impact_seed  = glGetUniformLocation(s_sphere_shader, "u_impact_seed[0]");
     s_sp_impact_kind  = glGetUniformLocation(s_sphere_shader, "u_impact_kind[0]");
 
     /* Frame-constant camera parameters */
@@ -923,6 +925,7 @@ void render_frame(const float view[16], const float proj[16],
             float radii[COLLISION_MAX_SPOTS] = {0};
             float heats[COLLISION_MAX_SPOTS] = {0};
             float progress[COLLISION_MAX_SPOTS] = {0};
+            float seeds[COLLISION_MAX_SPOTS] = {0};
             int kinds[COLLISION_MAX_SPOTS] = {0};
             int nspots = collision_spots_for_body(i, spots);
             for (int k = 0; k < nspots; k++) {
@@ -935,6 +938,7 @@ void render_frame(const float view[16], const float proj[16],
                 radii[k] = spots[k].angular_radius;
                 heats[k] = spots[k].heat;
                 progress[k] = spots[k].progress;
+                seeds[k] = spots[k].seed;
                 kinds[k] = spots[k].kind;
             }
             glUniform1i(s_sp_impact_count, nspots);
@@ -943,6 +947,7 @@ void render_frame(const float view[16], const float proj[16],
             glUniform1fv(s_sp_impact_rad, nspots, radii);
             glUniform1fv(s_sp_impact_heat, nspots, heats);
             glUniform1fv(s_sp_impact_prog, nspots, progress);
+            glUniform1fv(s_sp_impact_seed, nspots, seeds);
             glUniform1iv(s_sp_impact_kind, nspots, kinds);
         }
 

--- a/src/render.c
+++ b/src/render.c
@@ -17,6 +17,7 @@
 #include "asteroids.h"
 #include "labels.h"
 #include "build.h"
+#include "collision.h"
 #include "gl_utils.h"
 #include "math3d.h"
 #include <math.h>
@@ -47,6 +48,12 @@ static GLint  s_sp_sun_world   = -1;
 static GLint  s_sp_rotation    = -1;
 static GLint  s_sp_obliquity   = -1;
 static GLint  s_sp_ptype       = -1;
+static GLint  s_sp_impact_count = -1;
+static GLint  s_sp_impact_dir   = -1;
+static GLint  s_sp_impact_rad   = -1;
+static GLint  s_sp_impact_heat  = -1;
+static GLint  s_sp_impact_prog  = -1;
+static GLint  s_sp_impact_kind  = -1;
 
 /* Planet-type lookup by body name — robust against loader order changes.
  * 0=rocky(default)  1=Earth  2=Mars  3=Venus  4=Jupiter  5=Saturn
@@ -225,7 +232,7 @@ static float clampf_local(float v, float lo, float hi)
  * Bodies too small to see as a disc are rendered as dots instead. */
 static float visual_radius(int i, float dcam) {
     (void)dcam;
-    return (float)(g_bodies[i].radius * RS);
+    return (float)(collision_visual_radius(i, g_bodies[i].radius) * RS);
 }
 
 static double smoothstepd(double edge0, double edge1, double x) {
@@ -253,7 +260,7 @@ static float body_point_star_glare_visibility(int body_idx) {
     for (int i = 0; i < g_nbodies; i++) {
         if (i == body_idx) continue;
         Body *s = &g_bodies[i];
-        if (!s->is_star) continue;
+        if (!s->alive || !s->is_star) continue;
 
         double sx = s->pos[0] * RS - g_cam.pos[0];
         double sy = s->pos[1] * RS - g_cam.pos[1];
@@ -294,7 +301,7 @@ static int body_point_occluded_by_body(int body_idx, const BodyRenderInfo info[]
 
     for (int i = 0; i < g_nbodies; i++) {
         if (i == body_idx) continue;
-        if (g_bodies[i].is_star || info[i].show) continue;
+        if (!g_bodies[i].alive || g_bodies[i].is_star || info[i].show) continue;
 
         double sx = g_bodies[i].pos[0] * RS - g_cam.pos[0];
         double sy = g_bodies[i].pos[1] * RS - g_cam.pos[1];
@@ -344,6 +351,12 @@ void render_init(void) {
     s_sp_rotation  = glGetUniformLocation(s_sphere_shader, "u_rotation");
     s_sp_obliquity = glGetUniformLocation(s_sphere_shader, "u_obliquity");
     s_sp_ptype     = glGetUniformLocation(s_sphere_shader, "u_planet_type");
+    s_sp_impact_count = glGetUniformLocation(s_sphere_shader, "u_impact_count");
+    s_sp_impact_dir   = glGetUniformLocation(s_sphere_shader, "u_impact_dir[0]");
+    s_sp_impact_rad   = glGetUniformLocation(s_sphere_shader, "u_impact_radius[0]");
+    s_sp_impact_heat  = glGetUniformLocation(s_sphere_shader, "u_impact_heat[0]");
+    s_sp_impact_prog  = glGetUniformLocation(s_sphere_shader, "u_impact_progress[0]");
+    s_sp_impact_kind  = glGetUniformLocation(s_sphere_shader, "u_impact_kind[0]");
 
     /* Frame-constant camera parameters */
     glUseProgram(s_sphere_shader);
@@ -754,6 +767,11 @@ void render_frame(const float view[16], const float proj[16],
 
     for (int i = 0; i < g_nbodies; i++) {
         Body *b = &g_bodies[i];
+        if (!b->alive) {
+            memset(&info[i], 0, sizeof(info[i]));
+            info[i].show = 1;
+            continue;
+        }
 
         float wx = (float)(b->pos[0] * RS);
         float wy = (float)(b->pos[1] * RS);
@@ -796,7 +814,7 @@ void render_frame(const float view[16], const float proj[16],
         info[i].show = (px < BODY_SPHERE_APPEAR_PX) ? 1 : 0;
 
         /* Sub-pixel bodies are shown as dots only — skip billboard render. */
-        if (info[i].show) continue;
+        if (!g_bodies[i].alive || info[i].show) continue;
         if (b->is_star) continue;
 
         /* Compute oc = cam - center in double to avoid float cancellation. */
@@ -831,6 +849,30 @@ void render_frame(const float view[16], const float proj[16],
         glUniform1f(s_sp_rotation,  (float)b->rotation_angle);
         glUniform1f(s_sp_obliquity, (float)(b->obliquity * (PI / 180.0)));
         glUniform1i(s_sp_ptype,     get_planet_type(b->name));
+        {
+            CollisionSpot spots[COLLISION_MAX_SPOTS];
+            float dirs[COLLISION_MAX_SPOTS * 3] = {0};
+            float radii[COLLISION_MAX_SPOTS] = {0};
+            float heats[COLLISION_MAX_SPOTS] = {0};
+            float progress[COLLISION_MAX_SPOTS] = {0};
+            int kinds[COLLISION_MAX_SPOTS] = {0};
+            int nspots = collision_spots_for_body(i, spots);
+            for (int k = 0; k < nspots; k++) {
+                dirs[k*3+0] = spots[k].dir[0];
+                dirs[k*3+1] = spots[k].dir[1];
+                dirs[k*3+2] = spots[k].dir[2];
+                radii[k] = spots[k].angular_radius;
+                heats[k] = spots[k].heat;
+                progress[k] = spots[k].progress;
+                kinds[k] = spots[k].kind;
+            }
+            glUniform1i(s_sp_impact_count, nspots);
+            glUniform3fv(s_sp_impact_dir, COLLISION_MAX_SPOTS, dirs);
+            glUniform1fv(s_sp_impact_rad, COLLISION_MAX_SPOTS, radii);
+            glUniform1fv(s_sp_impact_heat, COLLISION_MAX_SPOTS, heats);
+            glUniform1fv(s_sp_impact_prog, COLLISION_MAX_SPOTS, progress);
+            glUniform1iv(s_sp_impact_kind, COLLISION_MAX_SPOTS, kinds);
+        }
 
         glDrawElements(GL_TRIANGLES, 6, GL_UNSIGNED_INT, 0);
     }
@@ -855,6 +897,7 @@ void render_frame(const float view[16], const float proj[16],
         glBindVertexArray(s_sphere_vao);
 
         for (int i = 0; i < g_nbodies; i++) {
+            if (!g_bodies[i].alive) continue;
             if (info[i].show) continue;     /* sub-pixel body — skip */
             float intensity = g_bodies[i].atm_intensity;
             float scale     = g_bodies[i].atm_scale;
@@ -911,6 +954,7 @@ void render_frame(const float view[16], const float proj[16],
     int dot_ns = 0, dot_np = 0, dot_nm = 0;
     int dot_stars[MAX_BODIES], dot_planets[MAX_BODIES], dot_moons[MAX_BODIES];
     for (int i = 0; i < g_nbodies; i++) {
+        if (!g_bodies[i].alive) continue;
         if      (g_bodies[i].is_star)       dot_stars  [dot_ns++] = i;
         /* planet: no parent, or parent is a star (not a moon of a planet) */
         else if (g_bodies[i].parent < 0 ||
@@ -938,6 +982,7 @@ void render_frame(const float view[16], const float proj[16],
     for (int i = 0; i < dot_ns; i++) dot_order[i]                  = dot_stars[i];
     for (int i = 0; i < dot_np; i++) dot_order[dot_ns + i]          = dot_planets[i];
     for (int i = 0; i < dot_nm; i++) dot_order[dot_ns + dot_np + i] = dot_moons[i];
+    int dot_total = dot_ns + dot_np + dot_nm;
 
     /* Project to screen, greedy overlap removal, collect surviving dots.
      *
@@ -962,8 +1007,9 @@ void render_frame(const float view[16], const float proj[16],
         double cy2 = g_cam.pos[1];
         double cz2 = g_cam.pos[2];
 
-        for (int oi = 0; oi < g_nbodies; oi++) {
+        for (int oi = 0; oi < dot_total; oi++) {
             int i = dot_order[oi];
+            if (!g_bodies[i].alive) continue;
             if (body_point_star_glare_visibility(i) <= 0.02f) continue;
             if (g_bodies[i].is_star &&
                 body_px[i] * STAR_GLARE_BILL_SCALE >= STAR_DOT_FADE_START_GLARE_PX) continue;
@@ -1057,8 +1103,9 @@ void render_frame(const float view[16], const float proj[16],
          * even at warp distances (far beyond the 2000 AU far plane).          */
         const float DOT_CLAMP_DIST = 1500.0f;
 
-        for (int oi = 0; oi < g_nbodies; oi++) {
+        for (int oi = 0; oi < dot_total; oi++) {
             int i = dot_order[oi];
+            if (!g_bodies[i].alive) continue;
             if (!dot_candidate[i] || dot_overlap_alpha[i] <= 0.001f) continue;
             Body *b = &g_bodies[i];
 
@@ -1155,6 +1202,7 @@ void render_frame(const float view[16], const float proj[16],
         glBindVertexArray(s_sphere_vao);
 
         for (int i = 0; i < g_nbodies; i++) {
+            if (!g_bodies[i].alive) continue;
             if (!g_bodies[i].is_star) continue;
 
             float rx = (float)(g_bodies[i].pos[0] * RS - g_cam.pos[0]);

--- a/src/render.c
+++ b/src/render.c
@@ -937,7 +937,6 @@ void render_frame(const float view[16], const float proj[16],
         for (int i = 0; i < g_nbodies; i++) {
             if (!g_bodies[i].alive) continue;
             if (info[i].show) continue;     /* sub-pixel body — skip */
-            if (collision_body_has_active_merge(i)) continue;
             float intensity = g_bodies[i].atm_intensity;
             float scale     = g_bodies[i].atm_scale;
             float glow_color[3];

--- a/src/render.c
+++ b/src/render.c
@@ -50,6 +50,7 @@ static GLint  s_sp_obliquity   = -1;
 static GLint  s_sp_ptype       = -1;
 static GLint  s_sp_impact_count = -1;
 static GLint  s_sp_impact_dir   = -1;
+static GLint  s_sp_impact_t1    = -1;
 static GLint  s_sp_impact_rad   = -1;
 static GLint  s_sp_impact_heat  = -1;
 static GLint  s_sp_impact_prog  = -1;
@@ -397,6 +398,7 @@ void render_init(void) {
     s_sp_ptype     = glGetUniformLocation(s_sphere_shader, "u_planet_type");
     s_sp_impact_count = glGetUniformLocation(s_sphere_shader, "u_impact_count");
     s_sp_impact_dir   = glGetUniformLocation(s_sphere_shader, "u_impact_dir[0]");
+    s_sp_impact_t1    = glGetUniformLocation(s_sphere_shader, "u_impact_tangent1[0]");
     s_sp_impact_rad   = glGetUniformLocation(s_sphere_shader, "u_impact_radius[0]");
     s_sp_impact_heat  = glGetUniformLocation(s_sphere_shader, "u_impact_heat[0]");
     s_sp_impact_prog  = glGetUniformLocation(s_sphere_shader, "u_impact_progress[0]");
@@ -917,6 +919,7 @@ void render_frame(const float view[16], const float proj[16],
         {
             CollisionSpot spots[COLLISION_MAX_SPOTS];
             float dirs[COLLISION_MAX_SPOTS * 3] = {0};
+            float tangents[COLLISION_MAX_SPOTS * 3] = {0};
             float radii[COLLISION_MAX_SPOTS] = {0};
             float heats[COLLISION_MAX_SPOTS] = {0};
             float progress[COLLISION_MAX_SPOTS] = {0};
@@ -926,6 +929,9 @@ void render_frame(const float view[16], const float proj[16],
                 dirs[k*3+0] = spots[k].dir[0];
                 dirs[k*3+1] = spots[k].dir[1];
                 dirs[k*3+2] = spots[k].dir[2];
+                tangents[k*3+0] = spots[k].tangent1[0];
+                tangents[k*3+1] = spots[k].tangent1[1];
+                tangents[k*3+2] = spots[k].tangent1[2];
                 radii[k] = spots[k].angular_radius;
                 heats[k] = spots[k].heat;
                 progress[k] = spots[k].progress;
@@ -933,6 +939,7 @@ void render_frame(const float view[16], const float proj[16],
             }
             glUniform1i(s_sp_impact_count, nspots);
             glUniform3fv(s_sp_impact_dir, nspots, dirs);
+            glUniform3fv(s_sp_impact_t1, nspots, tangents);
             glUniform1fv(s_sp_impact_rad, nspots, radii);
             glUniform1fv(s_sp_impact_heat, nspots, heats);
             glUniform1fv(s_sp_impact_prog, nspots, progress);

--- a/src/render.c
+++ b/src/render.c
@@ -69,6 +69,11 @@ static int get_planet_type(const char *name)
         { "Europa",  9 }, { NULL,      0 }
     };
     int k;
+    if (!name) return 0;
+    if (strncmp(name, "Rocky Planet", 12) == 0) return 10;
+    if (strncmp(name, "Gas Giant", 9) == 0) return 11;
+    if (strncmp(name, "Ice Planet", 10) == 0) return 12;
+    if (strncmp(name, "Dwarf Planet", 12) == 0) return 0;
     for (k = 0; tbl[k].name; k++)
         if (strcmp(name, tbl[k].name) == 0) return tbl[k].ptype;
     return 0;   /* rocky / default for everything else */

--- a/src/render.c
+++ b/src/render.c
@@ -287,6 +287,44 @@ static float body_point_star_glare_visibility(int body_idx) {
     return (float)visibility;
 }
 
+static float system_dot_fade_for_body(int body_idx)
+{
+    int ref_star;
+    double sdx, sdy, sdz, dist_star;
+    float dot_fade;
+    const double FREE_DOT_FADE_START = 400.0;
+    const double FREE_DOT_FADE_END = 800.0;
+
+    if (body_idx < 0 || body_idx >= g_nbodies) return 1.0f;
+    if (g_bodies[body_idx].is_star) return 1.0f;
+
+    ref_star = body_root_star(body_idx);
+    if (ref_star < 0 || ref_star >= g_nbodies ||
+        !g_bodies[ref_star].alive || !g_bodies[ref_star].is_star) {
+        double bx = g_bodies[body_idx].pos[0] * RS - g_cam.pos[0];
+        double by = g_bodies[body_idx].pos[1] * RS - g_cam.pos[1];
+        double bz = g_bodies[body_idx].pos[2] * RS - g_cam.pos[2];
+        double dist_body = sqrt(bx*bx + by*by + bz*bz);
+
+        dot_fade = 1.0f - (float)((dist_body - FREE_DOT_FADE_START)
+                                / (FREE_DOT_FADE_END - FREE_DOT_FADE_START));
+        if (dot_fade > 1.0f) dot_fade = 1.0f;
+        if (dot_fade < 0.0f) dot_fade = 0.0f;
+        return dot_fade;
+    }
+
+    sdx = g_cam.pos[0] - g_bodies[ref_star].pos[0] * RS;
+    sdy = g_cam.pos[1] - g_bodies[ref_star].pos[1] * RS;
+    sdz = g_cam.pos[2] - g_bodies[ref_star].pos[2] * RS;
+    dist_star = sqrt(sdx*sdx + sdy*sdy + sdz*sdz);
+
+    dot_fade = 1.0f - (float)((dist_star - SYS_DOT_FADE_START)
+                            / (SYS_DOT_FADE_END - SYS_DOT_FADE_START));
+    if (dot_fade > 1.0f) dot_fade = 1.0f;
+    if (dot_fade < 0.0f) dot_fade = 0.0f;
+    return dot_fade;
+}
+
 static int body_point_occluded_by_body(int body_idx, const BodyRenderInfo info[]) {
     double bx = g_bodies[body_idx].pos[0] * RS - g_cam.pos[0];
     double by = g_bodies[body_idx].pos[1] * RS - g_cam.pos[1];
@@ -1081,25 +1119,6 @@ void render_frame(const float view[16], const float proj[16],
         }
     }
 
-    /* Distance from camera to nearest star — used for LOD dot fade.
-     * Non-star dots fade from opaque at SYS_DOT_FADE_START to transparent
-     * at SYS_DOT_FADE_END.  The star dot is handled by its own glare fade.
-     * Subtraction is done in double BEFORE casting to float to avoid the
-     * catastrophic float cancellation that occurs at 4+ ly (camera and star
-     * both at ~250,000 AU → float32 difference is meaningless).               */
-    float dot_fade = 1.0f;
-    {
-        int ref_star = nearest_star_idx();
-        float sdx = (float)(g_cam.pos[0] - g_bodies[ref_star].pos[0] * RS);
-        float sdy = (float)(g_cam.pos[1] - g_bodies[ref_star].pos[1] * RS);
-        float sdz = (float)(g_cam.pos[2] - g_bodies[ref_star].pos[2] * RS);
-        float dist_star = sqrtf(sdx*sdx + sdy*sdy + sdz*sdz);
-        dot_fade = 1.0f - (dist_star - SYS_DOT_FADE_START)
-                        / (SYS_DOT_FADE_END - SYS_DOT_FADE_START);
-        if (dot_fade > 1.0f) dot_fade = 1.0f;
-        if (dot_fade < 0.0f) dot_fade = 0.0f;
-    }
-
     /* Upload and draw surviving dots.
      * Positions are camera-relative (world_AU - cam_AU), matching the
      * convention used for trails and labels.  The dot shader is given
@@ -1129,7 +1148,7 @@ void render_frame(const float view[16], const float proj[16],
             Body *b = &g_bodies[i];
 
             /* LOD fade: star always full; planets/moons fade in interstellar space */
-            float f = b->is_star ? 1.0f : dot_fade;
+            float f = b->is_star ? 1.0f : system_dot_fade_for_body(i);
             f *= dot_overlap_alpha[i];
             f *= body_point_star_glare_visibility(i);
 

--- a/src/render.c
+++ b/src/render.c
@@ -1363,6 +1363,7 @@ void render_shutdown(void) {
     for (int i = 0; i < 3; i++)
         if (s_build_dist_text[i].tex) glDeleteTextures(1, &s_build_dist_text[i].tex);
     if (s_build_font) TTF_CloseFont(s_build_font);
+    TTF_Quit();
     glDeleteProgram(s_sphere_shader);
     glDeleteProgram(s_atm_shader);
     glDeleteProgram(s_dot_shader);

--- a/src/render.c
+++ b/src/render.c
@@ -48,6 +48,7 @@ static GLint  s_sp_sun_world   = -1;
 static GLint  s_sp_rotation    = -1;
 static GLint  s_sp_obliquity   = -1;
 static GLint  s_sp_ptype       = -1;
+static GLint  s_sp_star_heat   = -1;
 static GLint  s_sp_impact_count = -1;
 static GLint  s_sp_impact_dir   = -1;
 static GLint  s_sp_impact_t1    = -1;
@@ -402,6 +403,7 @@ void render_init(void) {
     s_sp_rotation  = glGetUniformLocation(s_sphere_shader, "u_rotation");
     s_sp_obliquity = glGetUniformLocation(s_sphere_shader, "u_obliquity");
     s_sp_ptype     = glGetUniformLocation(s_sphere_shader, "u_planet_type");
+    s_sp_star_heat = glGetUniformLocation(s_sphere_shader, "u_star_heat");
     s_sp_impact_count = glGetUniformLocation(s_sphere_shader, "u_impact_count");
     s_sp_impact_dir   = glGetUniformLocation(s_sphere_shader, "u_impact_dir[0]");
     s_sp_impact_t1    = glGetUniformLocation(s_sphere_shader, "u_impact_tangent1[0]");
@@ -923,6 +925,7 @@ void render_frame(const float view[16], const float proj[16],
         glUniform1f(s_sp_rotation,  (float)fmod(b->rotation_angle, 2.0 * PI));
         glUniform1f(s_sp_obliquity, (float)(b->obliquity * (PI / 180.0)));
         glUniform1i(s_sp_ptype,     get_planet_type(b->name));
+        glUniform1f(s_sp_star_heat, collision_body_star_heat(i));
         {
             CollisionSpot spots[COLLISION_MAX_SPOTS];
             float dirs[COLLISION_MAX_SPOTS * 3] = {0};

--- a/src/render.c
+++ b/src/render.c
@@ -20,6 +20,7 @@
 #include "collision.h"
 #include "gl_utils.h"
 #include "math3d.h"
+#include "ui_theme.h"
 #include <math.h>
 #include <string.h>
 
@@ -142,7 +143,7 @@ static GLint  s_build_ui_use_tex = -1;
 static GLint  s_build_ui_tex = -1;
 static TTF_Font *s_build_font = NULL;
 
-#define BUILD_UI_FONT_SIZE 14.0f
+#define BUILD_UI_FONT_SIZE 16.0f
 
 typedef struct {
     GLuint tex;
@@ -155,21 +156,6 @@ static BuildTextCache s_build_dist_text[3];
 /* ------------------------------------------------------------------ helpers */
 static float half_fov_tan(void) {
     return tanf(FOV * 0.5f * (float)(PI / 180.0));
-}
-
-static TTF_Font *build_find_font(int size) {
-    static const char *paths[] = {
-        "C:/Windows/Fonts/segoeui.ttf",
-        "C:/Windows/Fonts/arial.ttf",
-        "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf",
-        "/usr/share/fonts/TTF/DejaVuSans.ttf",
-        NULL
-    };
-    for (int i = 0; paths[i]; i++) {
-        TTF_Font *f = TTF_OpenFont(paths[i], size);
-        if (f) return f;
-    }
-    return NULL;
 }
 
 static GLuint build_surface_to_tex(SDL_Surface *surf, int *w, int *h) {
@@ -557,7 +543,7 @@ void render_init(void) {
         glUseProgram(0);
     }
     TTF_Init();
-    s_build_font = build_find_font((int)BUILD_UI_FONT_SIZE);
+    s_build_font = ui_theme_open_font((int)BUILD_UI_FONT_SIZE);
 }
 
 static void render_build_preview(const float vp_camrel[16])

--- a/src/rings.c
+++ b/src/rings.c
@@ -64,6 +64,28 @@ static void build_basis(ParticleDisc *d, float obl_deg)
     d->pole[0] = 0.0f; d->pole[1] = cosf(obl); d->pole[2] = sinf(obl);
 }
 
+static void retune_disc_parent(ParticleDisc *d, int parent_idx)
+{
+    if (!d || parent_idx < 0 || parent_idx >= g_nbodies) return;
+    d->parent_idx = parent_idx;
+    build_basis(d, (float)g_bodies[parent_idx].obliquity);
+
+    double gm = G_CONST * g_bodies[parent_idx].mass;
+    if (gm <= 0.0) {
+        d->initialized = 0;
+        return;
+    }
+    for (int i = 0; i < d->n_full; i++) {
+        double a_m = (double)d->data_full[i*8+1] * AU;
+        d->n_arr_full[i] = (float)sqrt(gm / (a_m * a_m * a_m));
+    }
+    for (int i = 0; i < d->n_lod; i++) {
+        double a_m = (double)d->data_lod[i*8+1] * AU;
+        d->n_arr_lod[i] = (float)sqrt(gm / (a_m * a_m * a_m));
+    }
+    d->initialized = 1;
+}
+
 /* ── bake_particles ─────────────────────────────────────────────────── */
 static void bake_particles(float *data, float *n_arr, int n,
                             const Zone *zones, int n_zones,
@@ -384,6 +406,8 @@ void rings_tick(double dt)
     for (int d = 0; d < s_n_discs; d++) {
         ParticleDisc *disc = &s_discs[d];
         if (!disc->initialized) continue;
+        if (disc->parent_idx < 0 || disc->parent_idx >= g_nbodies) continue;
+        if (!g_bodies[disc->parent_idx].alive) continue;
 
         for (int i = 0; i < disc->n_full; i++) {
             float M = disc->data_full[i*8+0]
@@ -403,8 +427,38 @@ void rings_tick(double dt)
 void rings_render(const float vp[16])
 {
     for (int d = 0; d < s_n_discs; d++) {
-        if (s_discs[d].initialized)
+        if (s_discs[d].initialized &&
+            s_discs[d].parent_idx >= 0 &&
+            s_discs[d].parent_idx < g_nbodies &&
+            g_bodies[s_discs[d].parent_idx].alive)
             render_disc(&s_discs[d], vp);
+    }
+}
+
+void rings_on_body_absorbed(int target_idx, int impactor_idx)
+{
+    for (int d = 0; d < s_n_discs; d++) {
+        ParticleDisc *disc = &s_discs[d];
+        if (!disc->initialized) continue;
+
+        if (disc->parent_idx == impactor_idx) {
+            int target_has_ring = 0;
+            for (int k = 0; k < s_n_discs; k++) {
+                if (k == d || !s_discs[k].initialized) continue;
+                if (s_discs[k].parent_idx == target_idx) {
+                    target_has_ring = 1;
+                    break;
+                }
+            }
+            if (target_has_ring || target_idx < 0 || target_idx >= g_nbodies ||
+                !g_bodies[target_idx].alive || g_bodies[target_idx].is_star) {
+                disc->initialized = 0;
+            } else {
+                retune_disc_parent(disc, target_idx);
+            }
+        } else if (disc->parent_idx == target_idx) {
+            retune_disc_parent(disc, target_idx);
+        }
     }
 }
 

--- a/src/rings.h
+++ b/src/rings.h
@@ -60,4 +60,5 @@ typedef struct {
 void rings_init(const char *path);
 void rings_tick(double dt);         /* advance mean anomalies — call each physics sub-step */
 void rings_render(const float vp[16]);
+void rings_on_body_absorbed(int target_idx, int impactor_idx);
 void rings_shutdown(void);

--- a/src/trails.c
+++ b/src/trails.c
@@ -116,6 +116,45 @@ void trails_add_body(int body_idx)
     s_n = new_n;
 }
 
+void trails_remove_body(int body_idx)
+{
+    if (body_idx < 0 || body_idx >= s_n) return;
+    s_last_head[body_idx] = 0;
+    s_last_count[body_idx] = 0;
+    if (body_idx < g_nbodies) {
+        g_bodies[body_idx].trail_head = 0;
+        g_bodies[body_idx].trail_count = 0;
+        g_bodies[body_idx].trail_accum = 0.0;
+    }
+}
+
+void trails_reset_body(int body_idx)
+{
+    Body *b;
+    double x, y, z;
+
+    if (body_idx < 0 || body_idx >= g_nbodies) return;
+    b = &g_bodies[body_idx];
+    if (!b->trail) return;
+
+    x = b->pos[0] * RS;
+    y = b->pos[1] * RS;
+    z = b->pos[2] * RS;
+    for (int i = 0; i < TRAIL_LEN; i++) {
+        b->trail[i][0] = x;
+        b->trail[i][1] = y;
+        b->trail[i][2] = z;
+    }
+    b->trail_head = 2 % TRAIL_LEN;
+    b->trail_count = 2;
+    b->trail_accum = 0.0;
+
+    if (body_idx < s_n) {
+        s_last_head[body_idx] = -1;
+        s_last_count[body_idx] = -1;
+    }
+}
+
 void trails_render(const float vp[16])
 {
     if (!s_shader) return;
@@ -152,7 +191,7 @@ void trails_render(const float vp[16])
 
     for (int i = 0; i < g_nbodies && i < s_n; i++) {
         Body *b = &g_bodies[i];
-        if (b->is_star || b->trail_count < 2 || !b->trail) continue;
+        if (!b->alive || b->is_star || b->trail_count < 2 || !b->trail) continue;
 
         const int head  = b->trail_head;
         const int count = b->trail_count;

--- a/src/trails.c
+++ b/src/trails.c
@@ -191,7 +191,8 @@ void trails_render(const float vp[16])
 
     for (int i = 0; i < g_nbodies && i < s_n; i++) {
         Body *b = &g_bodies[i];
-        if (!b->alive || b->is_star || b->trail_count < 2 || !b->trail) continue;
+        if (b->is_star || b->trail_count < 2 || !b->trail) continue;
+        if (!b->alive && b->trail_fade <= 0.0) continue;
 
         const int head  = b->trail_head;
         const int count = b->trail_count;
@@ -218,19 +219,25 @@ void trails_render(const float vp[16])
             s_last_count[i] = count;
         }
 
-        /* Always write the current live position as the final vertex so the
-         * trail tip follows the planet every frame even without a new sample.
-         * Camera-relative, same double-precision subtraction as above. */
-        float live[3] = {
-            (float)(b->pos[0] * RS - g_cam.pos[0]),
-            (float)(b->pos[1] * RS - g_cam.pos[1]),
-            (float)(b->pos[2] * RS - g_cam.pos[2])
-        };
-        glBufferSubData(GL_ARRAY_BUFFER,
-                        count * 3 * sizeof(float), sizeof(live), live);
+        int draw_count;
+        if (b->alive && b->trail_interval > 0.0) {
+            /* Append the live planet position as the final vertex so the
+             * trail tip follows the planet every frame without a new sample.
+             * Camera-relative, double-precision subtraction as above. */
+            float live[3] = {
+                (float)(b->pos[0] * RS - g_cam.pos[0]),
+                (float)(b->pos[1] * RS - g_cam.pos[1]),
+                (float)(b->pos[2] * RS - g_cam.pos[2])
+            };
+            glBufferSubData(GL_ARRAY_BUFFER,
+                            count * 3 * sizeof(float), sizeof(live), live);
+            draw_count = count + 1;
+        } else {
+            draw_count = count;
+        }
 
-        int draw_count = count + 1;
-        glUniform4f(s_loc_color, b->col[0], b->col[1], b->col[2], 0.6f * trail_fade);
+        float alpha = 0.6f * (float)b->trail_fade * trail_fade;
+        glUniform4f(s_loc_color, b->col[0], b->col[1], b->col[2], alpha);
         glUniform1i(s_loc_count, draw_count);
         glDrawArrays(GL_LINE_STRIP, 0, draw_count);
     }

--- a/src/trails.c
+++ b/src/trails.c
@@ -6,11 +6,14 @@
  * then uploaded here for rendering.
  *
  * Render strategy:
- *   - Trail positions are stored camera-relative in the VBO (world − cam),
- *     computed in double precision on the CPU before converting to float.
- *     This eliminates float cancellation jitter that arises when subtracting
- *     two large absolute AU-scale positions of similar magnitude.
- *   - Dirty check: re-upload when new samples were recorded OR the camera moved.
+ *   - VBO stores positions relative to a per-body reference point (the body's
+ *     world position at the time of last upload). This keeps VBO values small,
+ *     preserving float precision for the trail shape.
+ *   - Camera offset is applied in the shader via u_body_offset = ref - cam_pos,
+ *     computed CPU-side in double precision to avoid float cancellation jitter.
+ *   - Dirty check: re-upload ONLY when new trail samples were recorded.
+ *     Camera movement no longer triggers VBO re-uploads — only a cheap
+ *     glUniform3fv call per body per frame is needed instead.
  *   - The scratch buffer linearises the circular buffer (oldest→newest)
  *     and appends the live planet position as the final vertex.
  */
@@ -30,13 +33,14 @@ static int     s_n   = 0;
 static int *s_last_head  = NULL;
 static int *s_last_count = NULL;
 
-static GLuint s_shader    = 0;
-static GLint  s_loc_vp    = -1;
-static GLint  s_loc_color = -1;
+static GLuint s_shader          = 0;
+static GLint  s_loc_vp          = -1;
+static GLint  s_loc_color       = -1;
+static GLint  s_loc_body_offset = -1;
 
-/* Last camera position — used to detect when a re-upload is needed even if no
- * new trail samples were recorded (camera moved → camera-relative VBO is stale) */
-static double s_last_cam[3] = {0.0, 0.0, 0.0};
+/* Per-body reference position (world units) used as VBO origin.
+ * Stored at the time of each VBO upload; valid until the next upload. */
+static double (*s_ref_pos)[3] = NULL;
 
 /* Scratch: linearised trail + live position, interleaved xyz + alpha. */
 static float s_scratch[(TRAIL_LEN + 1) * 4];
@@ -49,14 +53,16 @@ void trails_gl_init(void)
                               "assets/shaders/solid.frag");
     if (!s_shader) return;
 
-    s_loc_vp    = glGetUniformLocation(s_shader, "u_vp");
-    s_loc_color = glGetUniformLocation(s_shader, "u_color");
+    s_loc_vp          = glGetUniformLocation(s_shader, "u_vp");
+    s_loc_color       = glGetUniformLocation(s_shader, "u_color");
+    s_loc_body_offset = glGetUniformLocation(s_shader, "u_body_offset");
     s_n          = g_nbodies;
     s_vao        = (GLuint*)malloc(s_n * sizeof(GLuint));
     s_vbo        = (GLuint*)malloc(s_n * sizeof(GLuint));
     s_last_head  = (int*)   malloc(s_n * sizeof(int));
     s_last_count = (int*)   malloc(s_n * sizeof(int));
-    if (!s_vao || !s_vbo || !s_last_head || !s_last_count) return;
+    s_ref_pos    = (double(*)[3])calloc(s_n, sizeof(*s_ref_pos));
+    if (!s_vao || !s_vbo || !s_last_head || !s_last_count || !s_ref_pos) return;
 
     for (int i = 0; i < s_n; i++) {
         s_last_head[i]  = 0;
@@ -85,8 +91,9 @@ void trails_add_body(int body_idx)
     GLuint *new_vbo = (GLuint*)malloc(new_n * sizeof(GLuint));
     int *new_head = (int*)malloc(new_n * sizeof(int));
     int *new_count = (int*)malloc(new_n * sizeof(int));
-    if (!new_vao || !new_vbo || !new_head || !new_count) {
-        free(new_vao); free(new_vbo); free(new_head); free(new_count);
+    double (*new_ref)[3] = (double(*)[3])calloc(new_n, sizeof(*new_ref));
+    if (!new_vao || !new_vbo || !new_head || !new_count || !new_ref) {
+        free(new_vao); free(new_vbo); free(new_head); free(new_count); free(new_ref);
         return;
     }
     if (s_n > 0) {
@@ -94,12 +101,14 @@ void trails_add_body(int body_idx)
         memcpy(new_vbo, s_vbo, s_n * sizeof(GLuint));
         memcpy(new_head, s_last_head, s_n * sizeof(int));
         memcpy(new_count, s_last_count, s_n * sizeof(int));
+        memcpy(new_ref, s_ref_pos, s_n * sizeof(*s_ref_pos));
     }
-    free(s_vao); free(s_vbo); free(s_last_head); free(s_last_count);
+    free(s_vao); free(s_vbo); free(s_last_head); free(s_last_count); free(s_ref_pos);
     s_vao = new_vao;
     s_vbo = new_vbo;
     s_last_head = new_head;
     s_last_count = new_count;
+    s_ref_pos = new_ref;
 
     for (int i = s_n; i < new_n; i++) {
         s_last_head[i] = 0;
@@ -209,13 +218,6 @@ void trails_render(const float vp[16])
     glUseProgram(s_shader);
     glUniformMatrix4fv(s_loc_vp, 1, GL_FALSE, vp);
 
-    /* Camera moved since last frame? If so every trail's VBO must be re-uploaded
-     * because the positions are stored camera-relative (double-precision CPU
-     * subtraction to avoid float cancellation jitter on WASD movement). */
-    const int cam_moved = (g_cam.pos[0] != s_last_cam[0] ||
-                           g_cam.pos[1] != s_last_cam[1] ||
-                           g_cam.pos[2] != s_last_cam[2]);
-
     glEnable(GL_DEPTH_TEST);
     glEnable(GL_BLEND);
     glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
@@ -232,19 +234,23 @@ void trails_render(const float vp[16])
         glBindVertexArray(s_vao[i]);
         glBindBuffer(GL_ARRAY_BUFFER, s_vbo[i]);
 
-        /* Re-upload when new samples were recorded OR the camera moved.
-         * Positions are stored camera-relative: the double-precision subtraction
-         * (b->trail[idx][x] - g_cam.pos[x]) is done here on the CPU so the
-         * shader only ever receives small residual floats, eliminating the
-         * cancellation jitter that appears when WASD moves the camera. */
-        if (cam_moved || head != s_last_head[i] || count != s_last_count[i]) {
-            /* Linearise circular buffer: oldest → newest, camera-relative.
+        /* Re-upload only when new trail samples were recorded.
+         * VBO stores positions relative to s_ref_pos[i] (the body's world
+         * position at upload time), keeping values small for float precision.
+         * Camera movement is handled cheaply via u_body_offset each frame. */
+        if (head != s_last_head[i] || count != s_last_count[i]) {
+            /* Capture reference point: body's current world position. */
+            s_ref_pos[i][0] = b->pos[0] * RS;
+            s_ref_pos[i][1] = b->pos[1] * RS;
+            s_ref_pos[i][2] = b->pos[2] * RS;
+
+            /* Linearise circular buffer: oldest → newest, ref-relative.
              * Alpha follows cumulative world length, not vertex index. */
             double total_len = b->trail_total_len;
             double cumulative_len = 0.0;
-            int oldest_idx = (head - count + TRAIL_LEN) % TRAIL_LEN;
+            int oldest_idx = (head - count + TRAIL_LEN) & TRAIL_MASK;
             for (int k = 0; k < count; k++) {
-                int idx = (head - count + k + TRAIL_LEN) % TRAIL_LEN;
+                int idx = (head - count + k + TRAIL_LEN) & TRAIL_MASK;
                 float alpha_t;
                 if (idx != oldest_idx && b->trail_seg_len) {
                     cumulative_len += b->trail_seg_len[idx];
@@ -252,10 +258,10 @@ void trails_render(const float vp[16])
                 }
                 if (total_len > 0.0) alpha_t = (float)(cumulative_len / total_len);
                 else alpha_t = (k == count - 1) ? 1.0f : 0.0f;
-                s_scratch[k*4+0] = (float)(b->trail[idx][0] - g_cam.pos[0]);
-                s_scratch[k*4+1] = (float)(b->trail[idx][1] - g_cam.pos[1]);
-                s_scratch[k*4+2] = (float)(b->trail[idx][2] - g_cam.pos[2]);
-                s_scratch[k*4+3] = alpha_t * alpha_t;
+                s_scratch[k*4+0] = (float)(b->trail[idx][0] - s_ref_pos[i][0]);
+                s_scratch[k*4+1] = (float)(b->trail[idx][1] - s_ref_pos[i][1]);
+                s_scratch[k*4+2] = (float)(b->trail[idx][2] - s_ref_pos[i][2]);
+                s_scratch[k*4+3] = alpha_t * sqrtf(alpha_t);
             }
             glBufferSubData(GL_ARRAY_BUFFER, 0,
                             count * 4 * sizeof(float), s_scratch);
@@ -263,15 +269,24 @@ void trails_render(const float vp[16])
             s_last_count[i] = count;
         }
 
+        /* Pass per-body offset = ref_pos - cam_pos, computed in double precision
+         * to avoid float cancellation jitter when the camera is near the body. */
+        float off[3] = {
+            (float)(s_ref_pos[i][0] - g_cam.pos[0]),
+            (float)(s_ref_pos[i][1] - g_cam.pos[1]),
+            (float)(s_ref_pos[i][2] - g_cam.pos[2])
+        };
+        glUniform3fv(s_loc_body_offset, 1, off);
+
         int draw_count;
         if (b->alive && b->trail_emitting) {
             /* Append the live planet position as the final vertex so the
              * trail tip follows the planet every frame without a new sample.
-             * Camera-relative, double-precision subtraction as above. */
+             * Stored ref-relative so it matches the VBO coordinate space. */
             float live[4] = {
-                (float)(b->pos[0] * RS - g_cam.pos[0]),
-                (float)(b->pos[1] * RS - g_cam.pos[1]),
-                (float)(b->pos[2] * RS - g_cam.pos[2]),
+                (float)(b->pos[0] * RS - s_ref_pos[i][0]),
+                (float)(b->pos[1] * RS - s_ref_pos[i][1]),
+                (float)(b->pos[2] * RS - s_ref_pos[i][2]),
                 1.0f
             };
             glBufferSubData(GL_ARRAY_BUFFER,
@@ -286,11 +301,6 @@ void trails_render(const float vp[16])
         glDrawArrays(GL_LINE_STRIP, 0, draw_count);
     }
 
-    /* Record camera position so we can detect movement next frame */
-    s_last_cam[0] = g_cam.pos[0];
-    s_last_cam[1] = g_cam.pos[1];
-    s_last_cam[2] = g_cam.pos[2];
-
     glDepthMask(GL_TRUE);
     glDisable(GL_BLEND);
     glBindVertexArray(0);
@@ -302,6 +312,7 @@ void trails_gl_shutdown(void)
     if (s_vao) { glDeleteVertexArrays(s_n, s_vao);  free(s_vao);      s_vao = NULL; }
     if (s_last_head)  { free(s_last_head);  s_last_head  = NULL; }
     if (s_last_count) { free(s_last_count); s_last_count = NULL; }
+    if (s_ref_pos)    { free(s_ref_pos);    s_ref_pos    = NULL; }
     glDeleteProgram(s_shader);
     s_shader = 0;
     s_n = 0;

--- a/src/trails.c
+++ b/src/trails.c
@@ -153,6 +153,24 @@ void trails_reset_body(int body_idx)
     b->trail_prev_pos[0] = b->pos[0];
     b->trail_prev_pos[1] = b->pos[1];
     b->trail_prev_pos[2] = b->pos[2];
+    b->trail_prev_vel[0] = b->vel[0];
+    b->trail_prev_vel[1] = b->vel[1];
+    b->trail_prev_vel[2] = b->vel[2];
+    b->trail_frame_accum = 0.0;
+    b->trail_frame_head = b->trail_head;
+    b->trail_frame_count = b->trail_count;
+    b->trail_frame_pos[0] = b->pos[0];
+    b->trail_frame_pos[1] = b->pos[1];
+    b->trail_frame_pos[2] = b->pos[2];
+    b->trail_frame_vel[0] = b->vel[0];
+    b->trail_frame_vel[1] = b->vel[1];
+    b->trail_frame_vel[2] = b->vel[2];
+    b->trail_frame_prev_pos[0] = b->trail_prev_pos[0];
+    b->trail_frame_prev_pos[1] = b->trail_prev_pos[1];
+    b->trail_frame_prev_pos[2] = b->trail_prev_pos[2];
+    b->trail_frame_prev_vel[0] = b->trail_prev_vel[0];
+    b->trail_frame_prev_vel[1] = b->trail_prev_vel[1];
+    b->trail_frame_prev_vel[2] = b->trail_prev_vel[2];
 
     if (body_idx < s_n) {
         s_last_head[body_idx] = -1;

--- a/src/trails.c
+++ b/src/trails.c
@@ -33,14 +33,13 @@ static int *s_last_count = NULL;
 static GLuint s_shader    = 0;
 static GLint  s_loc_vp    = -1;
 static GLint  s_loc_color = -1;
-static GLint  s_loc_count = -1;
 
 /* Last camera position — used to detect when a re-upload is needed even if no
  * new trail samples were recorded (camera moved → camera-relative VBO is stale) */
 static double s_last_cam[3] = {0.0, 0.0, 0.0};
 
-/* Scratch: linearised trail + live position, (TRAIL_LEN+1) × 3 floats */
-static float s_scratch[(TRAIL_LEN + 1) * 3];
+/* Scratch: linearised trail + live position, interleaved xyz + alpha. */
+static float s_scratch[(TRAIL_LEN + 1) * 4];
 
 /* ---------------------------------------------------------------- public */
 
@@ -52,8 +51,6 @@ void trails_gl_init(void)
 
     s_loc_vp    = glGetUniformLocation(s_shader, "u_vp");
     s_loc_color = glGetUniformLocation(s_shader, "u_color");
-    s_loc_count = glGetUniformLocation(s_shader, "u_count");
-
     s_n          = g_nbodies;
     s_vao        = (GLuint*)malloc(s_n * sizeof(GLuint));
     s_vbo        = (GLuint*)malloc(s_n * sizeof(GLuint));
@@ -66,11 +63,14 @@ void trails_gl_init(void)
         s_last_count[i] = 0;
 
         s_vao[i] = gl_vao_create();
-        s_vbo[i] = gl_vbo_create((TRAIL_LEN + 1) * 3 * sizeof(float),
+        s_vbo[i] = gl_vbo_create((TRAIL_LEN + 1) * 4 * sizeof(float),
                                  NULL, GL_DYNAMIC_DRAW);
         glEnableVertexAttribArray(0);
         glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE,
-                              3 * sizeof(float), (void*)0);
+                              4 * sizeof(float), (void*)0);
+        glEnableVertexAttribArray(1);
+        glVertexAttribPointer(1, 1, GL_FLOAT, GL_FALSE,
+                              4 * sizeof(float), (void*)(3 * sizeof(float)));
         glBindVertexArray(0);
     }
 }
@@ -105,11 +105,14 @@ void trails_add_body(int body_idx)
         s_last_head[i] = 0;
         s_last_count[i] = 0;
         s_vao[i] = gl_vao_create();
-        s_vbo[i] = gl_vbo_create((TRAIL_LEN + 1) * 3 * sizeof(float),
+        s_vbo[i] = gl_vbo_create((TRAIL_LEN + 1) * 4 * sizeof(float),
                                  NULL, GL_DYNAMIC_DRAW);
         glEnableVertexAttribArray(0);
         glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE,
-                              3 * sizeof(float), (void*)0);
+                              4 * sizeof(float), (void*)0);
+        glEnableVertexAttribArray(1);
+        glVertexAttribPointer(1, 1, GL_FLOAT, GL_FALSE,
+                              4 * sizeof(float), (void*)(3 * sizeof(float)));
         glBindVertexArray(0);
     }
 
@@ -125,6 +128,7 @@ void trails_remove_body(int body_idx)
         g_bodies[body_idx].trail_head = 0;
         g_bodies[body_idx].trail_count = 0;
         g_bodies[body_idx].trail_accum = 0.0;
+        g_bodies[body_idx].trail_total_len = 0.0;
         g_bodies[body_idx].trail_emitting = 0;
     }
 }
@@ -149,6 +153,10 @@ void trails_reset_body(int body_idx)
     b->trail_head = 2 % TRAIL_LEN;
     b->trail_count = 2;
     b->trail_accum = 0.0;
+    if (b->trail_seg_len) {
+        for (int i = 0; i < TRAIL_LEN; i++) b->trail_seg_len[i] = 0.0;
+    }
+    b->trail_total_len = 0.0;
     b->trail_emitting = 1;
     b->trail_prev_pos[0] = b->pos[0];
     b->trail_prev_pos[1] = b->pos[1];
@@ -159,6 +167,7 @@ void trails_reset_body(int body_idx)
     b->trail_frame_accum = 0.0;
     b->trail_frame_head = b->trail_head;
     b->trail_frame_count = b->trail_count;
+    b->trail_frame_total_len = b->trail_total_len;
     b->trail_frame_pos[0] = b->pos[0];
     b->trail_frame_pos[1] = b->pos[1];
     b->trail_frame_pos[2] = b->pos[2];
@@ -229,15 +238,27 @@ void trails_render(const float vp[16])
          * shader only ever receives small residual floats, eliminating the
          * cancellation jitter that appears when WASD moves the camera. */
         if (cam_moved || head != s_last_head[i] || count != s_last_count[i]) {
-            /* Linearise circular buffer: oldest → newest, camera-relative */
+            /* Linearise circular buffer: oldest → newest, camera-relative.
+             * Alpha follows cumulative world length, not vertex index. */
+            double total_len = b->trail_total_len;
+            double cumulative_len = 0.0;
+            int oldest_idx = (head - count + TRAIL_LEN) % TRAIL_LEN;
             for (int k = 0; k < count; k++) {
                 int idx = (head - count + k + TRAIL_LEN) % TRAIL_LEN;
-                s_scratch[k*3+0] = (float)(b->trail[idx][0] - g_cam.pos[0]);
-                s_scratch[k*3+1] = (float)(b->trail[idx][1] - g_cam.pos[1]);
-                s_scratch[k*3+2] = (float)(b->trail[idx][2] - g_cam.pos[2]);
+                float alpha_t;
+                if (idx != oldest_idx && b->trail_seg_len) {
+                    cumulative_len += b->trail_seg_len[idx];
+                    if (cumulative_len > total_len) cumulative_len = total_len;
+                }
+                if (total_len > 0.0) alpha_t = (float)(cumulative_len / total_len);
+                else alpha_t = (k == count - 1) ? 1.0f : 0.0f;
+                s_scratch[k*4+0] = (float)(b->trail[idx][0] - g_cam.pos[0]);
+                s_scratch[k*4+1] = (float)(b->trail[idx][1] - g_cam.pos[1]);
+                s_scratch[k*4+2] = (float)(b->trail[idx][2] - g_cam.pos[2]);
+                s_scratch[k*4+3] = alpha_t * alpha_t;
             }
             glBufferSubData(GL_ARRAY_BUFFER, 0,
-                            count * 3 * sizeof(float), s_scratch);
+                            count * 4 * sizeof(float), s_scratch);
             s_last_head[i]  = head;
             s_last_count[i] = count;
         }
@@ -247,13 +268,14 @@ void trails_render(const float vp[16])
             /* Append the live planet position as the final vertex so the
              * trail tip follows the planet every frame without a new sample.
              * Camera-relative, double-precision subtraction as above. */
-            float live[3] = {
+            float live[4] = {
                 (float)(b->pos[0] * RS - g_cam.pos[0]),
                 (float)(b->pos[1] * RS - g_cam.pos[1]),
-                (float)(b->pos[2] * RS - g_cam.pos[2])
+                (float)(b->pos[2] * RS - g_cam.pos[2]),
+                1.0f
             };
             glBufferSubData(GL_ARRAY_BUFFER,
-                            count * 3 * sizeof(float), sizeof(live), live);
+                            count * 4 * sizeof(float), sizeof(live), live);
             draw_count = count + 1;
         } else {
             draw_count = count;
@@ -261,7 +283,6 @@ void trails_render(const float vp[16])
 
         float alpha = 0.6f * (float)b->trail_fade * trail_fade;
         glUniform4f(s_loc_color, b->col[0], b->col[1], b->col[2], alpha);
-        glUniform1i(s_loc_count, draw_count);
         glDrawArrays(GL_LINE_STRIP, 0, draw_count);
     }
 

--- a/src/trails.c
+++ b/src/trails.c
@@ -2,8 +2,8 @@
  * trails.c — per-body orbital trail rendering
  *
  * Each body has a fixed-size circular buffer (TRAIL_LEN samples).
- * trail_interval ≈ T/200 gives ~200 samples per orbit; at high sim speeds
- * the buffer fills faster, naturally showing more orbital history.
+ * Samples are emitted by the physics layer using acceleration-driven timing,
+ * then uploaded here for rendering.
  *
  * Render strategy:
  *   - Trail positions are stored camera-relative in the VBO (world − cam),
@@ -125,6 +125,7 @@ void trails_remove_body(int body_idx)
         g_bodies[body_idx].trail_head = 0;
         g_bodies[body_idx].trail_count = 0;
         g_bodies[body_idx].trail_accum = 0.0;
+        g_bodies[body_idx].trail_emitting = 0;
     }
 }
 
@@ -148,6 +149,10 @@ void trails_reset_body(int body_idx)
     b->trail_head = 2 % TRAIL_LEN;
     b->trail_count = 2;
     b->trail_accum = 0.0;
+    b->trail_emitting = 1;
+    b->trail_prev_pos[0] = b->pos[0];
+    b->trail_prev_pos[1] = b->pos[1];
+    b->trail_prev_pos[2] = b->pos[2];
 
     if (body_idx < s_n) {
         s_last_head[body_idx] = -1;
@@ -220,7 +225,7 @@ void trails_render(const float vp[16])
         }
 
         int draw_count;
-        if (b->alive && b->trail_interval > 0.0) {
+        if (b->alive && b->trail_emitting) {
             /* Append the live planet position as the final vertex so the
              * trail tip follows the planet every frame without a new sample.
              * Camera-relative, double-precision subtraction as above. */

--- a/src/trails.h
+++ b/src/trails.h
@@ -10,6 +10,12 @@ void trails_gl_init(void);
 /* Allocate GL trail buffers for one runtime-added body. */
 void trails_add_body(int body_idx);
 
+/* Clear cached trail state for a removed/absorbed body. */
+void trails_remove_body(int body_idx);
+
+/* Re-seed a body's trail after a discontinuous state change like a merge. */
+void trails_reset_body(int body_idx);
+
 /* Upload and draw all trails.  vp: view-projection matrix. */
 void trails_render(const float vp[16]);
 

--- a/src/ui.c
+++ b/src/ui.c
@@ -126,6 +126,7 @@ static void nearest_body_distance_string(char *buf, size_t n)
     double best_d = 1e300;
 
     for (int i = 0; i < g_nbodies; i++) {
+        if (!g_bodies[i].alive) continue;
         double dx = g_bodies[i].pos[0] * RS - g_cam.pos[0];
         double dy = g_bodies[i].pos[1] * RS - g_cam.pos[1];
         double dz = g_bodies[i].pos[2] * RS - g_cam.pos[2];
@@ -140,6 +141,7 @@ static void nearest_body_distance_string(char *buf, size_t n)
         best = -1;
         best_d = 1e300;
         for (int i = 0; i < g_nbodies; i++) {
+            if (!g_bodies[i].alive) continue;
             if (!g_bodies[i].is_star) continue;
             double dx = g_bodies[i].pos[0] * RS - g_cam.pos[0];
             double dy = g_bodies[i].pos[1] * RS - g_cam.pos[1];

--- a/src/ui.c
+++ b/src/ui.c
@@ -23,6 +23,15 @@
 #define BAR_TOP       12.0f   /* distance from top of screen        */
 #define TEXT_GAP      6.0f    /* gap between bar bottom and text    */
 #define FONT_SIZE     14
+#define MENU_TITLE_SIZE 20
+#define MENU_TEXT_SIZE  18
+#define MENU_HINT_SIZE  14
+#define PAUSE_MENU_PANEL_W 360.0f
+#define PAUSE_MENU_PANEL_H 312.0f
+#define PAUSE_MENU_ITEM_W (PAUSE_MENU_PANEL_W - 36.0f)
+#define PAUSE_MENU_ITEM_H 42.0f
+#define PAUSE_MENU_ITEM_ACTIVE_H 50.0f
+#define PAUSE_MENU_ITEM_GAP 10.0f
 
 /* Camera speed range (AU / real-second) */
 #define CAM_MIN       0.00001f
@@ -39,6 +48,8 @@ static GLint  s_loc_use_tex = -1;
 static GLint  s_loc_tex     = -1;
 
 static TTF_Font *s_font = NULL;
+static TTF_Font *s_menu_font = NULL;
+static TTF_Font *s_menu_title_font = NULL;
 
 /* ------------------------------------------------------------------ text cache */
 typedef struct {
@@ -53,6 +64,13 @@ static TextCache s_tc_fps  = {0};
 static TextCache s_tc_nearest = {0};
 static TextCache s_tc_build_title = {0};
 static TextCache s_tc_build_items[8];
+static TextCache s_tc_pause_title = {0};
+static TextCache s_tc_pause_hint = {0};
+static TextCache s_tc_pause_items[4];
+
+static int s_pause_menu_visible = 0;
+static int s_pause_menu_selected = 0;
+static int s_pause_menu_vsync = 0;
 
 /* ------------------------------------------------------------------ FPS smoothing */
 /* Exponential moving average over ~30 frames, updated every UI frame.
@@ -96,7 +114,9 @@ static GLuint surf_to_tex(SDL_Surface *surf, int *w, int *h) {
 }
 
 /* Re-render text texture only when the string changes */
-static void update_text(TextCache *tc, const char *str, SDL_Color col) {
+static void update_text_with_font(TextCache *tc, TTF_Font *font,
+                                  const char *str, SDL_Color col) {
+    if (!font) return;
     if (strcmp(tc->str, str) == 0 &&
         tc->col.r == col.r && tc->col.g == col.g &&
         tc->col.b == col.b && tc->col.a == col.a) return;
@@ -104,8 +124,29 @@ static void update_text(TextCache *tc, const char *str, SDL_Color col) {
     tc->str[63] = '\0';
     tc->col = col;
     if (tc->tex) { glDeleteTextures(1, &tc->tex); tc->tex = 0; }
-    SDL_Surface *surf = TTF_RenderText_Blended(s_font, str, col);
+    SDL_Surface *surf = TTF_RenderText_Blended(font, str, col);
     if (surf) tc->tex = surf_to_tex(surf, &tc->w, &tc->h);
+}
+
+static void update_text(TextCache *tc, const char *str, SDL_Color col) {
+    update_text_with_font(tc, s_font, str, col);
+}
+
+static int pause_menu_item_at(float mx, float my)
+{
+    const float px = ((float)WIN_W - PAUSE_MENU_PANEL_W) * 0.5f;
+    const float py = ((float)WIN_H - PAUSE_MENU_PANEL_H) * 0.5f;
+    const float item_x = px + 18.0f;
+    const float first_item_y = py + 72.0f;
+
+    if (mx < item_x || mx > item_x + PAUSE_MENU_ITEM_W) return -1;
+
+    for (int i = 0; i < 4; i++) {
+        float slot_y = first_item_y + (float)i * (PAUSE_MENU_ITEM_H + PAUSE_MENU_ITEM_GAP);
+        if (my >= slot_y && my <= slot_y + PAUSE_MENU_ITEM_ACTIVE_H)
+            return i;
+    }
+    return -1;
 }
 
 static void format_distance(double au, char *buf, size_t n)
@@ -238,6 +279,66 @@ static void draw_build_bar(float W)
     }
 }
 
+static void draw_pause_menu(float W, float H)
+{
+    if (!s_pause_menu_visible) return;
+
+    const float px = (W - PAUSE_MENU_PANEL_W) * 0.5f;
+    const float py = (H - PAUSE_MENU_PANEL_H) * 0.5f;
+    const float item_x = px + 18.0f;
+    const float first_item_y = py + 72.0f;
+    const char *labels[4] = {
+        "Continue",
+        "Reset Universe",
+        s_pause_menu_vsync ? "Deactivate V-Sync" : "Activate V-Sync",
+        "Leave"
+    };
+
+    SDL_Color title_col = {255, 255, 255, 235};
+    SDL_Color item_col = {0, 0, 0, 255};
+    SDL_Color hint_col = {255, 255, 255, 170};
+
+    update_text_with_font(&s_tc_pause_title, s_menu_title_font, "SYSTEM MENU", title_col);
+    update_text_with_font(&s_tc_pause_hint, s_font, "ENTER select  |  ESC continue", hint_col);
+    for (int i = 0; i < 4; i++)
+        update_text_with_font(&s_tc_pause_items[i], s_menu_font, labels[i], item_col);
+
+    draw_rect(0.0f, 0.0f, W, H, 0.0f, 0.0f, 0.0f, 0.38f);
+    draw_rect(px, py, PAUSE_MENU_PANEL_W, PAUSE_MENU_PANEL_H, 0.03f, 0.04f, 0.07f, 0.90f);
+    draw_rect(px, py, PAUSE_MENU_PANEL_W, 5.0f, 1.0f, 1.0f, 1.0f, 0.95f);
+
+    if (s_tc_pause_title.tex) {
+        float tw = (float)MENU_TITLE_SIZE * (float)s_tc_pause_title.w / (float)s_tc_pause_title.h;
+        draw_tex(&s_tc_pause_title, px + (PAUSE_MENU_PANEL_W - tw) * 0.5f, py + 24.0f, (float)MENU_TITLE_SIZE);
+    }
+
+    for (int i = 0; i < 4; i++) {
+        int active = (i == s_pause_menu_selected);
+        float item_h = active ? PAUSE_MENU_ITEM_ACTIVE_H : PAUSE_MENU_ITEM_H;
+        float item_y = first_item_y + i * (PAUSE_MENU_ITEM_H + PAUSE_MENU_ITEM_GAP) + (PAUSE_MENU_ITEM_H - item_h);
+        float strip_h = active ? 7.0f : 5.0f;
+
+        draw_rect(item_x, item_y, PAUSE_MENU_ITEM_W, item_h, 1.0f, 1.0f, 1.0f,
+                  active ? 1.0f : 0.84f);
+        draw_rect(item_x, item_y, PAUSE_MENU_ITEM_W, strip_h,
+                  active ? 0.07f : 0.82f,
+                  active ? 0.09f : 0.82f,
+                  active ? 0.13f : 0.82f,
+                  1.0f);
+
+        if (s_tc_pause_items[i].tex) {
+            float tw = (float)MENU_TEXT_SIZE * (float)s_tc_pause_items[i].w / (float)s_tc_pause_items[i].h;
+            float text_y = item_y + strip_h + (item_h - strip_h - (float)MENU_TEXT_SIZE) * 0.5f;
+            draw_tex(&s_tc_pause_items[i], item_x + (PAUSE_MENU_ITEM_W - tw) * 0.5f, text_y, (float)MENU_TEXT_SIZE);
+        }
+    }
+
+    if (s_tc_pause_hint.tex) {
+        float tw = (float)MENU_HINT_SIZE * (float)s_tc_pause_hint.w / (float)s_tc_pause_hint.h;
+        draw_tex(&s_tc_pause_hint, px + (PAUSE_MENU_PANEL_W - tw) * 0.5f, py + PAUSE_MENU_PANEL_H - 28.0f, (float)MENU_HINT_SIZE);
+    }
+}
+
 /* ------------------------------------------------------------------ public */
 void ui_init(void) {
     s_shader = gl_shader_load("assets/shaders/ui.vert",
@@ -266,7 +367,23 @@ void ui_init(void) {
 
     TTF_Init();
     s_font = find_font(FONT_SIZE);
+    s_menu_font = find_font(MENU_TEXT_SIZE);
+    s_menu_title_font = find_font(MENU_TITLE_SIZE);
     if (!s_font) fprintf(stderr, "[UI] no font found\n");
+    if (!s_menu_font) s_menu_font = s_font;
+    if (!s_menu_title_font) s_menu_title_font = s_menu_font;
+}
+
+void ui_set_pause_menu(int visible, int selected, int vsync_enabled)
+{
+    s_pause_menu_visible = visible ? 1 : 0;
+    s_pause_menu_selected = selected;
+    s_pause_menu_vsync = vsync_enabled ? 1 : 0;
+}
+
+int ui_pause_menu_hit_test(int mouse_x, int mouse_y)
+{
+    return pause_menu_item_at((float)mouse_x, (float)mouse_y);
 }
 
 void ui_render(void) {
@@ -387,6 +504,7 @@ void ui_render(void) {
     }
 
     draw_build_bar(W);
+    draw_pause_menu(W, (float)WIN_H);
 
     /* ---- restore ---- */
     glBindVertexArray(0);
@@ -403,11 +521,21 @@ void ui_shutdown(void) {
     if (s_tc_build_title.tex) glDeleteTextures(1, &s_tc_build_title.tex);
     for (int i = 0; i < 8; i++)
         if (s_tc_build_items[i].tex) glDeleteTextures(1, &s_tc_build_items[i].tex);
+    if (s_tc_pause_title.tex) glDeleteTextures(1, &s_tc_pause_title.tex);
+    if (s_tc_pause_hint.tex) glDeleteTextures(1, &s_tc_pause_hint.tex);
+    for (int i = 0; i < 4; i++)
+        if (s_tc_pause_items[i].tex) glDeleteTextures(1, &s_tc_pause_items[i].tex);
     if (s_vbo)  glDeleteBuffers(1, &s_vbo);
     if (s_vao)  glDeleteVertexArrays(1, &s_vao);
     if (s_shader) glDeleteProgram(s_shader);
+    if (s_menu_title_font && s_menu_title_font != s_menu_font && s_menu_title_font != s_font)
+        TTF_CloseFont(s_menu_title_font);
+    if (s_menu_font && s_menu_font != s_font)
+        TTF_CloseFont(s_menu_font);
     if (s_font)   TTF_CloseFont(s_font);
     TTF_Quit();
     s_shader = s_vao = s_vbo = 0;
     s_font = NULL;
+    s_menu_font = NULL;
+    s_menu_title_font = NULL;
 }

--- a/src/ui.c
+++ b/src/ui.c
@@ -107,9 +107,14 @@ typedef struct {
     float panel_h;
 } BuildBarLayout;
 
+/* ------------------------------------------------------------------ build slide-in animation */
+static float  s_build_anim_t    = 0.0f;
+static Uint64 s_build_anim_ts   = 0;
+static int    s_build_prev_mode = 0;
+
 /* ------------------------------------------------------------------ FPS smoothing */
 /* Exponential moving average over ~30 frames, updated every UI frame.
- * We measure time internally so the ui_render() signature stays unchanged. */
+ * We manage time internally so the ui_render() signature stays unchanged. */
 static Uint64 s_fps_prev  = 0;
 static float  s_fps_smooth = 0.0f;
 
@@ -304,9 +309,35 @@ static void draw_tex(TextCache *tc, float x, float y, float h) {
 
 static void draw_build_bar(float W)
 {
-    if (!g_build_mode) return;
+    if (!g_build_mode) {
+        s_build_anim_t    = 0.0f;
+        s_build_prev_mode = 0;
+        return;
+    }
+
+    /* Slide-in animation ------------------------------------------------ */
+    if (!s_build_prev_mode) {
+        s_build_anim_t  = 0.0f;
+        s_build_anim_ts = SDL_GetPerformanceCounter();
+    }
+    s_build_prev_mode = 1;
+
+    if (s_build_anim_t < 1.0f) {
+        Uint64 now = SDL_GetPerformanceCounter();
+        float dt = (float)(now - s_build_anim_ts) / (float)SDL_GetPerformanceFrequency();
+        s_build_anim_ts = now;
+        s_build_anim_t += dt / 0.22f;
+        if (s_build_anim_t > 1.0f) s_build_anim_t = 1.0f;
+    }
+
+    /* Ease-out cubic: starts fast, settles smoothly */
+    float inv  = 1.0f - s_build_anim_t;
+    float ease = 1.0f - inv * inv * inv;
 
     BuildBarLayout layout = build_bar_layout(W);
+
+    /* Shift everything left by (1-ease) × full panel width+margin */
+    float ox = (ease - 1.0f) * (layout.panel_x + layout.panel_w);
 
     SDL_Color title_col = {255, 255, 255, 235};
     SDL_Color hint_col  = {255, 255, 255, 170};
@@ -317,14 +348,14 @@ static void draw_build_bar(float W)
                           g_build_tab_held ? "scroll to select" : "hold TAB and scroll",
                           hint_col);
 
-    draw_rect(layout.panel_x, layout.panel_y, layout.panel_w, layout.panel_h,
+    draw_rect(layout.panel_x + ox, layout.panel_y, layout.panel_w, layout.panel_h,
               UI_ACCENT_R, UI_ACCENT_G, UI_ACCENT_B, 1.0f);
-    draw_rect(layout.panel_x, layout.panel_y, layout.panel_w, 5.0f, 1.0f, 1.0f, 1.0f, 1.0f);
+    draw_rect(layout.panel_x + ox, layout.panel_y, layout.panel_w, 5.0f, 1.0f, 1.0f, 1.0f, 1.0f);
 
     if (s_tc_build_title.tex) {
         float tw = (float)MENU_TITLE_SIZE * (float)s_tc_build_title.w / (float)s_tc_build_title.h;
         draw_tex(&s_tc_build_title,
-                 layout.panel_x + (layout.panel_w - tw) * 0.5f,
+                 layout.panel_x + ox + (layout.panel_w - tw) * 0.5f,
                  layout.title_y,
                  (float)MENU_TITLE_SIZE);
     }
@@ -335,11 +366,11 @@ static void draw_build_bar(float W)
         const BuildPreset *p = build_preset_at(i);
         if (!p) continue;
         int active = (i == selected);
-        float item_y   = layout.items_y + (layout.item_h + layout.gap) * (float)i;
+        float item_y  = layout.items_y + (layout.item_h + layout.gap) * (float)i;
         float sw      = active ? layout.strip_active_w : layout.strip_w;
-        float strip_x = layout.item_x - layout.strip_w;
+        float strip_x = layout.item_x - layout.strip_w + ox;
 
-        draw_rect(layout.item_x, item_y, layout.item_w, layout.item_h,
+        draw_rect(layout.item_x + ox, item_y, layout.item_w, layout.item_h,
                   1.0f, 1.0f, 1.0f, active ? 1.0f : 0.72f);
         draw_rect(strip_x, item_y, sw, layout.item_h,
                   p->col[0], p->col[1], p->col[2], 1.0f);
@@ -350,7 +381,7 @@ static void draw_build_bar(float W)
             float tw     = (float)BUILD_ITEM_FONT_SIZE * (float)s_tc_build_items[i].w / (float)s_tc_build_items[i].h;
             float text_y = item_y + (layout.item_h - (float)BUILD_ITEM_FONT_SIZE) * 0.5f;
             draw_tex(&s_tc_build_items[i],
-                     layout.item_x + (layout.item_w - tw) * 0.5f,
+                     layout.item_x + ox + (layout.item_w - tw) * 0.5f,
                      text_y,
                      (float)BUILD_ITEM_FONT_SIZE);
         }
@@ -359,7 +390,7 @@ static void draw_build_bar(float W)
     if (s_tc_build_hint.tex) {
         float tw = (float)FONT_SIZE * (float)s_tc_build_hint.w / (float)s_tc_build_hint.h;
         draw_tex(&s_tc_build_hint,
-                 layout.panel_x + (layout.panel_w - tw) * 0.5f,
+                 layout.panel_x + ox + (layout.panel_w - tw) * 0.5f,
                  layout.hint_y,
                  (float)FONT_SIZE);
     }

--- a/src/ui.c
+++ b/src/ui.c
@@ -13,6 +13,7 @@
 #include "build.h"
 #include "body.h"
 #include "gl_utils.h"
+#include "ui_theme.h"
 #include <math.h>
 #include <stdio.h>
 #include <string.h>
@@ -22,15 +23,16 @@
 #define BAR_W_FRAC    0.5f    /* fraction of screen width           */
 #define BAR_TOP       12.0f   /* distance from top of screen        */
 #define TEXT_GAP      6.0f    /* gap between bar bottom and text    */
-#define FONT_SIZE     14
-#define MENU_TITLE_SIZE 20
+#define FONT_SIZE     16
+#define BUILD_ITEM_FONT_SIZE 18
+#define MENU_TITLE_SIZE 24
 #define MENU_TEXT_SIZE  18
-#define MENU_HINT_SIZE  14
+#define MENU_HINT_SIZE  16
 #define PAUSE_MENU_PANEL_W 360.0f
 #define PAUSE_MENU_PANEL_H 312.0f
 #define PAUSE_MENU_ITEM_W (PAUSE_MENU_PANEL_W - 36.0f)
 #define PAUSE_MENU_ITEM_H 42.0f
-#define PAUSE_MENU_ITEM_ACTIVE_H 50.0f
+#define PAUSE_MENU_ITEM_ACTIVE_H 42.0f
 #define PAUSE_MENU_ITEM_GAP 10.0f
 
 /* Camera speed range (AU / real-second) */
@@ -48,6 +50,7 @@ static GLint  s_loc_use_tex = -1;
 static GLint  s_loc_tex     = -1;
 
 static TTF_Font *s_font = NULL;
+static TTF_Font *s_build_item_font = NULL;
 static TTF_Font *s_menu_font = NULL;
 static TTF_Font *s_menu_title_font = NULL;
 
@@ -72,6 +75,34 @@ static int s_pause_menu_visible = 0;
 static int s_pause_menu_selected = 0;
 static int s_pause_menu_vsync = 0;
 
+typedef struct {
+    int n;
+    float item_w;
+    float item_h;
+    float item_active_h;
+    float gap;
+    float first_item_y;
+    float item_x;
+    float panel_x;
+    float panel_y;
+    float panel_w;
+    float panel_h;
+} PauseMenuLayout;
+
+typedef struct {
+    int n;
+    float item_w;
+    float item_h;
+    float item_active_h;
+    float gap;
+    float items_x;
+    float item_y_base;
+    float panel_x;
+    float panel_y;
+    float panel_w;
+    float panel_h;
+} BuildBarLayout;
+
 /* ------------------------------------------------------------------ FPS smoothing */
 /* Exponential moving average over ~30 frames, updated every UI frame.
  * We measure time internally so the ui_render() signature stays unchanged. */
@@ -79,20 +110,46 @@ static Uint64 s_fps_prev  = 0;
 static float  s_fps_smooth = 0.0f;
 
 /* ------------------------------------------------------------------ helpers */
-static const char *s_font_paths[] = {
-    "C:/Windows/Fonts/segoeui.ttf",
-    "C:/Windows/Fonts/arial.ttf",
-    "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf",
-    "/usr/share/fonts/TTF/DejaVuSans.ttf",
-    NULL
-};
 
-static TTF_Font *find_font(int size) {
-    for (int i = 0; s_font_paths[i]; i++) {
-        TTF_Font *f = TTF_OpenFont(s_font_paths[i], size);
-        if (f) return f;
+static PauseMenuLayout pause_menu_layout(float W, float H)
+{
+    PauseMenuLayout layout;
+    layout.n = 4;
+    layout.item_w = PAUSE_MENU_ITEM_W;
+    layout.item_h = PAUSE_MENU_ITEM_H;
+    layout.item_active_h = PAUSE_MENU_ITEM_ACTIVE_H;
+    layout.gap = PAUSE_MENU_ITEM_GAP;
+    layout.panel_x = (W - PAUSE_MENU_PANEL_W) * 0.5f;
+    layout.panel_y = (H - PAUSE_MENU_PANEL_H) * 0.5f;
+    layout.panel_w = PAUSE_MENU_PANEL_W;
+    layout.panel_h = PAUSE_MENU_PANEL_H;
+    layout.item_x = layout.panel_x + 18.0f;
+    layout.first_item_y = layout.panel_y + 72.0f;
+    return layout;
+}
+
+static BuildBarLayout build_bar_layout(float W)
+{
+    BuildBarLayout layout;
+    layout.n = build_preset_count();
+    if (layout.n > 8) layout.n = 8;
+    layout.item_w = 112.0f;
+    layout.item_h = 48.0f;
+    layout.item_active_h = 56.0f;
+    layout.gap = 8.0f;
+    layout.item_y_base = (float)WIN_H - 88.0f + 24.0f;
+
+    {
+        float total_w = layout.n * layout.item_w + (layout.n - 1) * layout.gap;
+        float panel_pad = (float)WIN_H - (layout.item_y_base + layout.item_h);
+        layout.items_x = (W - total_w) * 0.5f;
+        layout.panel_x = layout.items_x - panel_pad;
+        layout.panel_y = layout.item_y_base - panel_pad;
+        layout.panel_w = total_w + panel_pad * 2.0f;
+        layout.panel_h = (float)WIN_H - layout.panel_y;
     }
-    return NULL;
+
+    return layout;
 }
 
 static GLuint surf_to_tex(SDL_Surface *surf, int *w, int *h) {
@@ -134,16 +191,17 @@ static void update_text(TextCache *tc, const char *str, SDL_Color col) {
 
 static int pause_menu_item_at(float mx, float my)
 {
-    const float px = ((float)WIN_W - PAUSE_MENU_PANEL_W) * 0.5f;
-    const float py = ((float)WIN_H - PAUSE_MENU_PANEL_H) * 0.5f;
-    const float item_x = px + 18.0f;
-    const float first_item_y = py + 72.0f;
+    PauseMenuLayout layout = pause_menu_layout((float)WIN_W, (float)WIN_H);
 
-    if (mx < item_x || mx > item_x + PAUSE_MENU_ITEM_W) return -1;
+    if (mx < layout.item_x || mx > layout.item_x + layout.item_w) return -1;
 
-    for (int i = 0; i < 4; i++) {
-        float slot_y = first_item_y + (float)i * (PAUSE_MENU_ITEM_H + PAUSE_MENU_ITEM_GAP);
-        if (my >= slot_y && my <= slot_y + PAUSE_MENU_ITEM_ACTIVE_H)
+    for (int i = 0; i < layout.n; i++) {
+        int active = (i == s_pause_menu_selected);
+        float item_h = active ? layout.item_active_h : layout.item_h;
+        float item_y = layout.first_item_y
+                     + (float)i * (layout.item_h + layout.gap)
+                     + (layout.item_h - item_h);
+        if (my >= item_y && my <= item_y + item_h)
             return i;
     }
     return -1;
@@ -238,44 +296,41 @@ static void draw_build_bar(float W)
 {
     if (!g_build_mode) return;
 
-    const float H = 72.0f;
-    const float Y = (float)WIN_H - H;
     const float PAD = 14.0f;
-    const float ITEM_W = 112.0f;
-    const float ITEM_H = 42.0f;
-    const float ITEM_RAISED_H = 56.0f;
-    const float GAP = 8.0f;
-    int n = build_preset_count();
-    if (n > 8) n = 8;
+    BuildBarLayout layout = build_bar_layout(W);
 
     SDL_Color white = {255, 255, 255, 230};
     update_text(&s_tc_build_title,
                 g_build_tab_held ? "BUILD MODE  |  scroll to select" : "BUILD MODE  |  hold TAB and scroll",
                 white);
     draw_tex(&s_tc_build_title, PAD, (float)WIN_H - (FONT_SIZE + 6.0f), (float)FONT_SIZE);
+    draw_rect(layout.panel_x, layout.panel_y, layout.panel_w, layout.panel_h,
+              UI_ACCENT_R, UI_ACCENT_G, UI_ACCENT_B, 1.0f);
 
-    float total_w = n * ITEM_W + (n - 1) * GAP;
-    float x = (W - total_w) * 0.5f;
     int selected = build_selected_index();
 
-    for (int i = 0; i < n; i++) {
+    for (int i = 0; i < layout.n; i++) {
         const BuildPreset *p = build_preset_at(i);
         if (!p) continue;
         int active = (i == selected);
-        float item_h = active ? ITEM_RAISED_H : ITEM_H;
-        float item_y = Y + 24.0f + (ITEM_H - item_h);
+        float item_h = active ? layout.item_active_h : layout.item_h;
+        float item_y = layout.item_y_base + (layout.item_h - item_h);
+        float item_x = layout.items_x + (layout.item_w + layout.gap) * (float)i;
         float strip_h = active ? 8.0f : 6.0f;
-        draw_rect(x, item_y, ITEM_W, item_h, 1.0f, 1.0f, 1.0f,
-                  active ? 1.0f : 0.85f);
-        draw_rect(x, item_y, ITEM_W, strip_h, p->col[0], p->col[1], p->col[2], 1.0f);
+        draw_rect(item_x, item_y, layout.item_w, item_h,
+                  1.0f, 1.0f, 1.0f,
+                  active ? 1.0f : 0.84f);
+        draw_rect(item_x, item_y, layout.item_w, strip_h, p->col[0], p->col[1], p->col[2], 1.0f);
         SDL_Color item_col = {0, 0, 0, 255};
-        update_text(&s_tc_build_items[i], p->name, item_col);
+        update_text_with_font(&s_tc_build_items[i], s_build_item_font ? s_build_item_font : s_font,
+                              p->name, item_col);
         if (s_tc_build_items[i].tex) {
-            float tw = (float)FONT_SIZE * (float)s_tc_build_items[i].w / (float)s_tc_build_items[i].h;
-            float text_y = item_y + strip_h + (item_h - strip_h - (float)FONT_SIZE) * 0.5f;
-            draw_tex(&s_tc_build_items[i], x + (ITEM_W - tw) * 0.5f, text_y, (float)FONT_SIZE);
+            float tw = (float)BUILD_ITEM_FONT_SIZE * (float)s_tc_build_items[i].w / (float)s_tc_build_items[i].h;
+            float text_y = item_y + strip_h + (item_h - strip_h - (float)BUILD_ITEM_FONT_SIZE) * 0.5f;
+            draw_tex(&s_tc_build_items[i],
+                     item_x + (layout.item_w - tw) * 0.5f, text_y,
+                     (float)BUILD_ITEM_FONT_SIZE);
         }
-        x += ITEM_W + GAP;
     }
 }
 
@@ -283,10 +338,7 @@ static void draw_pause_menu(float W, float H)
 {
     if (!s_pause_menu_visible) return;
 
-    const float px = (W - PAUSE_MENU_PANEL_W) * 0.5f;
-    const float py = (H - PAUSE_MENU_PANEL_H) * 0.5f;
-    const float item_x = px + 18.0f;
-    const float first_item_y = py + 72.0f;
+    PauseMenuLayout layout = pause_menu_layout(W, H);
     const char *labels[4] = {
         "Continue",
         "Reset Universe",
@@ -298,44 +350,48 @@ static void draw_pause_menu(float W, float H)
     SDL_Color item_col = {0, 0, 0, 255};
     SDL_Color hint_col = {255, 255, 255, 170};
 
-    update_text_with_font(&s_tc_pause_title, s_menu_title_font, "SYSTEM MENU", title_col);
+    update_text_with_font(&s_tc_pause_title, s_menu_title_font, "MENU", title_col);
     update_text_with_font(&s_tc_pause_hint, s_font, "ENTER select  |  ESC continue", hint_col);
     for (int i = 0; i < 4; i++)
         update_text_with_font(&s_tc_pause_items[i], s_menu_font, labels[i], item_col);
 
     draw_rect(0.0f, 0.0f, W, H, 0.0f, 0.0f, 0.0f, 0.38f);
-    draw_rect(px, py, PAUSE_MENU_PANEL_W, PAUSE_MENU_PANEL_H, 0.03f, 0.04f, 0.07f, 0.90f);
-    draw_rect(px, py, PAUSE_MENU_PANEL_W, 5.0f, 1.0f, 1.0f, 1.0f, 0.95f);
+    draw_rect(layout.panel_x, layout.panel_y, layout.panel_w, layout.panel_h,
+              UI_ACCENT_R, UI_ACCENT_G, UI_ACCENT_B, 1.0f);
+    draw_rect(layout.panel_x, layout.panel_y, layout.panel_w, 5.0f, 1.0f, 1.0f, 1.0f, 1.0f);
 
     if (s_tc_pause_title.tex) {
         float tw = (float)MENU_TITLE_SIZE * (float)s_tc_pause_title.w / (float)s_tc_pause_title.h;
-        draw_tex(&s_tc_pause_title, px + (PAUSE_MENU_PANEL_W - tw) * 0.5f, py + 24.0f, (float)MENU_TITLE_SIZE);
+        draw_tex(&s_tc_pause_title,
+                 layout.panel_x + (layout.panel_w - tw) * 0.5f,
+                 layout.panel_y + 24.0f,
+                 (float)MENU_TITLE_SIZE);
     }
 
-    for (int i = 0; i < 4; i++) {
+    for (int i = 0; i < layout.n; i++) {
         int active = (i == s_pause_menu_selected);
-        float item_h = active ? PAUSE_MENU_ITEM_ACTIVE_H : PAUSE_MENU_ITEM_H;
-        float item_y = first_item_y + i * (PAUSE_MENU_ITEM_H + PAUSE_MENU_ITEM_GAP) + (PAUSE_MENU_ITEM_H - item_h);
-        float strip_h = active ? 7.0f : 5.0f;
+        float item_h = active ? layout.item_active_h : layout.item_h;
+        float item_y = layout.first_item_y + i * (layout.item_h + layout.gap) + (layout.item_h - item_h);
 
-        draw_rect(item_x, item_y, PAUSE_MENU_ITEM_W, item_h, 1.0f, 1.0f, 1.0f,
+        draw_rect(layout.item_x, item_y, layout.item_w, item_h, 1.0f, 1.0f, 1.0f,
                   active ? 1.0f : 0.84f);
-        draw_rect(item_x, item_y, PAUSE_MENU_ITEM_W, strip_h,
-                  active ? 0.07f : 0.82f,
-                  active ? 0.09f : 0.82f,
-                  active ? 0.13f : 0.82f,
-                  1.0f);
 
         if (s_tc_pause_items[i].tex) {
             float tw = (float)MENU_TEXT_SIZE * (float)s_tc_pause_items[i].w / (float)s_tc_pause_items[i].h;
-            float text_y = item_y + strip_h + (item_h - strip_h - (float)MENU_TEXT_SIZE) * 0.5f;
-            draw_tex(&s_tc_pause_items[i], item_x + (PAUSE_MENU_ITEM_W - tw) * 0.5f, text_y, (float)MENU_TEXT_SIZE);
+            float text_y = item_y + (item_h - (float)MENU_TEXT_SIZE) * 0.5f;
+            draw_tex(&s_tc_pause_items[i],
+                     layout.item_x + (layout.item_w - tw) * 0.5f,
+                     text_y,
+                     (float)MENU_TEXT_SIZE);
         }
     }
 
     if (s_tc_pause_hint.tex) {
         float tw = (float)MENU_HINT_SIZE * (float)s_tc_pause_hint.w / (float)s_tc_pause_hint.h;
-        draw_tex(&s_tc_pause_hint, px + (PAUSE_MENU_PANEL_W - tw) * 0.5f, py + PAUSE_MENU_PANEL_H - 28.0f, (float)MENU_HINT_SIZE);
+        draw_tex(&s_tc_pause_hint,
+                 layout.panel_x + (layout.panel_w - tw) * 0.5f,
+                 layout.panel_y + layout.panel_h - 28.0f,
+                 (float)MENU_HINT_SIZE);
     }
 }
 
@@ -366,12 +422,16 @@ void ui_init(void) {
     glUseProgram(0);
 
     TTF_Init();
-    s_font = find_font(FONT_SIZE);
-    s_menu_font = find_font(MENU_TEXT_SIZE);
-    s_menu_title_font = find_font(MENU_TITLE_SIZE);
+    s_font = ui_theme_open_font(FONT_SIZE);
+    s_build_item_font = ui_theme_open_font(BUILD_ITEM_FONT_SIZE);
+    s_menu_font = ui_theme_open_font(MENU_TEXT_SIZE);
+    s_menu_title_font = ui_theme_open_font(MENU_TITLE_SIZE);
     if (!s_font) fprintf(stderr, "[UI] no font found\n");
+    if (!s_build_item_font) s_build_item_font = s_font;
     if (!s_menu_font) s_menu_font = s_font;
     if (!s_menu_title_font) s_menu_title_font = s_menu_font;
+    if (s_menu_title_font && s_menu_title_font != s_menu_font && s_menu_title_font != s_font)
+        TTF_SetFontStyle(s_menu_title_font, TTF_STYLE_BOLD);
 }
 
 void ui_set_pause_menu(int visible, int selected, int vsync_enabled)
@@ -530,12 +590,15 @@ void ui_shutdown(void) {
     if (s_shader) glDeleteProgram(s_shader);
     if (s_menu_title_font && s_menu_title_font != s_menu_font && s_menu_title_font != s_font)
         TTF_CloseFont(s_menu_title_font);
+    if (s_build_item_font && s_build_item_font != s_font)
+        TTF_CloseFont(s_build_item_font);
     if (s_menu_font && s_menu_font != s_font)
         TTF_CloseFont(s_menu_font);
     if (s_font)   TTF_CloseFont(s_font);
     TTF_Quit();
     s_shader = s_vao = s_vbo = 0;
     s_font = NULL;
+    s_build_item_font = NULL;
     s_menu_font = NULL;
     s_menu_title_font = NULL;
 }

--- a/src/ui.c
+++ b/src/ui.c
@@ -66,6 +66,7 @@ static TextCache s_tc_sim  = {0};
 static TextCache s_tc_fps  = {0};
 static TextCache s_tc_nearest = {0};
 static TextCache s_tc_build_title = {0};
+static TextCache s_tc_build_hint  = {0};
 static TextCache s_tc_build_items[8];
 static TextCache s_tc_pause_title = {0};
 static TextCache s_tc_pause_hint = {0};
@@ -91,12 +92,15 @@ typedef struct {
 
 typedef struct {
     int n;
+    float item_x;         /* x of item body (fixed) */
     float item_w;
     float item_h;
-    float item_active_h;
+    float strip_w;        /* inactive strip width (strip right-edge = item_x) */
+    float strip_active_w; /* active strip width (expands left) */
     float gap;
-    float items_x;
-    float item_y_base;
+    float items_y;        /* y of first item */
+    float title_y;        /* y of "BUILD" title text */
+    float hint_y;         /* y of hint text below panel */
     float panel_x;
     float panel_y;
     float panel_w;
@@ -130,24 +134,30 @@ static PauseMenuLayout pause_menu_layout(float W, float H)
 
 static BuildBarLayout build_bar_layout(float W)
 {
+    (void)W;
     BuildBarLayout layout;
     layout.n = build_preset_count();
     if (layout.n > 8) layout.n = 8;
-    layout.item_w = 112.0f;
-    layout.item_h = 48.0f;
-    layout.item_active_h = 56.0f;
-    layout.gap = 8.0f;
-    layout.item_y_base = (float)WIN_H - 88.0f + 24.0f;
 
-    {
-        float total_w = layout.n * layout.item_w + (layout.n - 1) * layout.gap;
-        float panel_pad = (float)WIN_H - (layout.item_y_base + layout.item_h);
-        layout.items_x = (W - total_w) * 0.5f;
-        layout.panel_x = layout.items_x - panel_pad;
-        layout.panel_y = layout.item_y_base - panel_pad;
-        layout.panel_w = total_w + panel_pad * 2.0f;
-        layout.panel_h = (float)WIN_H - layout.panel_y;
-    }
+    const float PANEL_PAD    = 12.0f;
+    const float LEFT_MARGIN  = PANEL_PAD;
+    const float TITLE_AREA_H = 72.0f;
+    const float BOTTOM_AREA_H = 42.0f;
+    layout.strip_w        = 8.0f;
+    layout.strip_active_w = 14.0f;
+    layout.item_h         = PAUSE_MENU_ITEM_H;
+    layout.item_w         = 112.0f;
+    layout.gap            = PAUSE_MENU_ITEM_GAP;
+    layout.panel_x        = LEFT_MARGIN;
+    layout.item_x         = layout.panel_x + PANEL_PAD + layout.strip_w;
+    layout.panel_w        = PANEL_PAD + layout.strip_w + layout.item_w + PANEL_PAD;
+
+    float total_h    = layout.n * layout.item_h + (layout.n - 1) * layout.gap;
+    layout.panel_h   = TITLE_AREA_H + total_h + BOTTOM_AREA_H;
+    layout.panel_y   = ((float)WIN_H - layout.panel_h) * 0.5f;
+    layout.items_y   = layout.panel_y + TITLE_AREA_H;
+    layout.title_y   = layout.panel_y + 24.0f;
+    layout.hint_y    = layout.panel_y + layout.panel_h - 28.0f;
 
     return layout;
 }
@@ -296,16 +306,28 @@ static void draw_build_bar(float W)
 {
     if (!g_build_mode) return;
 
-    const float PAD = 14.0f;
     BuildBarLayout layout = build_bar_layout(W);
 
-    SDL_Color white = {255, 255, 255, 230};
-    update_text(&s_tc_build_title,
-                g_build_tab_held ? "BUILD MODE  |  scroll to select" : "BUILD MODE  |  hold TAB and scroll",
-                white);
-    draw_tex(&s_tc_build_title, PAD, (float)WIN_H - (FONT_SIZE + 6.0f), (float)FONT_SIZE);
+    SDL_Color title_col = {255, 255, 255, 235};
+    SDL_Color hint_col  = {255, 255, 255, 170};
+    SDL_Color item_col  = {0, 0, 0, 255};
+
+    update_text_with_font(&s_tc_build_title, s_menu_title_font, "BUILD", title_col);
+    update_text_with_font(&s_tc_build_hint, s_font,
+                          g_build_tab_held ? "scroll to select" : "hold TAB and scroll",
+                          hint_col);
+
     draw_rect(layout.panel_x, layout.panel_y, layout.panel_w, layout.panel_h,
               UI_ACCENT_R, UI_ACCENT_G, UI_ACCENT_B, 1.0f);
+    draw_rect(layout.panel_x, layout.panel_y, layout.panel_w, 5.0f, 1.0f, 1.0f, 1.0f, 1.0f);
+
+    if (s_tc_build_title.tex) {
+        float tw = (float)MENU_TITLE_SIZE * (float)s_tc_build_title.w / (float)s_tc_build_title.h;
+        draw_tex(&s_tc_build_title,
+                 layout.panel_x + (layout.panel_w - tw) * 0.5f,
+                 layout.title_y,
+                 (float)MENU_TITLE_SIZE);
+    }
 
     int selected = build_selected_index();
 
@@ -313,24 +335,33 @@ static void draw_build_bar(float W)
         const BuildPreset *p = build_preset_at(i);
         if (!p) continue;
         int active = (i == selected);
-        float item_h = active ? layout.item_active_h : layout.item_h;
-        float item_y = layout.item_y_base + (layout.item_h - item_h);
-        float item_x = layout.items_x + (layout.item_w + layout.gap) * (float)i;
-        float strip_h = active ? 8.0f : 6.0f;
-        draw_rect(item_x, item_y, layout.item_w, item_h,
-                  1.0f, 1.0f, 1.0f,
-                  active ? 1.0f : 0.84f);
-        draw_rect(item_x, item_y, layout.item_w, strip_h, p->col[0], p->col[1], p->col[2], 1.0f);
-        SDL_Color item_col = {0, 0, 0, 255};
+        float item_y   = layout.items_y + (layout.item_h + layout.gap) * (float)i;
+        float sw      = active ? layout.strip_active_w : layout.strip_w;
+        float strip_x = layout.item_x - layout.strip_w;
+
+        draw_rect(layout.item_x, item_y, layout.item_w, layout.item_h,
+                  1.0f, 1.0f, 1.0f, active ? 1.0f : 0.72f);
+        draw_rect(strip_x, item_y, sw, layout.item_h,
+                  p->col[0], p->col[1], p->col[2], 1.0f);
+
         update_text_with_font(&s_tc_build_items[i], s_build_item_font ? s_build_item_font : s_font,
                               p->name, item_col);
         if (s_tc_build_items[i].tex) {
-            float tw = (float)BUILD_ITEM_FONT_SIZE * (float)s_tc_build_items[i].w / (float)s_tc_build_items[i].h;
-            float text_y = item_y + strip_h + (item_h - strip_h - (float)BUILD_ITEM_FONT_SIZE) * 0.5f;
+            float tw     = (float)BUILD_ITEM_FONT_SIZE * (float)s_tc_build_items[i].w / (float)s_tc_build_items[i].h;
+            float text_y = item_y + (layout.item_h - (float)BUILD_ITEM_FONT_SIZE) * 0.5f;
             draw_tex(&s_tc_build_items[i],
-                     item_x + (layout.item_w - tw) * 0.5f, text_y,
+                     layout.item_x + (layout.item_w - tw) * 0.5f,
+                     text_y,
                      (float)BUILD_ITEM_FONT_SIZE);
         }
+    }
+
+    if (s_tc_build_hint.tex) {
+        float tw = (float)FONT_SIZE * (float)s_tc_build_hint.w / (float)s_tc_build_hint.h;
+        draw_tex(&s_tc_build_hint,
+                 layout.panel_x + (layout.panel_w - tw) * 0.5f,
+                 layout.hint_y,
+                 (float)FONT_SIZE);
     }
 }
 
@@ -374,7 +405,7 @@ static void draw_pause_menu(float W, float H)
         float item_y = layout.first_item_y + i * (layout.item_h + layout.gap) + (layout.item_h - item_h);
 
         draw_rect(layout.item_x, item_y, layout.item_w, item_h, 1.0f, 1.0f, 1.0f,
-                  active ? 1.0f : 0.84f);
+                  active ? 1.0f : 0.72f);
 
         if (s_tc_pause_items[i].tex) {
             float tw = (float)MENU_TEXT_SIZE * (float)s_tc_pause_items[i].w / (float)s_tc_pause_items[i].h;

--- a/src/ui.h
+++ b/src/ui.h
@@ -5,5 +5,7 @@
 #include "common.h"
 
 void ui_init(void);
+void ui_set_pause_menu(int visible, int selected, int vsync_enabled);
+int ui_pause_menu_hit_test(int mouse_x, int mouse_y);
 void ui_render(void);
 void ui_shutdown(void);

--- a/src/ui_theme.c
+++ b/src/ui_theme.c
@@ -1,0 +1,21 @@
+/*
+ * ui_theme.c - shared UI theme helpers
+ */
+#include "ui_theme.h"
+
+static const char *s_ui_font_paths[] = {
+    "C:/Windows/Fonts/segoeui.ttf",
+    "C:/Windows/Fonts/arial.ttf",
+    "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf",
+    "/usr/share/fonts/TTF/DejaVuSans.ttf",
+    NULL
+};
+
+TTF_Font *ui_theme_open_font(int size)
+{
+    for (int i = 0; s_ui_font_paths[i]; i++) {
+        TTF_Font *f = TTF_OpenFont(s_ui_font_paths[i], size);
+        if (f) return f;
+    }
+    return NULL;
+}

--- a/src/ui_theme.h
+++ b/src/ui_theme.h
@@ -1,0 +1,12 @@
+/*
+ * ui_theme.h - shared UI theme helpers
+ */
+#pragma once
+#include "common.h"
+
+#define UI_ACCENT_R 0.0f
+#define UI_ACCENT_G 0.39215687f
+#define UI_ACCENT_B 0.87058824f
+
+TTF_Font *ui_theme_open_font(int size);
+

--- a/src/universe.c
+++ b/src/universe.c
@@ -86,6 +86,7 @@ static void read_color(const JsonNode *arr, float col[3])
 static void body_defaults(Body *bo)
 {
     memset(bo, 0, sizeof(*bo));
+    bo->alive     = 1;
     bo->parent    = -1;
     bo->atm_scale = 1.0f;
 }
@@ -136,12 +137,7 @@ static void read_atmosphere(const JsonNode *bn, Body *bo)
  *   Planets (parent=star) return the star in one hop.
  *   Moons  (parent=planet, parent=star) return the star in two hops.
  */
-static int root_star_of(int i)
-{
-    while (g_bodies[i].parent >= 0)
-        i = g_bodies[i].parent;
-    return i;
-}
+static int root_star_of(int i) { return body_root_star(i); }
 
 /* ------------------------------------------------------------------ public */
 
@@ -453,6 +449,34 @@ int universe_add_body(const BodyCreateSpec *spec)
     alloc_trail(bo);
 
     return idx;
+}
+
+void universe_rebind_to_nearest_stars(void)
+{
+    for (int i = 0; i < g_nbodies; i++) {
+        int best_star = -1;
+        double best_d2 = 1e300;
+
+        if (!g_bodies[i].alive || g_bodies[i].is_star) continue;
+        if (g_bodies[i].parent >= 0 && !g_bodies[g_bodies[i].parent].is_star)
+            continue;
+
+        for (int s = 0; s < g_nbodies; s++) {
+            double dx, dy, dz, d2;
+            if (!g_bodies[s].alive || !g_bodies[s].is_star) continue;
+            dx = g_bodies[s].pos[0] - g_bodies[i].pos[0];
+            dy = g_bodies[s].pos[1] - g_bodies[i].pos[1];
+            dz = g_bodies[s].pos[2] - g_bodies[i].pos[2];
+            d2 = dx*dx + dy*dy + dz*dz;
+            if (d2 < best_d2) {
+                best_d2 = d2;
+                best_star = s;
+            }
+        }
+
+        if (best_star >= 0)
+            g_bodies[i].parent = best_star;
+    }
 }
 
 void universe_shutdown(void)

--- a/src/universe.c
+++ b/src/universe.c
@@ -66,6 +66,7 @@ static void alloc_trail(Body *bo)
     bo->trail_head  = 0;
     bo->trail_count = 0;
     bo->trail_accum = 0.0;
+    bo->trail_fade  = 1.0;
 }
 
 static int find_body_index(const char *name, int n)

--- a/src/universe.c
+++ b/src/universe.c
@@ -71,6 +71,24 @@ static void alloc_trail(Body *bo)
     bo->trail_prev_pos[0] = bo->pos[0];
     bo->trail_prev_pos[1] = bo->pos[1];
     bo->trail_prev_pos[2] = bo->pos[2];
+    bo->trail_prev_vel[0] = bo->vel[0];
+    bo->trail_prev_vel[1] = bo->vel[1];
+    bo->trail_prev_vel[2] = bo->vel[2];
+    bo->trail_frame_accum = 0.0;
+    bo->trail_frame_head = 0;
+    bo->trail_frame_count = 0;
+    bo->trail_frame_pos[0] = bo->pos[0];
+    bo->trail_frame_pos[1] = bo->pos[1];
+    bo->trail_frame_pos[2] = bo->pos[2];
+    bo->trail_frame_vel[0] = bo->vel[0];
+    bo->trail_frame_vel[1] = bo->vel[1];
+    bo->trail_frame_vel[2] = bo->vel[2];
+    bo->trail_frame_prev_pos[0] = bo->trail_prev_pos[0];
+    bo->trail_frame_prev_pos[1] = bo->trail_prev_pos[1];
+    bo->trail_frame_prev_pos[2] = bo->trail_prev_pos[2];
+    bo->trail_frame_prev_vel[0] = bo->trail_prev_vel[0];
+    bo->trail_frame_prev_vel[1] = bo->trail_prev_vel[1];
+    bo->trail_frame_prev_vel[2] = bo->trail_prev_vel[2];
 }
 
 static int find_body_index(const char *name, int n)

--- a/src/universe.c
+++ b/src/universe.c
@@ -62,10 +62,15 @@ static void ensure_capacity(int needed)
 static void alloc_trail(Body *bo)
 {
     bo->trail = (double(*)[3])calloc(TRAIL_LEN, 3 * sizeof(double));
-    if (!bo->trail) { fprintf(stderr, "[universe] trail alloc failed\n"); exit(1); }
+    bo->trail_seg_len = (double*)calloc(TRAIL_LEN, sizeof(double));
+    if (!bo->trail || !bo->trail_seg_len) {
+        fprintf(stderr, "[universe] trail alloc failed\n");
+        exit(1);
+    }
     bo->trail_head  = 0;
     bo->trail_count = 0;
     bo->trail_accum = 0.0;
+    bo->trail_total_len = 0.0;
     bo->trail_fade  = 1.0;
     bo->trail_emitting = 1;
     bo->trail_prev_pos[0] = bo->pos[0];
@@ -77,6 +82,7 @@ static void alloc_trail(Body *bo)
     bo->trail_frame_accum = 0.0;
     bo->trail_frame_head = 0;
     bo->trail_frame_count = 0;
+    bo->trail_frame_total_len = 0.0;
     bo->trail_frame_pos[0] = bo->pos[0];
     bo->trail_frame_pos[1] = bo->pos[1];
     bo->trail_frame_pos[2] = bo->pos[2];
@@ -472,6 +478,8 @@ void universe_shutdown(void)
     for (i = 0; i < g_nbodies; i++) {
         free(g_bodies[i].trail);
         g_bodies[i].trail = NULL;
+        free(g_bodies[i].trail_seg_len);
+        g_bodies[i].trail_seg_len = NULL;
     }
     free(g_bodies);
     g_bodies     = NULL;

--- a/src/universe.c
+++ b/src/universe.c
@@ -67,6 +67,10 @@ static void alloc_trail(Body *bo)
     bo->trail_count = 0;
     bo->trail_accum = 0.0;
     bo->trail_fade  = 1.0;
+    bo->trail_emitting = 1;
+    bo->trail_prev_pos[0] = bo->pos[0];
+    bo->trail_prev_pos[1] = bo->pos[1];
+    bo->trail_prev_pos[2] = bo->pos[2];
 }
 
 static int find_body_index(const char *name, int n)
@@ -90,25 +94,6 @@ static void body_defaults(Body *bo)
     bo->alive     = 1;
     bo->parent    = -1;
     bo->atm_scale = 1.0f;
-}
-
-static double trail_interval_for_body(const Body *bo)
-{
-    if (bo->is_star) return DAY * 25.0;
-    if (bo->parent >= 0 && bo->parent < g_nbodies && g_bodies[bo->parent].mass > 0.0) {
-        double dx = bo->pos[0] - g_bodies[bo->parent].pos[0];
-        double dy = bo->pos[1] - g_bodies[bo->parent].pos[1];
-        double dz = bo->pos[2] - g_bodies[bo->parent].pos[2];
-        double r = sqrt(dx*dx + dy*dy + dz*dz);
-        double gm = G_CONST * g_bodies[bo->parent].mass;
-        if (r > 0.0 && gm > 0.0) {
-            double T = 2.0 * PI * sqrt(r * r * r / gm);
-            double interval = T / 400.0;
-            if (interval < 60.0) interval = 60.0;
-            return interval;
-        }
-    }
-    return DAY;
 }
 
 static void read_rotation(const JsonNode *bn, Body *bo)
@@ -197,7 +182,6 @@ void universe_load(const char *path)
             bo->pos[0]         = px; bo->pos[1] = py; bo->pos[2] = pz;
             bo->col[0]         = col[0]; bo->col[1] = col[1]; bo->col[2] = col[2];
             bo->is_star        = 1;
-            bo->trail_interval = DAY * 25.0;
             read_rotation(bn, bo);
 
             /* Stash bulk velocity for post-processing */
@@ -261,10 +245,6 @@ void universe_load(const char *path)
             p[1] += g_bodies[par_idx].pos[1];
             p[2] += g_bodies[par_idx].pos[2];
 
-            /* Trail interval: T/400 in sim-seconds */
-            double T_days = 2.0 * PI * sqrt(a * a * a / gm_star_au2);
-            double trail_int   = (T_days / 400.0) * DAY;
-
             ensure_capacity(g_nbodies + 1);
             Body *bo = &g_bodies[g_nbodies++];
             body_defaults(bo);
@@ -275,7 +255,6 @@ void universe_load(const char *path)
             bo->vel[0]         = v[0]; bo->vel[1] = v[1]; bo->vel[2] = v[2];
             bo->col[0]         = col[0]; bo->col[1] = col[1]; bo->col[2] = col[2];
             bo->parent         = par_idx;
-            bo->trail_interval = trail_int;
             read_rotation(bn, bo);
             read_atmosphere(bn, bo);
             alloc_trail(bo);
@@ -329,15 +308,6 @@ void universe_load(const char *path)
                               M0_deg, gm_par, rel_p, rel_v);
             }
 
-            /* Trail interval: T/400, minimum 60 s */
-            double trail_int = DAY;
-            if (a_km > 0.0) {
-                double a_m = a_km * 1000.0;
-                double T   = 2.0 * PI * sqrt(a_m * a_m * a_m / gm_par);
-                trail_int = T / 400.0;
-                if (trail_int < 60.0) trail_int = 60.0;
-            }
-
             ensure_capacity(g_nbodies + 1);
             Body *bo = &g_bodies[g_nbodies++];
             body_defaults(bo);
@@ -352,7 +322,6 @@ void universe_load(const char *path)
             bo->vel[2]         = par_v[2] + rel_v[2];
             bo->col[0]         = col[0]; bo->col[1] = col[1]; bo->col[2] = col[2];
             bo->parent         = par_idx;
-            bo->trail_interval = trail_int;
             read_rotation(bn, bo);
             read_atmosphere(bn, bo);
             alloc_trail(bo);
@@ -446,7 +415,6 @@ int universe_add_body(const BodyCreateSpec *spec)
     bo->atm_color[2] = spec->atm_color[2];
     bo->atm_intensity = spec->atm_intensity;
     bo->atm_scale = spec->atm_scale > 0.0f ? spec->atm_scale : 1.0f;
-    bo->trail_interval = trail_interval_for_body(bo);
     alloc_trail(bo);
 
     return idx;

--- a/src/universe.c
+++ b/src/universe.c
@@ -154,6 +154,8 @@ static int root_star_of(int i) { return body_root_star(i); }
 void universe_load(const char *path)
 {
     int i, s;
+    fprintf(stdout, "[Boot] Loading universe data from %s\n", path);
+    fflush(stdout);
     JsonNode *root = json_parse_file(path);
     if (!root) {
         fprintf(stderr, "[universe] failed to open or parse '%s'\n", path);
@@ -177,6 +179,8 @@ void universe_load(const char *path)
      * Placed at their absolute position (pos_ly → metres).
      * Bulk velocity stashed in bv[]; applied in post-processing.
      * ================================================================ */
+    fprintf(stdout, "[Boot] Universe pass 1/3: stars\n");
+    fflush(stdout);
     {
         JsonNode *bn;
         for (bn = bodies_arr->first_child; bn; bn = bn->next) {
@@ -227,6 +231,8 @@ void universe_load(const char *path)
      * Body.parent is set to the star's index so root_star_of() works
      * and the physics engine correctly skips planet–star fast forces.
      * ================================================================ */
+    fprintf(stdout, "[Boot] Universe pass 2/3: planets and dwarf planets\n");
+    fflush(stdout);
     {
         JsonNode *bn;
         for (bn = bodies_arr->first_child; bn; bn = bn->next) {
@@ -289,6 +295,8 @@ void universe_load(const char *path)
      * Pass 3 — Moons
      * Parent-relative orbit; parent must be a planet already loaded.
      * ================================================================ */
+    fprintf(stdout, "[Boot] Universe pass 3/3: moons\n");
+    fflush(stdout);
     {
         JsonNode *bn;
         for (bn = bodies_arr->first_child; bn; bn = bn->next) {
@@ -357,6 +365,8 @@ void universe_load(const char *path)
      *   1. Centre-of-mass velocity correction (zero internal momentum).
      *   2. Apply bulk velocity (proper motion) to all bodies in system.
      * ================================================================ */
+    fprintf(stdout, "[Boot] Universe post-processing: system velocities\n");
+    fflush(stdout);
     int n_stars = 0;
     for (s = 0; s < g_nbodies; s++) {
         if (!g_bodies[s].is_star) continue;
@@ -389,7 +399,7 @@ void universe_load(const char *path)
         for (i = 0; i < g_nbodies; i++)
             if (root_star_of(i) == s) cnt++;
         fprintf(stdout,
-                "[universe] '%s' at (%.3g, %.3g, %.3g) ly  —  %d bod%s\n",
+                "[universe] '%s' at (%.3g, %.3g, %.3g) ly  -  %d bod%s\n",
                 g_bodies[s].name,
                 g_bodies[s].pos[0] / LY,
                 g_bodies[s].pos[1] / LY,
@@ -399,6 +409,7 @@ void universe_load(const char *path)
 
     fprintf(stdout, "[universe] total: %d bodies across %d star%s\n",
             g_nbodies, n_stars, n_stars == 1 ? "" : "s");
+    fflush(stdout);
 
     json_free(root);
 }
@@ -486,3 +497,4 @@ void universe_shutdown(void)
     g_nbodies    = 0;
     g_bodies_cap = 0;
 }
+

--- a/src/universe.h
+++ b/src/universe.h
@@ -36,5 +36,8 @@ void universe_load(const char *path);
 /* Add a fully specified runtime body. Returns the new body index, or -1. */
 int universe_add_body(const BodyCreateSpec *spec);
 
+/* Reassign planets/dwarf bodies to the nearest star after sandbox edits. */
+void universe_rebind_to_nearest_stars(void);
+
 /* universe_shutdown — free all body trail buffers and the g_bodies array. */
 void universe_shutdown(void);


### PR DESCRIPTION
## Summary

This branch introduces a full collision and merge system for planet-scale impacts, a rewritten RESPA physics engine with adaptive timestep management, acceleration-driven orbital trails, a redesigned UI, and build mode improvements.

---

### Physics & Simulation

- **RESPA hierarchical integrator** — rewrote the physics engine with a 2-level RESPA split (slow primary–primary forces / fast parent→satellite forces), achieving ~32× fewer pair evaluations per frame at high simulation speeds
- **Per-system timestep model** — each solar system independently computes optimal outer/inner dt based on orbital periods and perturbation ratios; one short-period moon no longer throttles the entire scene
- **Adaptive close-approach subdivision** — outer steps are split by up to 8× when time-to-closest-approach falls below a threshold, giving accurate flyby integration without wasting steps during quiet phases

---

### Collision & Merge System

- **Planet–planet collision-merge animation** — bodies smoothly merge with an intersection glow, sphere-sphere boundary rendering, and a configurable merge duration
- **Impact particle spray** — collision events spawn directional particle bursts rendered as billboards
- **Persistent impact craters** — craters are baked into the planet shader after the heat fades
- **Collision-driven spin** — impactor angular momentum is transferred to the target on impact
- **Star collision heating** — bodies approaching the star develop a red heat glow that scales with proximity; the sun suppresses trail rendering inside the corona
- **Swept-sphere continuous collision detection** — tunneling prevention using pre-physics position snapshots; adaptive pair scheduling based on time-to-contact

---

### Orbital Trails

- **Acceleration-driven sampling** — trail point density scales with gravitational acceleration magnitude, giving dense coverage at periapsis and sparse coverage in quiet regions
- **World-space length budget** — trail length is capped by a physical distance rather than point count, keeping visual consistency across orbital scales
- **Higher density for moons and close approaches** — satellites and encountering primaries get a dedicated dense-sampling bucket
- **Merge trail handling** — target trail is preserved through a merge; impactor trail fades out

---

### UI & Build Mode

- **ESC pause menu** — system menu with keyboard/mouse navigation, V-Sync toggle, universe reset, and resume; slides open over the scene
- **Redesigned build mode panel** — matches the pause menu visual style; animates in from the left edge
- **Improved build presets** — better randomization and atmosphere billboard coverage for placed bodies

---

### Docs & Project

- Added `ARCHITECTURE.md` with a full codebase reference (~1100 lines)
- Added `CONTRIBUTING.md`
- Added GitHub issue templates and PR template