### PR TITLE
Feat/inspection mode

### DIFF
--- a/assets/shaders/phong.frag
+++ b/assets/shaders/phong.frag
@@ -103,6 +103,21 @@ vec3 lava_color(float heat)
     return mix(vec3(0.98, 0.58, 0.14), vec3(1.00, 0.80, 0.34), (heat - 0.92) / 0.08);
 }
 
+vec3 local_surface_dir_to_world(vec3 local_dir)
+{
+    float cr = cos(u_rotation);
+    float sr = sin(u_rotation);
+    float tx = local_dir.x * cr - local_dir.z * sr;
+    float ty = local_dir.y;
+    float tz = local_dir.x * sr + local_dir.z * cr;
+
+    float co = cos(u_obliquity);
+    float so = sin(u_obliquity);
+    return normalize(vec3(co * tx + so * ty,
+                          -so * tx + co * ty,
+                          tz));
+}
+
 /* ======================================================================
  * Per-planet surface colour  (NL = normal in body-local frame)
  * ====================================================================== */
@@ -314,6 +329,7 @@ void main() {
 
     vec3 base_surface = surface_color(NL);
     vec3 surface = base_surface;
+    vec3 shade_N = N;
     vec3 lava_emit = vec3(0.0);
 
     /* Sun direction — computed once, reused for emission clamping inside the
@@ -519,6 +535,25 @@ void main() {
             float size_fade = smoothstep(0.006, 0.18, rad);
             float crater_alpha = mix(0.58, 1.0, earth_crater) * mix(0.08, 1.0, size_fade)
                                * (1.0 - s_intersection * 0.35) * cap_gate;
+            vec3 crater_radial_dir = (scar_t1 * crater_uv.x + scar_t2 * crater_uv.y)
+                                   / max(crater_r, 0.001);
+            float bowl_slope = smoothstep(0.12, 0.62, crater_r)
+                             * (1.0 - smoothstep(0.62, 0.92, crater_r));
+            float rim_inner = smoothstep(0.60 + rim_shift, 0.84 + rim_shift, crater_r)
+                            * (1.0 - smoothstep(0.84 + rim_shift, 0.98 + rim_shift, crater_r));
+            float rim_outer = smoothstep(0.84 + rim_shift, 0.98 + rim_shift, crater_r)
+                            * (1.0 - smoothstep(0.98 + rim_shift, 1.16 + rim_shift, crater_r));
+            float normal_depth = crater_alpha * crater_mask * outer_fade;
+            vec3 rubble_normal = (scar_t1 * rubble_var + scar_t2 * chunk_var)
+                               * fractured_band * 0.18;
+            vec3 crater_local_n = normalize(NL
+                                      - crater_radial_dir * bowl_slope * (0.34 + depth * 0.18)
+                                      - crater_radial_dir * rim_inner * 0.22
+                                      + crater_radial_dir * rim_outer * 0.18
+                                      + rubble_normal);
+            shade_N = normalize(mix(shade_N,
+                                    local_surface_dir_to_world(crater_local_n),
+                                    normal_depth * 0.82));
             vec3 warm_brown = mix(vec3(0.18, 0.14, 0.11), vec3(0.34, 0.26, 0.18), crater_coarse);
             vec3 dusty_brown = mix(vec3(0.24, 0.19, 0.14), vec3(0.42, 0.33, 0.24), crater_fine);
             vec3 ridge_brown = mix(vec3(0.32, 0.25, 0.18), vec3(0.50, 0.40, 0.30), crater_coarse * 0.65 + crater_fine * 0.35);
@@ -564,6 +599,7 @@ void main() {
     }
 
     /* ---- Phong diffuse ------------------------------------------------ */
+    diff = max(dot(shade_N, L), 0.0);
     float light = u_ambient + (1.0 - u_ambient) * diff;
 
     frag_color = vec4(surface * light + lava_emit, 1.0);

--- a/assets/shaders/phong.frag
+++ b/assets/shaders/phong.frag
@@ -401,14 +401,16 @@ void main() {
         if (kind == 1) {
             float crater_floor = 1.0 - smoothstep(0.0, rad * 0.72, ang);
             float hot_rim = ring * (1.0 - progress * 0.65);
-            surface = mix(surface, surface * 0.12, crater_floor * 0.58);
-            surface = mix(surface, mix(lava_deep, lava_molten, core), core * heat * 0.72);
-            surface = mix(surface, vec3(0.08, 0.05, 0.04), ring * 0.32);
+            float glow_cover = heat * (0.42 + 0.28 * (1.0 - progress));
+            surface = mix(surface, surface * 0.42, crater_floor * heat * 0.22);
+            surface = mix(surface, mix(lava_deep, lava_molten, core), core * glow_cover);
+            surface = mix(surface, vec3(0.08, 0.05, 0.04), ring * heat * 0.14);
             lava_emit += lava_molten * (core * 1.5 + hot_rim * 0.9) * heat;
         } else if (kind == 2) {
             float ash = outer * 0.35;
-            surface = mix(surface, surface * 0.18, ring * heat * 0.72 + ash);
-            surface = mix(surface, mix(lava_deep, lava_hot, core), melt * heat * 0.88);
+            float glow_cover = heat * (0.50 + 0.28 * (1.0 - progress));
+            surface = mix(surface, surface * 0.34, ring * heat * 0.24 + ash * 0.45);
+            surface = mix(surface, mix(lava_deep, lava_hot, core), melt * glow_cover);
             lava_emit += lava * (core * 1.8 + melt * 0.9 + outer * 0.35) * heat;
         } else if (kind == 3) {
             float flood = 1.0 - smoothstep(0.0, rad * 1.08, ang);
@@ -467,6 +469,7 @@ void main() {
             vec3 scar_p = vec3(dot(NL, scar_t1),
                                dot(NL, scar_t2),
                                dot(NL, idir) - cos(rad));
+            float cap_gate = 1.0 - smoothstep(rad * 1.02, rad * 1.22, ang);
             vec2 crater_uv = scar_p.xy / max(rad, 0.001);
             float crater_r = length(crater_uv);
             float crater_ang = atan(crater_uv.y, crater_uv.x);
@@ -515,7 +518,7 @@ void main() {
             float earth_crater = u_planet_type == 1 ? 1.0 : 0.0;
             float size_fade = smoothstep(0.006, 0.18, rad);
             float crater_alpha = mix(0.58, 1.0, earth_crater) * mix(0.08, 1.0, size_fade)
-                               * (1.0 - s_intersection * 0.95);
+                               * (1.0 - s_intersection * 0.35) * cap_gate;
             vec3 warm_brown = mix(vec3(0.18, 0.14, 0.11), vec3(0.34, 0.26, 0.18), crater_coarse);
             vec3 dusty_brown = mix(vec3(0.24, 0.19, 0.14), vec3(0.42, 0.33, 0.24), crater_fine);
             vec3 ridge_brown = mix(vec3(0.32, 0.25, 0.18), vec3(0.50, 0.40, 0.30), crater_coarse * 0.65 + crater_fine * 0.35);

--- a/src/collision.c
+++ b/src/collision.c
@@ -112,6 +112,7 @@ static ImpactEvent s_impacts[MAX_IMPACTS];
 static PersistentScar s_perm_scars[MAX_PERSISTENT_SCARS];
 static RadiusTransition s_radius_fx[MAX_BODIES];
 static MergeEvent s_merges[MAX_MERGES];
+static int s_absorbed_by[MAX_BODIES];
 static ImpactParticleState s_particles[MAX_COLLISION_PARTICLES];
 static double s_pair_next[MAX_BODIES][MAX_BODIES];
 static unsigned char s_system_dirty[MAX_BODIES];
@@ -144,6 +145,7 @@ void collision_reset(void)
     memset(s_perm_scars, 0, sizeof(s_perm_scars));
     memset(s_radius_fx, 0, sizeof(s_radius_fx));
     memset(s_merges, 0, sizeof(s_merges));
+    for (int i = 0; i < MAX_BODIES; i++) s_absorbed_by[i] = -1;
     memset(s_particles, 0, sizeof(s_particles));
     memset(s_pair_next, 0, sizeof(s_pair_next));
     memset(s_system_dirty, 0, sizeof(s_system_dirty));
@@ -1346,6 +1348,8 @@ static void finalize_absorb_body(int target, int impactor, double rel_speed,
     }
 
     rings_on_body_absorbed(target, impactor);
+    if (impactor >= 0 && impactor < MAX_BODIES)
+        s_absorbed_by[impactor] = target;
     b->alive = 0;
     b->mass = 0.0;
     a->trail_emitting = 1;
@@ -2521,6 +2525,12 @@ int collision_body_has_active_merge(int body_idx)
 {
     if (body_idx < 0 || body_idx >= g_nbodies) return 0;
     return body_is_in_merge(body_idx);
+}
+
+int collision_body_absorbed_by(int body_idx)
+{
+    if (body_idx < 0 || body_idx >= MAX_BODIES) return -1;
+    return s_absorbed_by[body_idx];
 }
 
 int collision_body_needs_dense_trail(int body_idx)

--- a/src/collision.h
+++ b/src/collision.h
@@ -43,6 +43,7 @@ void collision_body_heat_glow(int body_idx, float out_color[3],
                               float *out_intensity, float *out_scale);
 float collision_body_star_heat(int body_idx);
 int collision_body_has_active_merge(int body_idx);
+int collision_body_absorbed_by(int body_idx);
 int collision_body_needs_dense_trail(int body_idx);
 int collision_particles(CollisionParticle *out, int max_particles,
                         const double cam_pos[3]);

--- a/src/inspect.c
+++ b/src/inspect.c
@@ -24,6 +24,8 @@ static double s_orbit_transition_t = 1.0;
 static double s_orbit_transition_duration = 1.45;
 static int s_orbit_zoom_smoothing = 0;
 static double s_orbit_dir[3] = {0.0, 0.0, 1.0};
+static double s_look_transition_t = 1.0;
+static double s_look_transition_duration = 0.75;
 
 #define INSPECT_MAX_PICK_AU 100.0
 
@@ -93,14 +95,26 @@ static double smootherstep(double t)
 {
     if (t < 0.0) t = 0.0;
     if (t > 1.0) t = 1.0;
+    t = pow(t, 1.45);
     return t * t * t * (t * (t * 6.0 - 15.0) + 10.0);
+}
+
+static double visual_distance_lerp(double start, double target, double t)
+{
+    double log_start, log_target, log_dist;
+    if (start <= 1e-12 || target <= 1e-12)
+        return start + (target - start) * t;
+
+    log_start = log(start);
+    log_target = log(target);
+    log_dist = log_start + (log_target - log_start) * t;
+    return exp(log_dist);
 }
 
 static void set_orbit_target_from_camera(int idx, double duration)
 {
     double center[3], rel[3], dist, radius_au, target_dist, axis[3];
-    double small_body_blend;
-    double travel_ratio;
+    double visual_ratio;
     double distance_blend;
     center[0] = g_bodies[idx].pos[0] * RS;
     center[1] = g_bodies[idx].pos[1] * RS;
@@ -137,20 +151,17 @@ static void set_orbit_target_from_camera(int idx, double duration)
     s_orbit_start_distance = dist;
     s_orbit_distance = target_dist;
     s_orbit_transition_t = 0.0;
-    small_body_blend = 0.00014 / fmax(target_dist, 1e-9);
-    if (small_body_blend > 1.0) small_body_blend = 1.0;
-    if (small_body_blend < 0.0) small_body_blend = 0.0;
-    travel_ratio = fabs(dist - target_dist) / fmax(target_dist, 1e-9);
-    distance_blend = log(1.0 + travel_ratio) / log(1.0 + 5000.0);
+    visual_ratio = fmax(dist, target_dist) / fmax(fmin(dist, target_dist), 1e-9);
+    distance_blend = log(visual_ratio) / log(10000.0);
     if (distance_blend > 1.0) distance_blend = 1.0;
     if (distance_blend < 0.0) distance_blend = 0.0;
-    s_orbit_transition_duration = duration
-                                * (1.0 + small_body_blend * 0.85)
-                                * (1.0 + distance_blend * 1.65);
+    s_orbit_transition_duration = duration * (1.0 + distance_blend * 3.25);
     s_orbit_zoom_smoothing = 0;
+    s_look_transition_t = 0.0;
+    s_look_transition_duration = duration < 1.0 ? 0.55 : 0.75;
 }
 
-static void look_at_target(int idx)
+static void desired_look_angles(int idx, double *yaw, double *pitch)
 {
     double tx, ty, tz, dx, dy, dz, len;
     if (idx < 0 || idx >= g_nbodies) return;
@@ -167,8 +178,40 @@ static void look_at_target(int idx)
     dx /= len;
     dy /= len;
     dz /= len;
-    g_cam.yaw = (float)(atan2(dz, dx) * 180.0 / PI);
-    g_cam.pitch = (float)(asin(dy) * 180.0 / PI);
+    *yaw = atan2(dz, dx) * 180.0 / PI;
+    *pitch = asin(dy) * 180.0 / PI;
+}
+
+static void smooth_look_at_target(int idx, float dt)
+{
+    double yaw = g_cam.yaw;
+    double pitch = g_cam.pitch;
+    double dyaw, dpitch, follow;
+
+    desired_look_angles(idx, &yaw, &pitch);
+    dyaw = yaw - (double)g_cam.yaw;
+    while (dyaw > 180.0) dyaw -= 360.0;
+    while (dyaw < -180.0) dyaw += 360.0;
+    dpitch = pitch - (double)g_cam.pitch;
+
+    if (s_look_transition_t >= 1.0) {
+        g_cam.yaw += (float)dyaw;
+        g_cam.pitch = (float)pitch;
+        if (g_cam.pitch > 89.0f) g_cam.pitch = 89.0f;
+        if (g_cam.pitch < -89.0f) g_cam.pitch = -89.0f;
+        return;
+    }
+
+    s_look_transition_t += (double)dt / fmax(s_look_transition_duration, 0.001);
+    if (s_look_transition_t > 1.0) s_look_transition_t = 1.0;
+    follow = 1.0 - exp(-(double)dt * (3.0 + 10.0 * smootherstep(s_look_transition_t)));
+    if (follow < 0.0) follow = 0.0;
+    if (follow > 1.0) follow = 1.0;
+
+    g_cam.yaw += (float)(dyaw * follow);
+    g_cam.pitch += (float)(dpitch * follow);
+    if (g_cam.pitch > 89.0f) g_cam.pitch = 89.0f;
+    if (g_cam.pitch < -89.0f) g_cam.pitch = -89.0f;
 }
 
 static float projected_radius_px(int idx, const float cam_fwd[3], float radius_au)
@@ -200,6 +243,8 @@ void inspect_init(void)
     s_orbit_transition_t = 1.0;
     s_orbit_transition_duration = 1.45;
     s_orbit_zoom_smoothing = 0;
+    s_look_transition_t = 1.0;
+    s_look_transition_duration = 0.75;
     s_orbit_dir[0] = 0.0;
     s_orbit_dir[1] = 0.0;
     s_orbit_dir[2] = 1.0;
@@ -291,8 +336,12 @@ int inspect_begin_orbit(void)
 
     set_orbit_target_from_camera(idx, 1.45);
     g_inspect_orbit_mode = 1;
-    look_at_target(idx);
     return 1;
+}
+
+static int inspect_centering_active(void)
+{
+    return s_orbit_transition_t < 1.0 || s_look_transition_t < 1.0;
 }
 
 void inspect_orbit_mouse(int dx, int dy, float sens_deg_per_px)
@@ -301,6 +350,7 @@ void inspect_orbit_mouse(int dx, int dy, float sens_deg_per_px)
     double axis[3], view_fwd[3], world_up[3] = {0.0, 1.0, 0.0};
     double cam_right[3], len;
     if (!g_inspect_orbit_mode) return;
+    if (inspect_centering_active()) return;
 
     world_orbit_axis(axis);
     rotate_vec_axis(s_orbit_dir, axis, -(double)dx * s);
@@ -328,6 +378,7 @@ void inspect_orbit_mouse(int dx, int dy, float sens_deg_per_px)
 void inspect_orbit_zoom(int wheel_y)
 {
     if (!g_inspect_orbit_mode || wheel_y == 0) return;
+    if (inspect_centering_active()) return;
     s_orbit_distance *= (wheel_y > 0) ? (1.0 / 1.18) : 1.18;
     if (s_orbit_distance < s_orbit_min_distance)
         s_orbit_distance = s_orbit_min_distance;
@@ -367,8 +418,8 @@ void inspect_orbit_update(float dt)
         s_orbit_transition_t += (double)dt / fmax(s_orbit_transition_duration, 0.001);
         if (s_orbit_transition_t > 1.0) s_orbit_transition_t = 1.0;
         u = smootherstep(s_orbit_transition_t);
-        s_orbit_current_distance = s_orbit_start_distance
-                                 + (s_orbit_distance - s_orbit_start_distance) * u;
+        s_orbit_current_distance = visual_distance_lerp(s_orbit_start_distance,
+                                                        s_orbit_distance, u);
     } else {
         s_orbit_current_distance = s_orbit_distance;
     }
@@ -376,30 +427,21 @@ void inspect_orbit_update(float dt)
     g_cam.pos[0] = center[0] + s_orbit_current_distance * s_orbit_dir[0];
     g_cam.pos[1] = center[1] + s_orbit_current_distance * s_orbit_dir[1];
     g_cam.pos[2] = center[2] + s_orbit_current_distance * s_orbit_dir[2];
-    look_at_target(idx);
+    smooth_look_at_target(idx, dt);
 }
 
-int inspect_ring_screen(const float vp_camrel[16], const BodyRenderInfo *info,
-                        float *sx, float *sy, float *radius_px, float *alpha)
+int inspect_ring_params(const BodyRenderInfo *info,
+                        float rel[3], float *dr, float *alpha)
 {
     int idx;
-    float rx, ry, rz, px, py, fdx, fdy, fdz, body_px;
     if (!g_inspect_mode || !info) return 0;
     idx = g_inspect_orbit_mode ? g_inspect_target : g_inspect_hovered;
     if (idx < 0 || idx >= g_nbodies || !g_bodies[idx].alive) return 0;
 
-    rx = (float)(g_bodies[idx].pos[0] * RS - g_cam.pos[0]);
-    ry = (float)(g_bodies[idx].pos[1] * RS - g_cam.pos[1]);
-    rz = (float)(g_bodies[idx].pos[2] * RS - g_cam.pos[2]);
-    if (!mat4_project(vp_camrel, rx, ry, rz, WIN_W, WIN_H, &px, &py)) return 0;
-
-    cam_get_dir(&fdx, &fdy, &fdz);
-    body_px = projected_radius_px(idx, (float[3]){fdx, fdy, fdz}, info[idx].dr);
-    *sx = px;
-    *sy = (float)WIN_H - py;
-    *radius_px = body_px * 1.12f + 2.0f;
-    if (*radius_px < 6.0f) *radius_px = 6.0f;
-    if (*radius_px > 1800.0f) *radius_px = 1800.0f;
+    rel[0] = (float)(g_bodies[idx].pos[0] * RS - g_cam.pos[0]);
+    rel[1] = (float)(g_bodies[idx].pos[1] * RS - g_cam.pos[1]);
+    rel[2] = (float)(g_bodies[idx].pos[2] * RS - g_cam.pos[2]);
+    *dr    = info[idx].dr;
     *alpha = g_inspect_orbit_mode ? 0.92f : 0.78f;
     return 1;
 }

--- a/src/inspect.c
+++ b/src/inspect.c
@@ -1,0 +1,405 @@
+/*
+ * inspect.c - target picking and orbit camera for inspect mode
+ */
+#include "inspect.h"
+#include "body.h"
+#include "camera.h"
+#include "physics.h"
+#include "math3d.h"
+#include "collision.h"
+#include <float.h>
+
+int g_inspect_mode = 0;
+int g_inspect_orbit_mode = 0;
+int g_inspect_hovered = -1;
+int g_inspect_target = -1;
+
+static int s_prev_paused = 0;
+static double s_orbit_distance = 0.01;
+static double s_orbit_current_distance = 0.01;
+static double s_orbit_start_distance = 0.01;
+static double s_orbit_min_distance = 0.01;
+static double s_orbit_max_distance = 0.1;
+static double s_orbit_transition_t = 1.0;
+static double s_orbit_transition_duration = 1.45;
+static int s_orbit_zoom_smoothing = 0;
+static double s_orbit_dir[3] = {0.0, 0.0, 1.0};
+
+#define INSPECT_MAX_PICK_AU 100.0
+
+static void world_orbit_axis(double axis[3])
+{
+    axis[0] = 0.0;
+    axis[1] = 1.0;
+    axis[2] = 0.0;
+}
+
+static void normalize3(double v[3])
+{
+    double len = sqrt(v[0]*v[0] + v[1]*v[1] + v[2]*v[2]);
+    if (len <= 1e-12) return;
+    v[0] /= len;
+    v[1] /= len;
+    v[2] /= len;
+}
+
+static void rotate_vec_axis(double v[3], const double axis[3], double angle)
+{
+    double c = cos(angle);
+    double s = sin(angle);
+    double dot = v[0]*axis[0] + v[1]*axis[1] + v[2]*axis[2];
+    double cross[3] = {
+        axis[1]*v[2] - axis[2]*v[1],
+        axis[2]*v[0] - axis[0]*v[2],
+        axis[0]*v[1] - axis[1]*v[0]
+    };
+    double out[3] = {
+        v[0]*c + cross[0]*s + axis[0]*dot*(1.0 - c),
+        v[1]*c + cross[1]*s + axis[1]*dot*(1.0 - c),
+        v[2]*c + cross[2]*s + axis[2]*dot*(1.0 - c)
+    };
+    v[0] = out[0];
+    v[1] = out[1];
+    v[2] = out[2];
+    normalize3(v);
+}
+
+static void clamp_orbit_pole(const double axis[3])
+{
+    const double limit = 0.985;
+    double dot = s_orbit_dir[0]*axis[0] + s_orbit_dir[1]*axis[1] + s_orbit_dir[2]*axis[2];
+    double side[3], side_len, side_scale, sign;
+    if (dot <= limit && dot >= -limit) return;
+    sign = dot < 0.0 ? -1.0 : 1.0;
+    side[0] = s_orbit_dir[0] - axis[0] * dot;
+    side[1] = s_orbit_dir[1] - axis[1] * dot;
+    side[2] = s_orbit_dir[2] - axis[2] * dot;
+    side_len = sqrt(side[0]*side[0] + side[1]*side[1] + side[2]*side[2]);
+    if (side_len < 1e-9) {
+        side[0] = 1.0;
+        side[1] = 0.0;
+        side[2] = 0.0;
+        side_len = 1.0;
+    }
+    side[0] /= side_len; side[1] /= side_len; side[2] /= side_len;
+    side_scale = sqrt(1.0 - limit * limit);
+    s_orbit_dir[0] = axis[0] * limit * sign + side[0] * side_scale;
+    s_orbit_dir[1] = axis[1] * limit * sign + side[1] * side_scale;
+    s_orbit_dir[2] = axis[2] * limit * sign + side[2] * side_scale;
+    normalize3(s_orbit_dir);
+}
+
+static double smootherstep(double t)
+{
+    if (t < 0.0) t = 0.0;
+    if (t > 1.0) t = 1.0;
+    return t * t * t * (t * (t * 6.0 - 15.0) + 10.0);
+}
+
+static void set_orbit_target_from_camera(int idx, double duration)
+{
+    double center[3], rel[3], dist, radius_au, target_dist, axis[3];
+    double small_body_blend;
+    double travel_ratio;
+    double distance_blend;
+    center[0] = g_bodies[idx].pos[0] * RS;
+    center[1] = g_bodies[idx].pos[1] * RS;
+    center[2] = g_bodies[idx].pos[2] * RS;
+    rel[0] = g_cam.pos[0] - center[0];
+    rel[1] = g_cam.pos[1] - center[1];
+    rel[2] = g_cam.pos[2] - center[2];
+    dist = sqrt(rel[0]*rel[0] + rel[1]*rel[1] + rel[2]*rel[2]);
+    if (dist < 1e-12) dist = 1e-12;
+
+    radius_au = collision_visual_radius(idx, g_bodies[idx].radius) * RS;
+    target_dist = radius_au * 7.0;
+    if (target_dist < 0.000015) target_dist = 0.000015;
+    g_cam.speed = (float)(2.5 * pow(radius_au, 0.835));
+    if (g_cam.speed < 0.00003f) g_cam.speed = 0.00003f;
+    if (g_cam.speed > 0.08f) g_cam.speed = 0.08f;
+
+    s_orbit_min_distance = radius_au * 2.4;
+    s_orbit_max_distance = radius_au * 55.0;
+    if (s_orbit_min_distance < 0.000006) s_orbit_min_distance = 0.000006;
+    if (s_orbit_max_distance < s_orbit_min_distance * 4.0)
+        s_orbit_max_distance = s_orbit_min_distance * 4.0;
+    if (target_dist < s_orbit_min_distance) target_dist = s_orbit_min_distance;
+    if (target_dist > s_orbit_max_distance) target_dist = s_orbit_max_distance;
+
+    s_orbit_dir[0] = rel[0] / dist;
+    s_orbit_dir[1] = rel[1] / dist;
+    s_orbit_dir[2] = rel[2] / dist;
+    normalize3(s_orbit_dir);
+    g_inspect_target = idx;
+    world_orbit_axis(axis);
+    clamp_orbit_pole(axis);
+    s_orbit_current_distance = dist;
+    s_orbit_start_distance = dist;
+    s_orbit_distance = target_dist;
+    s_orbit_transition_t = 0.0;
+    small_body_blend = 0.00014 / fmax(target_dist, 1e-9);
+    if (small_body_blend > 1.0) small_body_blend = 1.0;
+    if (small_body_blend < 0.0) small_body_blend = 0.0;
+    travel_ratio = fabs(dist - target_dist) / fmax(target_dist, 1e-9);
+    distance_blend = log(1.0 + travel_ratio) / log(1.0 + 5000.0);
+    if (distance_blend > 1.0) distance_blend = 1.0;
+    if (distance_blend < 0.0) distance_blend = 0.0;
+    s_orbit_transition_duration = duration
+                                * (1.0 + small_body_blend * 0.85)
+                                * (1.0 + distance_blend * 1.65);
+    s_orbit_zoom_smoothing = 0;
+}
+
+static void look_at_target(int idx)
+{
+    double tx, ty, tz, dx, dy, dz, len;
+    if (idx < 0 || idx >= g_nbodies) return;
+
+    tx = g_bodies[idx].pos[0] * RS;
+    ty = g_bodies[idx].pos[1] * RS;
+    tz = g_bodies[idx].pos[2] * RS;
+    dx = tx - g_cam.pos[0];
+    dy = ty - g_cam.pos[1];
+    dz = tz - g_cam.pos[2];
+    len = sqrt(dx*dx + dy*dy + dz*dz);
+    if (len <= 1e-12) return;
+
+    dx /= len;
+    dy /= len;
+    dz /= len;
+    g_cam.yaw = (float)(atan2(dz, dx) * 180.0 / PI);
+    g_cam.pitch = (float)(asin(dy) * 180.0 / PI);
+}
+
+static float projected_radius_px(int idx, const float cam_fwd[3], float radius_au)
+{
+    double rx, ry, rz;
+    float eye_z;
+    if (idx < 0 || idx >= g_nbodies) return 0.0f;
+    rx = g_bodies[idx].pos[0] * RS - g_cam.pos[0];
+    ry = g_bodies[idx].pos[1] * RS - g_cam.pos[1];
+    rz = g_bodies[idx].pos[2] * RS - g_cam.pos[2];
+    eye_z = (float)(rx*cam_fwd[0] + ry*cam_fwd[1] + rz*cam_fwd[2]);
+    if (eye_z <= 0.0f) return 0.0f;
+    return (WIN_H * 0.5f) * radius_au
+         / (eye_z * tanf(FOV * 0.5f * (float)(PI / 180.0)) + 1e-9f);
+}
+
+void inspect_init(void)
+{
+    g_inspect_mode = 0;
+    g_inspect_orbit_mode = 0;
+    g_inspect_hovered = -1;
+    g_inspect_target = -1;
+    s_prev_paused = 0;
+    s_orbit_distance = 0.01;
+    s_orbit_current_distance = 0.01;
+    s_orbit_start_distance = 0.01;
+    s_orbit_min_distance = 0.01;
+    s_orbit_max_distance = 0.1;
+    s_orbit_transition_t = 1.0;
+    s_orbit_transition_duration = 1.45;
+    s_orbit_zoom_smoothing = 0;
+    s_orbit_dir[0] = 0.0;
+    s_orbit_dir[1] = 0.0;
+    s_orbit_dir[2] = 1.0;
+}
+
+void inspect_cancel(void)
+{
+    if (g_inspect_mode)
+        g_paused = s_prev_paused;
+    g_inspect_mode = 0;
+    g_inspect_orbit_mode = 0;
+    g_inspect_hovered = -1;
+    g_inspect_target = -1;
+}
+
+void inspect_exit_orbit(void)
+{
+    g_inspect_orbit_mode = 0;
+    g_inspect_target = -1;
+}
+
+void inspect_toggle(void)
+{
+    if (g_inspect_mode) {
+        inspect_cancel();
+        return;
+    }
+    s_prev_paused = g_paused;
+    g_paused = 1;
+    g_inspect_mode = 1;
+    g_inspect_orbit_mode = 0;
+    g_inspect_hovered = -1;
+    g_inspect_target = -1;
+}
+
+void inspect_pick_center(const float vp_camrel[16], const BodyRenderInfo *info)
+{
+    float fdx, fdy, fdz;
+    float center_x, center_y;
+    float best_score = FLT_MAX;
+    int best_idx = -1;
+
+    if (!g_inspect_mode || g_inspect_orbit_mode || !info) {
+        if (!g_inspect_orbit_mode) g_inspect_hovered = -1;
+        return;
+    }
+
+    cam_get_dir(&fdx, &fdy, &fdz);
+    center_x = (float)WIN_W * 0.5f;
+    center_y = (float)WIN_H * 0.5f;
+
+    for (int i = 0; i < g_nbodies; i++) {
+        float rx, ry, rz, sx, sy, sy_top, dx, dy, screen_d, body_px, tol, score;
+        if (!g_bodies[i].alive) continue;
+        if (info[i].dcam > INSPECT_MAX_PICK_AU) continue;
+
+        rx = (float)(g_bodies[i].pos[0] * RS - g_cam.pos[0]);
+        ry = (float)(g_bodies[i].pos[1] * RS - g_cam.pos[1]);
+        rz = (float)(g_bodies[i].pos[2] * RS - g_cam.pos[2]);
+        if (!mat4_project(vp_camrel, rx, ry, rz, WIN_W, WIN_H, &sx, &sy))
+            continue;
+
+        sy_top = (float)WIN_H - sy;
+        dx = sx - center_x;
+        dy = sy_top - center_y;
+        screen_d = sqrtf(dx*dx + dy*dy);
+        body_px = projected_radius_px(i, (float[3]){fdx, fdy, fdz}, info[i].dr);
+        tol = body_px * 1.35f + 56.0f;
+        if (tol < 72.0f) tol = 72.0f;
+        if (tol > 190.0f) tol = 190.0f;
+        if (screen_d > tol) continue;
+
+        score = screen_d / tol + info[i].dcam * 0.000001f;
+        if (score < best_score) {
+            best_score = score;
+            best_idx = i;
+        }
+    }
+
+    g_inspect_hovered = best_idx;
+}
+
+int inspect_begin_orbit(void)
+{
+    int idx = g_inspect_hovered;
+
+    if (!g_inspect_mode || idx < 0 || idx >= g_nbodies || !g_bodies[idx].alive)
+        return 0;
+
+    set_orbit_target_from_camera(idx, 1.45);
+    g_inspect_orbit_mode = 1;
+    look_at_target(idx);
+    return 1;
+}
+
+void inspect_orbit_mouse(int dx, int dy, float sens_deg_per_px)
+{
+    double s = (double)sens_deg_per_px * PI / 180.0;
+    double axis[3], view_fwd[3], world_up[3] = {0.0, 1.0, 0.0};
+    double cam_right[3], len;
+    if (!g_inspect_orbit_mode) return;
+
+    world_orbit_axis(axis);
+    rotate_vec_axis(s_orbit_dir, axis, -(double)dx * s);
+
+    view_fwd[0] = -s_orbit_dir[0];
+    view_fwd[1] = -s_orbit_dir[1];
+    view_fwd[2] = -s_orbit_dir[2];
+    cam_right[0] = view_fwd[1]*world_up[2] - view_fwd[2]*world_up[1];
+    cam_right[1] = view_fwd[2]*world_up[0] - view_fwd[0]*world_up[2];
+    cam_right[2] = view_fwd[0]*world_up[1] - view_fwd[1]*world_up[0];
+    len = sqrt(cam_right[0]*cam_right[0] + cam_right[1]*cam_right[1] + cam_right[2]*cam_right[2]);
+    if (len < 1e-9) {
+        cam_right[0] = 1.0;
+        cam_right[1] = 0.0;
+        cam_right[2] = 0.0;
+    } else {
+        cam_right[0] /= len;
+        cam_right[1] /= len;
+        cam_right[2] /= len;
+    }
+    rotate_vec_axis(s_orbit_dir, cam_right, -(double)dy * s);
+    clamp_orbit_pole(axis);
+}
+
+void inspect_orbit_zoom(int wheel_y)
+{
+    if (!g_inspect_orbit_mode || wheel_y == 0) return;
+    s_orbit_distance *= (wheel_y > 0) ? (1.0 / 1.18) : 1.18;
+    if (s_orbit_distance < s_orbit_min_distance)
+        s_orbit_distance = s_orbit_min_distance;
+    if (s_orbit_distance > s_orbit_max_distance)
+        s_orbit_distance = s_orbit_max_distance;
+    s_orbit_zoom_smoothing = 1;
+    s_orbit_transition_t = 1.0;
+}
+
+void inspect_orbit_update(float dt)
+{
+    int idx = g_inspect_target;
+    double center[3], u;
+    if (!g_inspect_orbit_mode || idx < 0 || idx >= g_nbodies || !g_bodies[idx].alive) {
+        int survivor = collision_body_absorbed_by(idx);
+        if (survivor >= 0 && survivor < g_nbodies && g_bodies[survivor].alive) {
+            set_orbit_target_from_camera(survivor, 0.95);
+            idx = survivor;
+        } else {
+            g_inspect_orbit_mode = 0;
+            g_inspect_target = -1;
+            return;
+        }
+    }
+
+    center[0] = g_bodies[idx].pos[0] * RS;
+    center[1] = g_bodies[idx].pos[1] * RS;
+    center[2] = g_bodies[idx].pos[2] * RS;
+    if (s_orbit_zoom_smoothing) {
+        double follow = 1.0 - exp(-(double)dt * 14.0);
+        if (follow < 0.0) follow = 0.0;
+        if (follow > 1.0) follow = 1.0;
+        s_orbit_current_distance += (s_orbit_distance - s_orbit_current_distance) * follow;
+        if (fabs(s_orbit_current_distance - s_orbit_distance) < s_orbit_distance * 0.0005)
+            s_orbit_zoom_smoothing = 0;
+    } else if (s_orbit_transition_t < 1.0) {
+        s_orbit_transition_t += (double)dt / fmax(s_orbit_transition_duration, 0.001);
+        if (s_orbit_transition_t > 1.0) s_orbit_transition_t = 1.0;
+        u = smootherstep(s_orbit_transition_t);
+        s_orbit_current_distance = s_orbit_start_distance
+                                 + (s_orbit_distance - s_orbit_start_distance) * u;
+    } else {
+        s_orbit_current_distance = s_orbit_distance;
+    }
+
+    g_cam.pos[0] = center[0] + s_orbit_current_distance * s_orbit_dir[0];
+    g_cam.pos[1] = center[1] + s_orbit_current_distance * s_orbit_dir[1];
+    g_cam.pos[2] = center[2] + s_orbit_current_distance * s_orbit_dir[2];
+    look_at_target(idx);
+}
+
+int inspect_ring_screen(const float vp_camrel[16], const BodyRenderInfo *info,
+                        float *sx, float *sy, float *radius_px, float *alpha)
+{
+    int idx;
+    float rx, ry, rz, px, py, fdx, fdy, fdz, body_px;
+    if (!g_inspect_mode || !info) return 0;
+    idx = g_inspect_orbit_mode ? g_inspect_target : g_inspect_hovered;
+    if (idx < 0 || idx >= g_nbodies || !g_bodies[idx].alive) return 0;
+
+    rx = (float)(g_bodies[idx].pos[0] * RS - g_cam.pos[0]);
+    ry = (float)(g_bodies[idx].pos[1] * RS - g_cam.pos[1]);
+    rz = (float)(g_bodies[idx].pos[2] * RS - g_cam.pos[2]);
+    if (!mat4_project(vp_camrel, rx, ry, rz, WIN_W, WIN_H, &px, &py)) return 0;
+
+    cam_get_dir(&fdx, &fdy, &fdz);
+    body_px = projected_radius_px(idx, (float[3]){fdx, fdy, fdz}, info[idx].dr);
+    *sx = px;
+    *sy = (float)WIN_H - py;
+    *radius_px = body_px * 1.12f + 2.0f;
+    if (*radius_px < 6.0f) *radius_px = 6.0f;
+    if (*radius_px > 1800.0f) *radius_px = 1800.0f;
+    *alpha = g_inspect_orbit_mode ? 0.92f : 0.78f;
+    return 1;
+}

--- a/src/inspect.c
+++ b/src/inspect.c
@@ -1,5 +1,11 @@
 /*
  * inspect.c - target picking and orbit camera for inspect mode
+ *
+ * Sections (search "§"):
+ *   § STATE  — statics, constants
+ *   § MATH   — geometry helpers (double-precision, orbit-specific)
+ *   § CAMERA — look-at animation, orbit distance lerp
+ *   § API    — public interface
  */
 #include "inspect.h"
 #include "body.h"
@@ -9,26 +15,31 @@
 #include "collision.h"
 #include <float.h>
 
+/* ── § STATE ─────────────────────────────────────────────────────────────── */
+
 int g_inspect_mode = 0;
 int g_inspect_orbit_mode = 0;
 int g_inspect_hovered = -1;
 int g_inspect_target = -1;
 
-static int s_prev_paused = 0;
-static double s_orbit_distance = 0.01;
+static int    s_prev_paused = 0;
+static double s_orbit_distance         = 0.01;
 static double s_orbit_current_distance = 0.01;
-static double s_orbit_start_distance = 0.01;
-static double s_orbit_min_distance = 0.01;
-static double s_orbit_max_distance = 0.1;
-static double s_orbit_transition_t = 1.0;
+static double s_orbit_start_distance   = 0.01;
+static double s_orbit_min_distance     = 0.01;
+static double s_orbit_max_distance     = 0.1;
+static double s_orbit_transition_t        = 1.0; /* ≥1 = idle (no fly-in) */
 static double s_orbit_transition_duration = 1.45;
-static int s_orbit_zoom_smoothing = 0;
-static double s_orbit_dir[3] = {0.0, 0.0, 1.0};
-static double s_look_transition_t = 1.0;
+static int    s_orbit_zoom_smoothing = 0;
+static double s_orbit_dir[3] = {0.0, 0.0, 1.0}; /* camera offset direction, unit */
+static double s_look_transition_t        = 1.0;  /* ≥1 = locked on target */
 static double s_look_transition_duration = 0.75;
 
 #define INSPECT_MAX_PICK_AU 100.0
 
+/* ── § MATH ──────────────────────────────────────────────────────────────── */
+
+/* Orbit pole constraint axis — world Y-up; not the body's orbital plane. */
 static void world_orbit_axis(double axis[3])
 {
     axis[0] = 0.0;
@@ -45,6 +56,7 @@ static void normalize3(double v[3])
     v[2] /= len;
 }
 
+/* Rodrigues rotation; renormalizes to prevent float drift. */
 static void rotate_vec_axis(double v[3], const double axis[3], double angle)
 {
     double c = cos(angle);
@@ -66,6 +78,7 @@ static void rotate_vec_axis(double v[3], const double axis[3], double angle)
     normalize3(v);
 }
 
+/* Clamp s_orbit_dir away from the poles of axis: keeps |dot| ≤ 0.985 (~10°). */
 static void clamp_orbit_pole(const double axis[3])
 {
     const double limit = 0.985;
@@ -91,6 +104,9 @@ static void clamp_orbit_pole(const double axis[3])
     normalize3(s_orbit_dir);
 }
 
+/* ── § CAMERA ────────────────────────────────────────────────────────────── */
+
+/* pow(t,1.45) bias front-loads the motion so the initial snap feels snappy. */
 static double smootherstep(double t)
 {
     if (t < 0.0) t = 0.0;
@@ -99,6 +115,7 @@ static double smootherstep(double t)
     return t * t * t * (t * (t * 6.0 - 15.0) + 10.0);
 }
 
+/* Log-space lerp: equal perceptual speed across orders-of-magnitude distances. */
 static double visual_distance_lerp(double start, double target, double t)
 {
     double log_start, log_target, log_dist;
@@ -114,8 +131,8 @@ static double visual_distance_lerp(double start, double target, double t)
 static void set_orbit_target_from_camera(int idx, double duration)
 {
     double center[3], rel[3], dist, radius_au, target_dist, axis[3];
-    double visual_ratio;
-    double distance_blend;
+    double visual_ratio, distance_blend;
+
     center[0] = g_bodies[idx].pos[0] * RS;
     center[1] = g_bodies[idx].pos[1] * RS;
     center[2] = g_bodies[idx].pos[2] * RS;
@@ -125,12 +142,12 @@ static void set_orbit_target_from_camera(int idx, double duration)
     dist = sqrt(rel[0]*rel[0] + rel[1]*rel[1] + rel[2]*rel[2]);
     if (dist < 1e-12) dist = 1e-12;
 
-    radius_au = collision_visual_radius(idx, g_bodies[idx].radius) * RS;
+    radius_au   = collision_visual_radius(idx, g_bodies[idx].radius) * RS;
     target_dist = radius_au * 7.0;
     if (target_dist < 0.000015) target_dist = 0.000015;
     g_cam.speed = (float)(2.5 * pow(radius_au, 0.835));
     if (g_cam.speed < 0.00003f) g_cam.speed = 0.00003f;
-    if (g_cam.speed > 0.08f) g_cam.speed = 0.08f;
+    if (g_cam.speed > 0.08f)    g_cam.speed = 0.08f;
 
     s_orbit_min_distance = radius_au * 2.4;
     s_orbit_max_distance = radius_au * 55.0;
@@ -140,25 +157,29 @@ static void set_orbit_target_from_camera(int idx, double duration)
     if (target_dist < s_orbit_min_distance) target_dist = s_orbit_min_distance;
     if (target_dist > s_orbit_max_distance) target_dist = s_orbit_max_distance;
 
+    /* rel/dist is already a unit vector — no further normalize needed. */
     s_orbit_dir[0] = rel[0] / dist;
     s_orbit_dir[1] = rel[1] / dist;
     s_orbit_dir[2] = rel[2] / dist;
-    normalize3(s_orbit_dir);
     g_inspect_target = idx;
     world_orbit_axis(axis);
     clamp_orbit_pole(axis);
+
     s_orbit_current_distance = dist;
-    s_orbit_start_distance = dist;
-    s_orbit_distance = target_dist;
-    s_orbit_transition_t = 0.0;
-    visual_ratio = fmax(dist, target_dist) / fmax(fmin(dist, target_dist), 1e-9);
-    distance_blend = log(visual_ratio) / log(10000.0);
+    s_orbit_start_distance   = dist;
+    s_orbit_distance         = target_dist;
+    s_orbit_transition_t     = 0.0;
+
+    /* Scale animation duration by log10 of the distance ratio so a 10000×
+     * distance change gets ~4× longer than a same-scale transition. */
+    visual_ratio     = fmax(dist, target_dist) / fmax(fmin(dist, target_dist), 1e-9);
+    distance_blend   = log(visual_ratio) / log(10000.0);
     if (distance_blend > 1.0) distance_blend = 1.0;
     if (distance_blend < 0.0) distance_blend = 0.0;
     s_orbit_transition_duration = duration * (1.0 + distance_blend * 3.25);
-    s_orbit_zoom_smoothing = 0;
-    s_look_transition_t = 0.0;
-    s_look_transition_duration = duration < 1.0 ? 0.55 : 0.75;
+    s_orbit_zoom_smoothing      = 0;
+    s_look_transition_t         = 0.0;
+    s_look_transition_duration  = duration < 1.0 ? 0.55 : 0.75;
 }
 
 static void desired_look_angles(int idx, double *yaw, double *pitch)
@@ -178,8 +199,8 @@ static void desired_look_angles(int idx, double *yaw, double *pitch)
     dx /= len;
     dy /= len;
     dz /= len;
-    *yaw = atan2(dz, dx) * 180.0 / PI;
-    *pitch = asin(dy) * 180.0 / PI;
+    *yaw   = atan2(dz, dx) * 180.0 / PI;
+    *pitch = asin(dy)      * 180.0 / PI;
 }
 
 static void smooth_look_at_target(int idx, float dt)
@@ -190,14 +211,15 @@ static void smooth_look_at_target(int idx, float dt)
 
     desired_look_angles(idx, &yaw, &pitch);
     dyaw = yaw - (double)g_cam.yaw;
-    while (dyaw > 180.0) dyaw -= 360.0;
+    while (dyaw >  180.0) dyaw -= 360.0;
     while (dyaw < -180.0) dyaw += 360.0;
     dpitch = pitch - (double)g_cam.pitch;
 
     if (s_look_transition_t >= 1.0) {
+        /* Transition done: snap-track so the target stays centered. */
         g_cam.yaw += (float)dyaw;
         g_cam.pitch = (float)pitch;
-        if (g_cam.pitch > 89.0f) g_cam.pitch = 89.0f;
+        if (g_cam.pitch >  89.0f) g_cam.pitch =  89.0f;
         if (g_cam.pitch < -89.0f) g_cam.pitch = -89.0f;
         return;
     }
@@ -208,42 +230,30 @@ static void smooth_look_at_target(int idx, float dt)
     if (follow < 0.0) follow = 0.0;
     if (follow > 1.0) follow = 1.0;
 
-    g_cam.yaw += (float)(dyaw * follow);
+    g_cam.yaw   += (float)(dyaw   * follow);
     g_cam.pitch += (float)(dpitch * follow);
-    if (g_cam.pitch > 89.0f) g_cam.pitch = 89.0f;
+    if (g_cam.pitch >  89.0f) g_cam.pitch =  89.0f;
     if (g_cam.pitch < -89.0f) g_cam.pitch = -89.0f;
 }
 
-static float projected_radius_px(int idx, const float cam_fwd[3], float radius_au)
-{
-    double rx, ry, rz;
-    float eye_z;
-    if (idx < 0 || idx >= g_nbodies) return 0.0f;
-    rx = g_bodies[idx].pos[0] * RS - g_cam.pos[0];
-    ry = g_bodies[idx].pos[1] * RS - g_cam.pos[1];
-    rz = g_bodies[idx].pos[2] * RS - g_cam.pos[2];
-    eye_z = (float)(rx*cam_fwd[0] + ry*cam_fwd[1] + rz*cam_fwd[2]);
-    if (eye_z <= 0.0f) return 0.0f;
-    return (WIN_H * 0.5f) * radius_au
-         / (eye_z * tanf(FOV * 0.5f * (float)(PI / 180.0)) + 1e-9f);
-}
+/* ── § API ───────────────────────────────────────────────────────────────── */
 
 void inspect_init(void)
 {
-    g_inspect_mode = 0;
+    g_inspect_mode       = 0;
     g_inspect_orbit_mode = 0;
-    g_inspect_hovered = -1;
-    g_inspect_target = -1;
-    s_prev_paused = 0;
-    s_orbit_distance = 0.01;
-    s_orbit_current_distance = 0.01;
-    s_orbit_start_distance = 0.01;
-    s_orbit_min_distance = 0.01;
-    s_orbit_max_distance = 0.1;
-    s_orbit_transition_t = 1.0;
-    s_orbit_transition_duration = 1.45;
-    s_orbit_zoom_smoothing = 0;
-    s_look_transition_t = 1.0;
+    g_inspect_hovered    = -1;
+    g_inspect_target     = -1;
+    s_prev_paused              = 0;
+    s_orbit_distance           = 0.01;
+    s_orbit_current_distance   = 0.01;
+    s_orbit_start_distance     = 0.01;
+    s_orbit_min_distance       = 0.01;
+    s_orbit_max_distance       = 0.1;
+    s_orbit_transition_t       = 1.0;
+    s_orbit_transition_duration= 1.45;
+    s_orbit_zoom_smoothing     = 0;
+    s_look_transition_t        = 1.0;
     s_look_transition_duration = 0.75;
     s_orbit_dir[0] = 0.0;
     s_orbit_dir[1] = 0.0;
@@ -254,16 +264,16 @@ void inspect_cancel(void)
 {
     if (g_inspect_mode)
         g_paused = s_prev_paused;
-    g_inspect_mode = 0;
+    g_inspect_mode       = 0;
     g_inspect_orbit_mode = 0;
-    g_inspect_hovered = -1;
-    g_inspect_target = -1;
+    g_inspect_hovered    = -1;
+    g_inspect_target     = -1;
 }
 
 void inspect_exit_orbit(void)
 {
     g_inspect_orbit_mode = 0;
-    g_inspect_target = -1;
+    g_inspect_target     = -1;
 }
 
 void inspect_toggle(void)
@@ -272,17 +282,16 @@ void inspect_toggle(void)
         inspect_cancel();
         return;
     }
-    s_prev_paused = g_paused;
-    g_paused = 1;
-    g_inspect_mode = 1;
+    s_prev_paused        = g_paused;
+    g_paused             = 1;
+    g_inspect_mode       = 1;
     g_inspect_orbit_mode = 0;
-    g_inspect_hovered = -1;
-    g_inspect_target = -1;
+    g_inspect_hovered    = -1;
+    g_inspect_target     = -1;
 }
 
 void inspect_pick_center(const float vp_camrel[16], const BodyRenderInfo *info)
 {
-    float fdx, fdy, fdz;
     float center_x, center_y;
     float best_score = FLT_MAX;
     int best_idx = -1;
@@ -292,7 +301,6 @@ void inspect_pick_center(const float vp_camrel[16], const BodyRenderInfo *info)
         return;
     }
 
-    cam_get_dir(&fdx, &fdy, &fdz);
     center_x = (float)WIN_W * 0.5f;
     center_y = (float)WIN_H * 0.5f;
 
@@ -307,20 +315,22 @@ void inspect_pick_center(const float vp_camrel[16], const BodyRenderInfo *info)
         if (!mat4_project(vp_camrel, rx, ry, rz, WIN_W, WIN_H, &sx, &sy))
             continue;
 
-        sy_top = (float)WIN_H - sy;
-        dx = sx - center_x;
-        dy = sy_top - center_y;
+        sy_top   = (float)WIN_H - sy;
+        dx       = sx - center_x;
+        dy       = sy_top - center_y;
         screen_d = sqrtf(dx*dx + dy*dy);
-        body_px = projected_radius_px(i, (float[3]){fdx, fdy, fdz}, info[i].dr);
+        body_px  = (WIN_H * 0.5f) * info[i].dr
+                 / (info[i].dcam * tanf(FOV * 0.5f * (float)(PI / 180.0)) + 1e-9f);
         tol = body_px * 1.35f + 56.0f;
-        if (tol < 72.0f) tol = 72.0f;
+        if (tol < 72.0f)  tol = 72.0f;
         if (tol > 190.0f) tol = 190.0f;
         if (screen_d > tol) continue;
 
+        /* Prefer centred bodies; dcam term breaks ties between overlapping bodies. */
         score = screen_d / tol + info[i].dcam * 0.000001f;
         if (score < best_score) {
             best_score = score;
-            best_idx = i;
+            best_idx   = i;
         }
     }
 
