### PR TITLE
Build/release packaging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,65 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  # ── Windows ────────────────────────────────────────────────────────────────
+  build-windows:
+    runs-on: windows-latest
+    defaults:
+      run:
+        shell: msys2 {0}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: msys2/setup-msys2@v2
+        with:
+          msystem: MINGW64
+          update: true
+          install: >-
+            mingw-w64-x86_64-gcc
+            mingw-w64-x86_64-SDL2
+            mingw-w64-x86_64-SDL2_ttf
+            mingw-w64-x86_64-glew
+            zip
+
+      - name: Build
+        run: mingw32-make
+
+      - name: Package
+        run: bash package_windows.sh ${{ github.ref_name }}
+
+      - name: Upload to Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: dist/*.zip
+
+  # ── Linux ──────────────────────────────────────────────────────────────────
+  build-linux:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libsdl2-dev libsdl2-ttf-dev libglew-dev
+
+      - name: Build
+        run: make
+
+      - name: Package
+        run: bash package_linux.sh ${{ github.ref_name }}
+
+      - name: Upload to Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: dist/*.tar.gz

--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,6 @@ dkms.conf
 
 # debug information files
 *.dwo
+
+# Release packaging output
+dist/

--- a/package_linux.sh
+++ b/package_linux.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Run this on Linux after compiling with: make
+# Usage: bash package_linux.sh [version]
+# Example: bash package_linux.sh 1.0.0
+set -e
+
+VERSION=${1:-"dev"}
+NAME="verse-linux-x64-${VERSION}"
+DIST="dist/${NAME}"
+LIBS_DIR="${DIST}/libs"
+
+echo ">>> Packaging verse for Linux: ${NAME}"
+
+# Clean and create output directories
+rm -rf "${DIST}"
+mkdir -p "${DIST}"
+mkdir -p "${LIBS_DIR}"
+
+# Copy binary
+if [ ! -f "verse" ]; then
+    echo "ERROR: verse binary not found. Run 'make' first."
+    exit 1
+fi
+cp verse "${DIST}/verse.bin"
+chmod +x "${DIST}/verse.bin"
+
+# Copy assets
+cp -r assets/ "${DIST}/"
+
+# Bundle shared libraries (SDL2, SDL2_ttf, GLEW and their deps)
+echo ">>> Collecting shared libraries via ldd..."
+ldd verse \
+    | grep -v "linux-vdso\|ld-linux\|libGL\|libEGL\|/lib/x86_64" \
+    | awk '{print $3}' \
+    | grep "^/" \
+    | while read lib; do
+        if [ -f "$lib" ]; then
+            echo "  + $(basename $lib)"
+            cp "$lib" "${LIBS_DIR}/"
+        fi
+    done
+
+# Create launch wrapper that sets LD_LIBRARY_PATH
+cat > "${DIST}/verse" << 'EOF'
+#!/usr/bin/env bash
+DIR="$(cd "$(dirname "$0")" && pwd)"
+export LD_LIBRARY_PATH="${DIR}/libs:${LD_LIBRARY_PATH}"
+exec "${DIR}/verse.bin" "$@"
+EOF
+chmod +x "${DIST}/verse"
+
+# Create archive
+echo ">>> Creating archive..."
+mkdir -p dist
+cd dist
+tar -czf "${NAME}.tar.gz" "${NAME}/"
+cd ..
+
+echo ""
+echo "Done! Package ready: dist/${NAME}.tar.gz"
+echo "Contents:"
+ls -lh "${DIST}/"

--- a/package_linux.sh
+++ b/package_linux.sh
@@ -30,7 +30,7 @@ cp -r assets/ "${DIST}/"
 # Bundle shared libraries (SDL2, SDL2_ttf, GLEW and their deps)
 echo ">>> Collecting shared libraries via ldd..."
 ldd verse \
-    | grep -v "linux-vdso\|ld-linux\|libGL\|libEGL\|/lib/x86_64" \
+    | grep -v "linux-vdso\|ld-linux\|libc\.so\|libpthread\|libdl\.so\|libm\.so\|librt\.so\|libGL\|libEGL" \
     | awk '{print $3}' \
     | grep "^/" \
     | while read lib; do

--- a/package_windows.sh
+++ b/package_windows.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Run this in MSYS2 MINGW64 after compiling with: mingw32-make
+# Usage: bash package_windows.sh [version]
+# Example: bash package_windows.sh 1.0.0
+set -e
+
+VERSION=${1:-"dev"}
+NAME="verse-windows-x64-${VERSION}"
+DIST="dist/${NAME}"
+
+echo ">>> Packaging verse for Windows: ${NAME}"
+
+# Clean and create output directory
+rm -rf "${DIST}"
+mkdir -p "${DIST}"
+
+# Copy executable
+if [ ! -f "verse.exe" ]; then
+    echo "ERROR: verse.exe not found. Run 'mingw32-make' first."
+    exit 1
+fi
+cp verse.exe "${DIST}/"
+
+# Copy assets
+cp -r assets/ "${DIST}/"
+
+# Copy all required DLLs (filter out Windows system DLLs)
+echo ">>> Collecting DLLs via ldd..."
+ldd verse.exe \
+    | grep -iv "/c/windows" \
+    | grep -v "not found" \
+    | awk '{print $3}' \
+    | grep -v "^$" \
+    | while read dll; do
+        if [ -f "$dll" ]; then
+            echo "  + $(basename $dll)"
+            cp "$dll" "${DIST}/"
+        fi
+    done
+
+# Create ZIP archive
+echo ">>> Creating archive..."
+mkdir -p dist
+cd dist
+zip -r "${NAME}.zip" "${NAME}/"
+cd ..
+
+echo ""
+echo "Done! Package ready: dist/${NAME}.zip"
+echo "Contents:"
+ls "${DIST}/"


### PR DESCRIPTION
### What does this PR do?
Adds a GitHub Actions pipeline and two packaging scripts that automatically build and bundle portable release packages for Windows and Linux whenever a version tag is pushed.

### Related Issue
Closes #

### Changes
- `.github/workflows/release.yml` — CI pipeline that triggers on `v*` tags, builds on Windows (MSYS2/MinGW64) and Linux (Ubuntu) in parallel, and attaches the resulting packages to the GitHub Release automatically
- `package_windows.sh` — collects `verse.exe`, all required DLLs (SDL2, SDL2_ttf, GLEW etc. via `ldd`) and the `assets/` folder into a `.zip`
- `package_linux.sh` — collects the `verse` binary, bundles shared libraries into a `libs/` subfolder with a launch wrapper script that sets `LD_LIBRARY_PATH`, and packages everything as a `.tar.gz`
- `.gitignore` — added `dist/` to exclude local packaging output

### Testing
- Verified DLL collection logic filters out Windows system DLLs (`/c/Windows`) correctly
- Verified Linux `ldd` filter excludes glibc (`libc`, `libm`, `libpthread` etc.) and GPU libs (`libGL`, `libEGL`) while correctly bundling SDL2, GLEW and their dependencies
- Scripts tested locally in MSYS2 MINGW64

### Usage
After merging to main, create and push a tag to trigger the pipeline:
```bash
git tag v0.7-beta
git push origin v0.7-beta