@@ -384,8 +394,9 @@ void inspect_orbit_zoom(int wheel_y)
         s_orbit_distance = s_orbit_min_distance;
     if (s_orbit_distance > s_orbit_max_distance)
         s_orbit_distance = s_orbit_max_distance;
+    /* Switch to zoom-smoothing path; mark fly-in transition as done. */
     s_orbit_zoom_smoothing = 1;
-    s_orbit_transition_t = 1.0;
+    s_orbit_transition_t   = 1.0;
 }
 
 void inspect_orbit_update(float dt)
@@ -393,13 +404,14 @@ void inspect_orbit_update(float dt)
     int idx = g_inspect_target;
     double center[3], u;
     if (!g_inspect_orbit_mode || idx < 0 || idx >= g_nbodies || !g_bodies[idx].alive) {
+        /* Target was absorbed — follow the survivor if one exists. */
         int survivor = collision_body_absorbed_by(idx);
         if (survivor >= 0 && survivor < g_nbodies && g_bodies[survivor].alive) {
             set_orbit_target_from_camera(survivor, 0.95);
             idx = survivor;
         } else {
             g_inspect_orbit_mode = 0;
-            g_inspect_target = -1;
+            g_inspect_target     = -1;
             return;
         }
     }

--- a/src/inspect.h
+++ b/src/inspect.h
@@ -21,5 +21,7 @@ void inspect_orbit_mouse(int dx, int dy, float sens_deg_per_px);
 void inspect_orbit_zoom(int wheel_y);
 void inspect_orbit_update(float dt);
 
-int inspect_ring_screen(const float vp_camrel[16], const BodyRenderInfo *info,
-                        float *sx, float *sy, float *radius_px, float *alpha);
+/* Returns 1 and fills rel (camera-relative body position), dr (visual radius
+   in AU), and alpha if a ring should be drawn this frame, 0 otherwise. */
+int inspect_ring_params(const BodyRenderInfo *info,
+                        float rel[3], float *dr, float *alpha);

--- a/src/inspect.h
+++ b/src/inspect.h
@@ -1,0 +1,25 @@
+/*
+ * inspect.h - body inspection and orbit camera mode
+ */
+#pragma once
+#include "common.h"
+#include "labels.h"
+
+extern int g_inspect_mode;
+extern int g_inspect_orbit_mode;
+extern int g_inspect_hovered;
+extern int g_inspect_target;
+
+void inspect_init(void);
+void inspect_toggle(void);
+void inspect_cancel(void);
+void inspect_exit_orbit(void);
+
+void inspect_pick_center(const float vp_camrel[16], const BodyRenderInfo *info);
+int  inspect_begin_orbit(void);
+void inspect_orbit_mouse(int dx, int dy, float sens_deg_per_px);
+void inspect_orbit_zoom(int wheel_y);
+void inspect_orbit_update(float dt);
+
+int inspect_ring_screen(const float vp_camrel[16], const BodyRenderInfo *info,
+                        float *sx, float *sy, float *radius_px, float *alpha);

--- a/src/main.c
+++ b/src/main.c
@@ -45,6 +45,7 @@
 #include "asteroids.h"
 #include "ui.h"
 #include "build.h"
+#include "inspect.h"
 #include "collision.h"
 #include "supernova.h"
 #include "audio.h"
@@ -111,6 +112,12 @@ static void boot_log(const char *msg) {
 
 static void clear_movement_keys(void) {
     s_key_w = s_key_s = s_key_a = s_key_d = s_key_q = s_key_e = 0;
+}
+
+static void leave_inspect_keep_mouse(void) {
+    inspect_cancel();
+    s_freelook = 1;
+    SDL_SetRelativeMouseMode(SDL_TRUE);
 }
 
 static int set_vsync(int enabled) {
@@ -243,6 +250,8 @@ static void init_runtime_world(void) {
     labels_init();
     boot_log("Initializing build mode");
     build_init();
+    boot_log("Initializing inspect mode");
+    inspect_init();
     boot_log("Refreshing physics timestep model");
     physics_refresh_timestep_model();
     warmup_universe();
@@ -470,12 +479,30 @@ static void handle_event(const SDL_Event *e, float dt, int *running) {
 
     case SDL_KEYDOWN:
         switch (e->key.keysym.sym) {
-        case SDLK_w: s_key_w = 1; break;
-        case SDLK_s: s_key_s = 1; break;
-        case SDLK_a: s_key_a = 1; break;
-        case SDLK_d: s_key_d = 1; break;
-        case SDLK_q: s_key_q = 1; break;
-        case SDLK_e: s_key_e = 1; break;
+        case SDLK_w:
+            s_key_w = 1;
+            if (g_inspect_orbit_mode) leave_inspect_keep_mouse();
+            break;
+        case SDLK_s:
+            s_key_s = 1;
+            if (g_inspect_orbit_mode) leave_inspect_keep_mouse();
+            break;
+        case SDLK_a:
+            s_key_a = 1;
+            if (g_inspect_orbit_mode) leave_inspect_keep_mouse();
+            break;
+        case SDLK_d:
+            s_key_d = 1;
+            if (g_inspect_orbit_mode) leave_inspect_keep_mouse();
+            break;
+        case SDLK_q:
+            s_key_q = 1;
+            if (g_inspect_orbit_mode) leave_inspect_keep_mouse();
+            break;
+        case SDLK_e:
+            s_key_e = 1;
+            if (g_inspect_orbit_mode) leave_inspect_keep_mouse();
+            break;
         case SDLK_r: cam_reset(); break;
         case SDLK_F11:
             if (!e->key.repeat) toggle_fullscreen();
@@ -485,7 +512,22 @@ static void handle_event(const SDL_Event *e, float dt, int *running) {
                 toggle_fullscreen();
             break;
         case SDLK_b:
-            if (!e->key.repeat) build_toggle();
+            if (!e->key.repeat) {
+                if (g_inspect_mode) {
+                    inspect_cancel();
+                    s_freelook = 1;
+                    SDL_SetRelativeMouseMode(SDL_TRUE);
+                }
+                build_toggle();
+            }
+            break;
+        case SDLK_i:
+            if (!e->key.repeat) {
+                if (g_build_mode) build_toggle();
+                inspect_toggle();
+                s_freelook = 1;
+                SDL_SetRelativeMouseMode(SDL_TRUE);
+            }
             break;
         case SDLK_TAB:
             build_set_tab_held(1);
@@ -511,6 +553,11 @@ static void handle_event(const SDL_Event *e, float dt, int *running) {
         case SDLK_ESCAPE:
             if (g_build_mode) {
                 build_toggle();
+                break;
+            }
+            if (g_inspect_mode) {
+                leave_inspect_keep_mouse();
+                clear_movement_keys();
                 break;
             }
             if (s_freelook) {
@@ -550,6 +597,10 @@ static void handle_event(const SDL_Event *e, float dt, int *running) {
             build_place_current();
             break;
         }
+        if (g_inspect_mode && e->button.button == SDL_BUTTON_LEFT) {
+            inspect_begin_orbit();
+            break;
+        }
         if (e->button.button == SDL_BUTTON_LEFT && !s_freelook) {
             s_freelook = 1;
             SDL_SetRelativeMouseMode(SDL_TRUE);
@@ -557,7 +608,9 @@ static void handle_event(const SDL_Event *e, float dt, int *running) {
         break;
 
     case SDL_MOUSEMOTION:
-        if (s_freelook) {
+        if (g_inspect_orbit_mode) {
+            inspect_orbit_mouse(e->motion.xrel, e->motion.yrel, s_mouse_sens);
+        } else if (s_freelook) {
             g_cam.yaw   += e->motion.xrel * s_mouse_sens;
             g_cam.pitch -= e->motion.yrel * s_mouse_sens;
             if (g_cam.pitch >  89.0f) g_cam.pitch =  89.0f;
@@ -566,6 +619,10 @@ static void handle_event(const SDL_Event *e, float dt, int *running) {
         break;
 
     case SDL_MOUSEWHEEL:
+        if (g_inspect_orbit_mode) {
+            inspect_orbit_zoom(e->wheel.y);
+            break;
+        }
         if (g_build_mode && g_build_tab_held) {
             build_scroll(e->wheel.y);
             break;
@@ -685,7 +742,7 @@ int main(int argc, char **argv) {
             handle_event(&e, dt, &running);
         }
 
-        if (!s_pause_menu_open)
+        if (!s_pause_menu_open && !g_inspect_orbit_mode)
             camera_move(dt);
 
         /* Physics — RESPA hierarchical integrator */
@@ -750,6 +807,9 @@ int main(int argc, char **argv) {
                 rings_tick(effective_sim_dt);
             }
         }
+
+        if (!s_pause_menu_open && g_inspect_orbit_mode)
+            inspect_orbit_update(dt);
 
         /* Build matrices.
          * view_rot: rotation-only lookAt (origin as eye). Used for all distant

--- a/src/main.c
+++ b/src/main.c
@@ -513,11 +513,8 @@ static void handle_event(const SDL_Event *e, float dt, int *running) {
             break;
         case SDLK_b:
             if (!e->key.repeat) {
-                if (g_inspect_mode) {
-                    inspect_cancel();
-                    s_freelook = 1;
-                    SDL_SetRelativeMouseMode(SDL_TRUE);
-                }
+                if (g_inspect_mode)
+                    leave_inspect_keep_mouse();
                 build_toggle();
             }
             break;

--- a/src/render.c
+++ b/src/render.c
@@ -328,49 +328,110 @@ static void build_draw_text(BuildTextCache *tc, float x, float y, float h) {
     build_draw_ui_quad(x, y, w, h);
 }
 
-static void draw_screen_ring(float cx, float cy, float r, float alpha)
+/*
+ * draw_ring_3d — inspect-target ring rendered in 3D camera-relative space.
+ *
+ * Ring points are computed on the sphere's silhouette ring and projected
+ * through the perspective matrix, so the ring is always correctly centred
+ * on the body regardless of camera angle or FOV.
+ *
+ * Fixed 8 dashes; only physical size changes with distance.
+ * Each dash is approximated with SEGS_PER_DASH line segments for a
+ * smooth arc even when the ring is large on screen.
+ */
+static void draw_ring_3d(const float rel[3], float dr,
+                         float alpha, const float vp[16])
 {
-    enum { MAX_DASHES = 96 };
-    float v[MAX_DASHES * 2 * 4];
-    float phase;
-    float step;
-    int dashes;
+    enum { N_DASHES = 8, SEGS = 5 };
+    /* 8 dashes × 5 segs × 2 endpoints × 4 floats — well within the 768-float VBO */
+    float v[N_DASHES * SEGS * 2 * 4];
+    float D, corr, ring_r, Cx, Cy, Cz;
+    float p_hat[3], tmp[3], t1[3], t2[3], len;
+    float phase, step;
+    int vtx = 0;
+
     if (!s_build_ui_shader || !s_build_ui_vbo) return;
 
-    dashes = (int)(r * 0.28f);
-    if (dashes < 8) dashes = 8;
-    if (dashes > MAX_DASHES) dashes = MAX_DASHES;
+    D = sqrtf(rel[0]*rel[0] + rel[1]*rel[1] + rel[2]*rel[2]);
+    if (D < dr * 1.01f) return;
+
+    /* Silhouette ring geometry:
+     *   centre  = rel × (1 − R²/D²)   — lies on the same screen ray as rel
+     *   radius  = R × √(1 − R²/D²)    — exact silhouette radius
+     * Scale by 1.3 so the ring sits clearly outside the body silhouette. */
+    corr   = 1.0f - (dr * dr) / (D * D);
+    Cx     = rel[0] * corr;
+    Cy     = rel[1] * corr;
+    Cz     = rel[2] * corr;
+    ring_r = dr * sqrtf(corr) * 1.3f;
+
+    /* Two tangent vectors spanning the silhouette ring plane (perpendicular to rel) */
+    p_hat[0] = rel[0] / D;
+    p_hat[1] = rel[1] / D;
+    p_hat[2] = rel[2] / D;
+    if (fabsf(p_hat[1]) < 0.9f) { tmp[0]=0.0f; tmp[1]=1.0f; tmp[2]=0.0f; }
+    else                         { tmp[0]=1.0f; tmp[1]=0.0f; tmp[2]=0.0f; }
+
+    t1[0] = p_hat[1]*tmp[2] - p_hat[2]*tmp[1];
+    t1[1] = p_hat[2]*tmp[0] - p_hat[0]*tmp[2];
+    t1[2] = p_hat[0]*tmp[1] - p_hat[1]*tmp[0];
+    len   = sqrtf(t1[0]*t1[0] + t1[1]*t1[1] + t1[2]*t1[2]);
+    t1[0] /= len; t1[1] /= len; t1[2] /= len;
+
+    t2[0] = p_hat[1]*t1[2] - p_hat[2]*t1[1];
+    t2[1] = p_hat[2]*t1[0] - p_hat[0]*t1[2];
+    t2[2] = p_hat[0]*t1[1] - p_hat[1]*t1[0];
+
+    /* Minimum ring_r: keep the ring at least 12 px on screen.
+     * Uses Euclidean distance D with half_fov_tan() — the same formula the
+     * rest of render.c uses for px→AU conversions.  Immune to camera-angle
+     * variation (D is invariant under rotation); works for dr≈0 (asteroids). */
+    {
+        float ring_r_min = 12.0f * D * half_fov_tan() / (WIN_H * 0.5f);
+        if (ring_r < ring_r_min) ring_r = ring_r_min;
+    }
 
     phase = (float)SDL_GetTicks() * 0.00055f;
-    step = 2.0f * (float)PI / (float)dashes;
-    for (int i = 0; i < dashes; i++) {
-        float a0 = phase + (float)i * step;
-        float a1 = a0 + step * 0.36f;
-        int v0 = i * 2;
-        int v1 = v0 + 1;
-        v[v0*4+0] = cx + cosf(a0) * r;
-        v[v0*4+1] = cy + sinf(a0) * r;
-        v[v0*4+2] = 0.0f;
-        v[v0*4+3] = 0.0f;
-        v[v1*4+0] = cx + cosf(a1) * r;
-        v[v1*4+1] = cy + sinf(a1) * r;
-        v[v1*4+2] = 0.0f;
-        v[v1*4+3] = 0.0f;
+    step  = 2.0f * (float)PI / (float)N_DASHES;
+
+    for (int d = 0; d < N_DASHES; d++) {
+        float a0 = phase + (float)d * step;
+        float a1 = a0 + step * 0.45f;
+        for (int s = 0; s < SEGS; s++) {
+            float aa = a0 + (a1 - a0) * (float)s       / (float)SEGS;
+            float ab = a0 + (a1 - a0) * (float)(s + 1) / (float)SEGS;
+            float sx0, sy0, sx1, sy1;
+            float p0x = Cx + cosf(aa)*ring_r*t1[0] + sinf(aa)*ring_r*t2[0];
+            float p0y = Cy + cosf(aa)*ring_r*t1[1] + sinf(aa)*ring_r*t2[1];
+            float p0z = Cz + cosf(aa)*ring_r*t1[2] + sinf(aa)*ring_r*t2[2];
+            float p1x = Cx + cosf(ab)*ring_r*t1[0] + sinf(ab)*ring_r*t2[0];
+            float p1y = Cy + cosf(ab)*ring_r*t1[1] + sinf(ab)*ring_r*t2[1];
+            float p1z = Cz + cosf(ab)*ring_r*t1[2] + sinf(ab)*ring_r*t2[2];
+            if (!mat4_project(vp, p0x, p0y, p0z, WIN_W, WIN_H, &sx0, &sy0)) continue;
+            if (!mat4_project(vp, p1x, p1y, p1z, WIN_W, WIN_H, &sx1, &sy1)) continue;
+            /* mat4_project: y=0 at bottom; flip to y=0 at top for the UI shader */
+            sy0 = (float)WIN_H - sy0;
+            sy1 = (float)WIN_H - sy1;
+            v[vtx*4+0]=sx0; v[vtx*4+1]=sy0; v[vtx*4+2]=0.0f; v[vtx*4+3]=0.0f; vtx++;
+            v[vtx*4+0]=sx1; v[vtx*4+1]=sy1; v[vtx*4+2]=0.0f; v[vtx*4+3]=0.0f; vtx++;
+        }
     }
+
+    if (vtx == 0) return;
 
     glUseProgram(s_build_ui_shader);
     glUniform2f(s_build_ui_screen, (float)WIN_W, (float)WIN_H);
     glUniform1i(s_build_ui_use_tex, 0);
-    glUniform4f(s_build_ui_color, 0.78f, 0.96f, 1.0f, alpha);
+    glUniform4f(s_build_ui_color, 1.0f, 1.0f, 1.0f, alpha);
     glBindVertexArray(s_build_ui_vao);
     glBindBuffer(GL_ARRAY_BUFFER, s_build_ui_vbo);
-    glBufferSubData(GL_ARRAY_BUFFER, 0, sizeof(v), v);
+    glBufferSubData(GL_ARRAY_BUFFER, 0, vtx * 4 * sizeof(float), v);
     glDisable(GL_DEPTH_TEST);
     glDepthMask(GL_FALSE);
     glEnable(GL_BLEND);
     glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
-    glLineWidth(1.35f);
-    glDrawArrays(GL_LINES, 0, dashes * 2);
+    glLineWidth(1.5f);
+    glDrawArrays(GL_LINES, 0, vtx);
     glLineWidth(1.0f);
     glDisable(GL_BLEND);
     glDepthMask(GL_TRUE);
@@ -1801,9 +1862,9 @@ void render_frame(const float view[16], const float proj[16],
 
     /* ------------------------------------------------------------------ 6.6. Inspect target ring */
     {
-        float sx, sy, rr, aa;
-        if (inspect_ring_screen(vp_camrel, info, &sx, &sy, &rr, &aa))
-            draw_screen_ring(sx, sy, rr, aa);
+        float rel[3], dr, aa;
+        if (inspect_ring_params(info, rel, &dr, &aa))
+            draw_ring_3d(rel, dr, aa, vp_camrel);
     }
 
     /* ------------------------------------------------------------------ 7. Labels */

--- a/src/render.c
+++ b/src/render.c
@@ -329,67 +329,45 @@ static void build_draw_text(BuildTextCache *tc, float x, float y, float h) {
 }
 
 /*
- * draw_ring_3d — inspect-target ring rendered in 3D camera-relative space.
+ * draw_ring_2d — inspect-target ring as a screen-space dashed circle.
  *
- * Ring points are computed on the sphere's silhouette ring and projected
- * through the perspective matrix, so the ring is always correctly centred
- * on the body regardless of camera angle or FOV.
+ * Centre: uses the corrected perspective divisor pz_adj = eye_z − R²/eye_z.
+ *   For an off-axis sphere the projected silhouette is an ellipse whose
+ *   centre is NOT proj(body_pos) — it shifts toward the screen edge.
+ *   Dividing the clip-space x/y by pz_adj instead of eye_z gives the true
+ *   visual centre of the sphere disc at any camera angle.
  *
- * Fixed 8 dashes; only physical size changes with distance.
- * Each dash is approximated with SEGS_PER_DASH line segments for a
- * smooth arc even when the ring is large on screen.
+ * Radius: dr × 1.3 projected at Euclidean distance D (angle-stable),
+ *   with a 12 px floor so the ring stays visible for any body at any distance.
  */
-static void draw_ring_3d(const float rel[3], float dr,
+static void draw_ring_2d(const float rel[3], float dr,
                          float alpha, const float vp[16])
 {
     enum { N_DASHES = 8, SEGS = 5 };
-    /* 8 dashes × 5 segs × 2 endpoints × 4 floats — well within the 768-float VBO */
     float v[N_DASHES * SEGS * 2 * 4];
-    float D, corr, ring_r, Cx, Cy, Cz;
-    float p_hat[3], tmp[3], t1[3], t2[3], len;
-    float phase, step;
+    float D, r_px, cx, cy, phase, step;
+    float clip_x, clip_y, clip_w, pz_adj;
     int vtx = 0;
 
     if (!s_build_ui_shader || !s_build_ui_vbo) return;
 
     D = sqrtf(rel[0]*rel[0] + rel[1]*rel[1] + rel[2]*rel[2]);
-    if (D < dr * 1.01f) return;
+    if (D < 1e-6f) return;
 
-    /* Silhouette ring geometry:
-     *   centre  = rel × (1 − R²/D²)   — lies on the same screen ray as rel
-     *   radius  = R × √(1 − R²/D²)    — exact silhouette radius
-     * Scale by 1.3 so the ring sits clearly outside the body silhouette. */
-    corr   = 1.0f - (dr * dr) / (D * D);
-    Cx     = rel[0] * corr;
-    Cy     = rel[1] * corr;
-    Cz     = rel[2] * corr;
-    ring_r = dr * sqrtf(corr) * 1.3f;
+    clip_x = vp[0]*rel[0] + vp[4]*rel[1] + vp[8] *rel[2] + vp[12];
+    clip_y = vp[1]*rel[0] + vp[5]*rel[1] + vp[9] *rel[2] + vp[13];
+    clip_w = vp[3]*rel[0] + vp[7]*rel[1] + vp[11]*rel[2] + vp[15];
+    if (clip_w <= 0.0f) return;
 
-    /* Two tangent vectors spanning the silhouette ring plane (perpendicular to rel) */
-    p_hat[0] = rel[0] / D;
-    p_hat[1] = rel[1] / D;
-    p_hat[2] = rel[2] / D;
-    if (fabsf(p_hat[1]) < 0.9f) { tmp[0]=0.0f; tmp[1]=1.0f; tmp[2]=0.0f; }
-    else                         { tmp[0]=1.0f; tmp[1]=0.0f; tmp[2]=0.0f; }
+    pz_adj = clip_w - dr * dr / clip_w;
+    if (pz_adj <= 0.0f) return;
 
-    t1[0] = p_hat[1]*tmp[2] - p_hat[2]*tmp[1];
-    t1[1] = p_hat[2]*tmp[0] - p_hat[0]*tmp[2];
-    t1[2] = p_hat[0]*tmp[1] - p_hat[1]*tmp[0];
-    len   = sqrtf(t1[0]*t1[0] + t1[1]*t1[1] + t1[2]*t1[2]);
-    t1[0] /= len; t1[1] /= len; t1[2] /= len;
+    cx = (clip_x / pz_adj + 1.0f) * 0.5f * (float)WIN_W;
+    cy = (float)WIN_H - (clip_y / pz_adj + 1.0f) * 0.5f * (float)WIN_H;
 
-    t2[0] = p_hat[1]*t1[2] - p_hat[2]*t1[1];
-    t2[1] = p_hat[2]*t1[0] - p_hat[0]*t1[2];
-    t2[2] = p_hat[0]*t1[1] - p_hat[1]*t1[0];
-
-    /* Minimum ring_r: keep the ring at least 12 px on screen.
-     * Uses Euclidean distance D with half_fov_tan() — the same formula the
-     * rest of render.c uses for px→AU conversions.  Immune to camera-angle
-     * variation (D is invariant under rotation); works for dr≈0 (asteroids). */
-    {
-        float ring_r_min = 12.0f * D * half_fov_tan() / (WIN_H * 0.5f);
-        if (ring_r < ring_r_min) ring_r = ring_r_min;
-    }
+    /* Screen radius using D (Euclidean), not eye_z, so it is angle-stable */
+    r_px = dr * 1.3f * (WIN_H * 0.5f) / (D * half_fov_tan());
+    if (r_px < 12.0f) r_px = 12.0f;
 
     phase = (float)SDL_GetTicks() * 0.00055f;
     step  = 2.0f * (float)PI / (float)N_DASHES;
@@ -400,20 +378,10 @@ static void draw_ring_3d(const float rel[3], float dr,
         for (int s = 0; s < SEGS; s++) {
             float aa = a0 + (a1 - a0) * (float)s       / (float)SEGS;
             float ab = a0 + (a1 - a0) * (float)(s + 1) / (float)SEGS;
-            float sx0, sy0, sx1, sy1;
-            float p0x = Cx + cosf(aa)*ring_r*t1[0] + sinf(aa)*ring_r*t2[0];
-            float p0y = Cy + cosf(aa)*ring_r*t1[1] + sinf(aa)*ring_r*t2[1];
-            float p0z = Cz + cosf(aa)*ring_r*t1[2] + sinf(aa)*ring_r*t2[2];
-            float p1x = Cx + cosf(ab)*ring_r*t1[0] + sinf(ab)*ring_r*t2[0];
-            float p1y = Cy + cosf(ab)*ring_r*t1[1] + sinf(ab)*ring_r*t2[1];
-            float p1z = Cz + cosf(ab)*ring_r*t1[2] + sinf(ab)*ring_r*t2[2];
-            if (!mat4_project(vp, p0x, p0y, p0z, WIN_W, WIN_H, &sx0, &sy0)) continue;
-            if (!mat4_project(vp, p1x, p1y, p1z, WIN_W, WIN_H, &sx1, &sy1)) continue;
-            /* mat4_project: y=0 at bottom; flip to y=0 at top for the UI shader */
-            sy0 = (float)WIN_H - sy0;
-            sy1 = (float)WIN_H - sy1;
-            v[vtx*4+0]=sx0; v[vtx*4+1]=sy0; v[vtx*4+2]=0.0f; v[vtx*4+3]=0.0f; vtx++;
-            v[vtx*4+0]=sx1; v[vtx*4+1]=sy1; v[vtx*4+2]=0.0f; v[vtx*4+3]=0.0f; vtx++;
+            v[vtx*4+0]=cx+cosf(aa)*r_px; v[vtx*4+1]=cy+sinf(aa)*r_px;
+            v[vtx*4+2]=0.0f; v[vtx*4+3]=0.0f; vtx++;
+            v[vtx*4+0]=cx+cosf(ab)*r_px; v[vtx*4+1]=cy+sinf(ab)*r_px;
+            v[vtx*4+2]=0.0f; v[vtx*4+3]=0.0f; vtx++;
         }
     }
 
@@ -1864,7 +1832,7 @@ void render_frame(const float view[16], const float proj[16],
     {
         float rel[3], dr, aa;
         if (inspect_ring_params(info, rel, &dr, &aa))
-            draw_ring_3d(rel, dr, aa, vp_camrel);
+            draw_ring_2d(rel, dr, aa, vp_camrel);
     }
 
     /* ------------------------------------------------------------------ 7. Labels */

--- a/src/render.c
+++ b/src/render.c
@@ -385,8 +385,6 @@ static void draw_ring_2d(const float rel[3], float dr,
         }
     }
 
-    if (vtx == 0) return;
-
     glUseProgram(s_build_ui_shader);
     glUniform2f(s_build_ui_screen, (float)WIN_W, (float)WIN_H);
     glUniform1i(s_build_ui_use_tex, 0);

--- a/src/render.c
+++ b/src/render.c
@@ -55,6 +55,7 @@
 #include "asteroids.h"
 #include "labels.h"
 #include "build.h"
+#include "inspect.h"
 #include "collision.h"
 #include "gl_utils.h"
 #include "math3d.h"
@@ -325,6 +326,56 @@ static void build_draw_text(BuildTextCache *tc, float x, float y, float h) {
     glUniform4f(s_build_ui_color, 1, 1, 1, 1);
     glBindTexture(GL_TEXTURE_2D, tc->tex);
     build_draw_ui_quad(x, y, w, h);
+}
+
+static void draw_screen_ring(float cx, float cy, float r, float alpha)
+{
+    enum { MAX_DASHES = 96 };
+    float v[MAX_DASHES * 2 * 4];
+    float phase;
+    float step;
+    int dashes;
+    if (!s_build_ui_shader || !s_build_ui_vbo) return;
+
+    dashes = (int)(r * 0.28f);
+    if (dashes < 8) dashes = 8;
+    if (dashes > MAX_DASHES) dashes = MAX_DASHES;
+
+    phase = (float)SDL_GetTicks() * 0.00055f;
+    step = 2.0f * (float)PI / (float)dashes;
+    for (int i = 0; i < dashes; i++) {
+        float a0 = phase + (float)i * step;
+        float a1 = a0 + step * 0.36f;
+        int v0 = i * 2;
+        int v1 = v0 + 1;
+        v[v0*4+0] = cx + cosf(a0) * r;
+        v[v0*4+1] = cy + sinf(a0) * r;
+        v[v0*4+2] = 0.0f;
+        v[v0*4+3] = 0.0f;
+        v[v1*4+0] = cx + cosf(a1) * r;
+        v[v1*4+1] = cy + sinf(a1) * r;
+        v[v1*4+2] = 0.0f;
+        v[v1*4+3] = 0.0f;
+    }
+
+    glUseProgram(s_build_ui_shader);
+    glUniform2f(s_build_ui_screen, (float)WIN_W, (float)WIN_H);
+    glUniform1i(s_build_ui_use_tex, 0);
+    glUniform4f(s_build_ui_color, 0.78f, 0.96f, 1.0f, alpha);
+    glBindVertexArray(s_build_ui_vao);
+    glBindBuffer(GL_ARRAY_BUFFER, s_build_ui_vbo);
+    glBufferSubData(GL_ARRAY_BUFFER, 0, sizeof(v), v);
+    glDisable(GL_DEPTH_TEST);
+    glDepthMask(GL_FALSE);
+    glEnable(GL_BLEND);
+    glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+    glLineWidth(1.35f);
+    glDrawArrays(GL_LINES, 0, dashes * 2);
+    glLineWidth(1.0f);
+    glDisable(GL_BLEND);
+    glDepthMask(GL_TRUE);
+    glEnable(GL_DEPTH_TEST);
+    glBindVertexArray(0);
 }
 
 /* Format a distance in AU into a human-readable string, adapting units. */
@@ -798,8 +849,8 @@ void render_init(void) {
         s_build_ui_use_tex = glGetUniformLocation(s_build_ui_shader, "u_use_tex");
         s_build_ui_tex     = glGetUniformLocation(s_build_ui_shader, "u_tex");
         s_build_ui_vao = gl_vao_create();
-        /* One quad: 6 vertices × 4 floats (xy, uv) */
-        s_build_ui_vbo = gl_vbo_create(24 * sizeof(float), NULL, GL_DYNAMIC_DRAW);
+        /* Shared overlay buffer: enough for one text quad or an inspect ring. */
+        s_build_ui_vbo = gl_vbo_create(96 * 2 * 4 * sizeof(float), NULL, GL_DYNAMIC_DRAW);
         glEnableVertexAttribArray(0);
         glVertexAttribPointer(0, 2, GL_FLOAT, GL_FALSE, 4*sizeof(float), (void*)0);
         glEnableVertexAttribArray(1);
@@ -1227,6 +1278,8 @@ void render_frame(const float view[16], const float proj[16],
         glDrawElements(GL_TRIANGLES, 6, GL_UNSIGNED_INT, 0);
     }
     glBindVertexArray(0);
+
+    inspect_pick_center(vp_camrel, info);
 
     /* ------------------------------------------------------------------ 2.5. Atmosphere glow
      * Separate additive pass: GL_SRC_ALPHA / GL_ONE, depth-tested but no depth write.
@@ -1745,6 +1798,13 @@ void render_frame(const float view[16], const float proj[16],
 
     /* ------------------------------------------------------------------ 6.5. Build preview */
     render_build_preview(vp_camrel);
+
+    /* ------------------------------------------------------------------ 6.6. Inspect target ring */
+    {
+        float sx, sy, rr, aa;
+        if (inspect_ring_screen(vp_camrel, info, &sx, &sy, &rr, &aa))
+            draw_screen_ring(sx, sy, rr, aa);
+    }
 
     /* ------------------------------------------------------------------ 7. Labels */
     labels_render(view_rot, proj, vp_camrel, info, dt);


### PR DESCRIPTION
### What does this PR do?
Adds an inspect mode that lets users pause the simulation, select a centered celestial body, and enter a smooth orbit camera around it. The PR also adds target ring highlighting, improves inspect-mode picking/interaction behavior, and refines crater rendering so persistent impact scars shade more naturally and avoid layering artifacts.

### Changes
<!-- List the files you changed and briefly explain why -->
- `src/inspect.c` / `src/inspect.h` - Add inspect mode state, center-body picking, orbit camera transitions, orbit mouse controls, zoom handling, and target-ring parameters.
- `src/main.c` - Wire inspect mode into runtime initialization, keyboard/mouse input, camera movement, build-mode interaction, pause behavior, and per-frame orbit updates.
- `src/render.c` - Feed body render info into inspect picking and draw the inspect target ring overlay with corrected screen-space placement.
- `src/collision.c` / `src/collision.h` - Track which body absorbed another body so inspect orbit can follow the surviving target after collisions/merges.
- `assets/shaders/phong.frag` - Fix persistent crater rendering so crater scars stay confined to the intended impact cap, no longer bleed onto the antipode, and layer correctly with active merge/intersection effects. Adds procedural crater normal shading for bowl/rim depth, tones down overly dark crater floors and hot rims, and reduces visual overwrite from live collision bloom so old scars remain readable without looking like transparent halos.

### Testing
- Orbit-view merge transistion checked
- Body inspection camera travel-animation checked and validated 
- Successful crater creation and transistion checked
- Full orbit-view movement checked
- Inspection mode exit commands checked

### Screenshots / Videos
<img width="1855" height="1055" alt="image" src="https://github.com/user-attachments/assets/c25faa56-c3ed-4f0c-8dad-b85940e03628" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/610cf1e5-a55e-4530-88ac-d182abd1e4da" />