### PR TITLE
Bugfix/issue#11

### DIFF
--- a/assets/shaders/atm.frag
+++ b/assets/shaders/atm.frag
@@ -63,18 +63,25 @@ void main() {
 
     /* Front face of the outer atmosphere sphere */
     float t_atm = -b - sqrt(max(0.0, R_atm * R_atm - p2));
-    if (t_atm <= 0.0) discard;   /* camera inside atmosphere */
+    /* When t_atm <= 0 the camera is already inside the atmosphere — still
+     * render glow.  Clamp t_hit to 0 so the lit-side normal is evaluated at
+     * the camera position rather than a point behind it. */
+    float t_hit = max(t_atm, 0.0);
 
     /* Smooth power-law falloff.
      * norm = 0 at the planet surface (limb), 1 at the outer atmosphere edge.
      * (1−norm)^3 concentrates the glow at the limb and tapers continuously
-     * to zero — no visible hard cutoff at the boundary.                    */
-    float p    = sqrt(p2);
+     * to zero — no visible hard cutoff at the boundary.
+     *
+     * When the camera is inside the atmosphere and the ray points outward
+     * (b > 0), the geometric closest approach on the positive ray is at t=0
+     * (the camera itself), so use oc2 rather than the infinite-line p2. */
+    float p    = sqrt(b > 0.0 ? oc2 : p2);
     float norm = clamp((p - R) / (R_atm - R), 0.0, 1.0);
     float glow = pow(1.0 - norm, 3.0);
 
     /* Lit-side boost: outward normal at atmosphere hit point vs. sun dir */
-    vec3  hit_n   = normalize(u_oc + t_atm * ray_dir);
+    vec3  hit_n   = normalize(u_oc + t_hit * ray_dir);
     float sun_dot = dot(hit_n, normalize(u_sun_rel));
     float lit     = 0.15 + 0.85 * clamp(sun_dot, 0.0, 1.0);
 

--- a/assets/shaders/atm.vert
+++ b/assets/shaders/atm.vert
@@ -17,9 +17,16 @@ uniform vec3  u_cam_up;
 const float BILL_SCALE = 2.0;
 
 void main() {
-    vec2 off    = a_uv * 2.0 - 1.0;          /* −1 .. +1 */
-    vec3 pos    = u_center
-                + u_cam_right * (off.x * u_radius * BILL_SCALE)
-                + u_cam_up    * (off.y * u_radius * BILL_SCALE);
-    gl_Position = u_vp * vec4(pos, 1.0);
+    vec2 off = a_uv * 2.0 - 1.0;          /* −1 .. +1 */
+
+    if (dot(u_center, u_center) < u_radius * u_radius) {
+        /* Camera is inside the atmosphere sphere — cover the full screen so
+         * every pixel gets a fragment invocation for the ray test. */
+        gl_Position = vec4(off, 0.0, 1.0);
+    } else {
+        vec3 pos = u_center
+                 + u_cam_right * (off.x * u_radius * BILL_SCALE)
+                 + u_cam_up    * (off.y * u_radius * BILL_SCALE);
+        gl_Position = u_vp * vec4(pos, 1.0);
+    }
 }

--- a/assets/shaders/atm.vert
+++ b/assets/shaders/atm.vert
@@ -1,9 +1,15 @@
 #version 330 core
 /*
- * atm.vert — atmospheric glow billboard
+ * atm.vert — atmospheric glow quad
  *
- * Sizes the quad to an oversized outer-atmosphere billboard so off-axis
- * planets do not have their atmosphere clipped by the quad bounds.
+ * Far from the planet: oversized billboard (BILL_SCALE × radius) so off-axis
+ * atmospheres are not clipped by the quad bounds.
+ *
+ * Within 4 radii: fullscreen NDC quad — the billboard math degenerates at
+ * oblique view angles where the planet centre projects near the camera plane.
+ * The fragment shader reconstructs the per-pixel ray independently and does
+ * the ray-sphere intersection, so a fullscreen quad produces the correct
+ * silhouette from any position or look direction.
  */
 
 layout(location = 0) in vec2 a_uv;
@@ -19,10 +25,8 @@ const float BILL_SCALE = 2.0;
 void main() {
     vec2 off = a_uv * 2.0 - 1.0;          /* −1 .. +1 */
 
-    if (dot(u_center, u_center) < u_radius * u_radius) {
-        /* Camera is inside the atmosphere sphere — cover the full screen so
-         * every pixel gets a fragment invocation for the ray test. */
-        gl_Position = vec4(off, 0.0, 1.0);
+    if (dot(u_center, u_center) < u_radius * u_radius * 16.0) {
+        gl_Position = vec4(off.x * 2.0, off.y * 2.0, 0.0, 1.0);
     } else {
         vec3 pos = u_center
                  + u_cam_right * (off.x * u_radius * BILL_SCALE)

--- a/assets/shaders/phong.vert
+++ b/assets/shaders/phong.vert
@@ -17,6 +17,7 @@ uniform vec3  u_center;
 uniform float u_radius;
 uniform vec3  u_cam_right;
 uniform vec3  u_cam_up;
+uniform int   u_inside;   /* 1 when camera is inside the sphere */
 
 out vec2 v_uv;
 
@@ -24,13 +25,21 @@ const float BILL_SCALE = 2.0;
 
 void main() {
     vec2 off = a_uv * 2.0 - 1.0;           /* -1..+1                     */
+    v_uv = off * BILL_SCALE;               /* -BILL_SCALE..+BILL_SCALE   */
+
+    if (u_inside == 1) {
+        /* Camera is inside this body — billboard would be behind the camera.
+         * Use an oversized fullscreen NDC quad instead; the fragment shader
+         * reconstructs the per-pixel ray from gl_FragCoord independently of
+         * billboard position, so inside-surface rendering is correct. */
+        gl_Position = vec4(off.x * 2.0, off.y * 2.0, 0.0, 1.0);
+        return;
+    }
 
     /* Oversized billboard: BILL_SCALE * radius in each camera axis */
     vec3 world = u_center
                + u_cam_right * (off.x * u_radius * BILL_SCALE)
                + u_cam_up    * (off.y * u_radius * BILL_SCALE);
 
-    /* v_uv scaled to match: frag_bill = center + right*v_uv.x*radius + ... */
-    v_uv        = off * BILL_SCALE;         /* -BILL_SCALE..+BILL_SCALE   */
     gl_Position = u_vp * vec4(world, 1.0);
 }

--- a/assets/shaders/phong.vert
+++ b/assets/shaders/phong.vert
@@ -1,10 +1,17 @@
 #version 330 core
 /*
- * phong.vert — sphere billboard (oversized for off-axis coverage)
+ * phong.vert — sphere quad
  *
- * The billboard is scaled by BILL_SCALE (2×) so that the sphere silhouette
- * is never clipped when the planet is near the viewport edge. The fragment
- * shader (ray-sphere intersection) handles the actual discard boundary.
+ * Far from the planet: oversized billboard (BILL_SCALE × radius) so the
+ * sphere silhouette is never clipped near the viewport edge.
+ *
+ * Close to the planet (u_use_fullscreen == 1): fullscreen NDC quad.  The
+ * billboard math degenerates whenever the sphere centre is at or behind the
+ * camera plane (perspective division by ~0), which happens at any oblique
+ * view angle when the camera is near the body.  The fragment shader
+ * reconstructs the per-pixel ray from gl_FragCoord and does the ray-sphere
+ * intersection independently of vertex position, so a fullscreen quad
+ * produces the correct silhouette from any view direction.
  *
  * v_uv is passed in [-BILL_SCALE, +BILL_SCALE] so the fragment shader can
  * reconstruct the exact same world-space position as this vertex.
@@ -17,7 +24,7 @@ uniform vec3  u_center;
 uniform float u_radius;
 uniform vec3  u_cam_right;
 uniform vec3  u_cam_up;
-uniform int   u_inside;   /* 1 when camera is inside the sphere */
+uniform int   u_use_fullscreen;   /* 1 when the billboard would degenerate */
 
 out vec2 v_uv;
 
@@ -27,16 +34,11 @@ void main() {
     vec2 off = a_uv * 2.0 - 1.0;           /* -1..+1                     */
     v_uv = off * BILL_SCALE;               /* -BILL_SCALE..+BILL_SCALE   */
 
-    if (u_inside == 1) {
-        /* Camera is inside this body — billboard would be behind the camera.
-         * Use an oversized fullscreen NDC quad instead; the fragment shader
-         * reconstructs the per-pixel ray from gl_FragCoord independently of
-         * billboard position, so inside-surface rendering is correct. */
+    if (u_use_fullscreen == 1) {
         gl_Position = vec4(off.x * 2.0, off.y * 2.0, 0.0, 1.0);
         return;
     }
 
-    /* Oversized billboard: BILL_SCALE * radius in each camera axis */
     vec3 world = u_center
                + u_cam_right * (off.x * u_radius * BILL_SCALE)
                + u_cam_up    * (off.y * u_radius * BILL_SCALE);

--- a/src/inspect.c
+++ b/src/inspect.c
@@ -321,6 +321,37 @@ void inspect_pick_center(const float vp_camrel[16], const BodyRenderInfo *info)
         screen_d = sqrtf(dx*dx + dy*dy);
         body_px  = (WIN_H * 0.5f) * info[i].dr
                  / (info[i].dcam * tanf(FOV * 0.5f * (float)(PI / 180.0)) + 1e-9f);
+
+        /* Skip moons that visually merge with their parent: tiny on screen AND
+         * within the parent's screen disc.  Otherwise the cursor often lands
+         * fractionally closer to a moon than to the parent itself, and the user
+         * accidentally picks the moon when targeting the planet.  Once the
+         * camera is close enough that the moon's disc grows past MOON_MERGE_PX,
+         * the moon becomes pickable normally.
+         *
+         * Sandbox safety: only applies to bodies whose parent is a non-star
+         * (i.e., true moons).  Free-floating bodies (parent < 0) and planets
+         * (parent is a star) are unaffected, so user-placed standalone bodies
+         * remain pickable at any distance. */
+        {
+            const float MOON_MERGE_PX = 5.0f;       /* tune: max moon px to consider "merged" */
+            const float MERGE_MARGIN_PX = 8.0f;     /* parent disc + margin */
+            int parent_idx = g_bodies[i].parent;
+            if (parent_idx >= 0 && parent_idx < g_nbodies &&
+                !g_bodies[parent_idx].is_star && body_px < MOON_MERGE_PX) {
+                float prx, pry, prz, psx, psy;
+                prx = (float)(g_bodies[parent_idx].pos[0] * RS - g_cam.pos[0]);
+                pry = (float)(g_bodies[parent_idx].pos[1] * RS - g_cam.pos[1]);
+                prz = (float)(g_bodies[parent_idx].pos[2] * RS - g_cam.pos[2]);
+                if (mat4_project(vp_camrel, prx, pry, prz, WIN_W, WIN_H, &psx, &psy)) {
+                    float parent_px = (WIN_H * 0.5f) * info[parent_idx].dr
+                                    / (info[parent_idx].dcam * tanf(FOV * 0.5f * (float)(PI / 180.0)) + 1e-9f);
+                    float pdx = sx - psx, pdy = sy - psy;
+                    if (sqrtf(pdx*pdx + pdy*pdy) < parent_px + MERGE_MARGIN_PX) continue;
+                }
+            }
+        }
+
         tol = body_px * 1.35f + 56.0f;
         if (tol < 72.0f)  tol = 72.0f;
         if (tol > 190.0f) tol = 190.0f;
@@ -337,21 +368,32 @@ void inspect_pick_center(const float vp_camrel[16], const BodyRenderInfo *info)
     g_inspect_hovered = best_idx;
 }
 
+static int inspect_centering_active(void)
+{
+    return s_orbit_transition_t < 1.0 || s_look_transition_t < 1.0;
+}
+
 int inspect_begin_orbit(void)
 {
     int idx = g_inspect_hovered;
 
     if (!g_inspect_mode || idx < 0 || idx >= g_nbodies || !g_bodies[idx].alive)
         return 0;
+    /* Lock out re-targeting while a fly-in is mid-animation, but only after a
+     * body has already been selected (orbit mode active).  Pre-selection clicks
+     * must still go through, otherwise the user can never enter orbit mode. */
+    if (g_inspect_orbit_mode && inspect_centering_active()) return 0;
+    /* No-op when clicking the body we are already inspecting and the camera
+     * is already at its target orbit distance.  Otherwise the user pays a
+     * full travel-animation duration for a transition that produces no visible
+     * motion.  A 1% tolerance lets the check survive minor zoom drift. */
+    if (g_inspect_orbit_mode && idx == g_inspect_target &&
+        fabs(s_orbit_current_distance - s_orbit_distance) < s_orbit_distance * 0.01)
+        return 0;
 
     set_orbit_target_from_camera(idx, 1.45);
     g_inspect_orbit_mode = 1;
     return 1;
-}
-
-static int inspect_centering_active(void)
-{
-    return s_orbit_transition_t < 1.0 || s_look_transition_t < 1.0;
 }
 
 void inspect_orbit_mouse(int dx, int dy, float sens_deg_per_px)

--- a/src/main.c
+++ b/src/main.c
@@ -565,12 +565,14 @@ static void handle_event(const SDL_Event *e, float dt, int *running) {
         case SDLK_PLUS:
             if (s_speed_idx < SPEED_TABLE_LEN - 1) s_speed_idx++;
             g_sim_speed = SPEED_TABLE[s_speed_idx] * DAY;
+            ui_notify_speed_change();
             fprintf(stdout, "[Sim] speed = %g days/s\n",
                     SPEED_TABLE[s_speed_idx]);
             break;
         case SDLK_MINUS:
             if (s_speed_idx > 0) s_speed_idx--;
             g_sim_speed = SPEED_TABLE[s_speed_idx] * DAY;
+            ui_notify_speed_change();
             fprintf(stdout, "[Sim] speed = %g days/s\n",
                     SPEED_TABLE[s_speed_idx]);
             break;

--- a/src/render.c
+++ b/src/render.c
@@ -1230,11 +1230,14 @@ void render_frame(const float view[16], const float proj[16],
          * dcam = eye_z/cos(θ), which makes the threshold oscillate when the camera
          * rotates.  eye_z is invariant under pure rotation so the transition is stable. */
         float eye_z = (float)(dxd*cam_fwd[0] + dyd*cam_fwd[1] + dzd*cam_fwd[2]);
-        int inside_body = (dcam < dr);
+        /* use_fullscreen: sphere center is behind the camera (eye_z < 0) but the
+         * sphere still extends in front (eye_z > -dr).  In this case the normal
+         * billboard quad would be clipped by the near plane, so replace it with a
+         * fullscreen NDC quad.  Covers both the inside-body case and the case where
+         * the camera is just outside the surface but looking away. */
+        int use_fullscreen = (eye_z < 0.0f) && (eye_z > -dr);
         float px;
-        if (inside_body) {
-            /* Camera is inside the sphere — always render as sphere (large px
-             * suppresses the dot, show=0 enables sphere rendering below). */
+        if (use_fullscreen) {
             px = 1000.0f;
         } else {
             px = (eye_z > 0.0f)
@@ -1244,7 +1247,7 @@ void render_frame(const float view[16], const float proj[16],
         /* Threshold: sphere first appears when its diameter (2×px) equals the dot
          * diameter (2.5px), i.e. px = 1.25 = BODY_SPHERE_APPEAR_PX. */
         body_px[i]   = px;
-        info[i].show = (!inside_body && px < BODY_SPHERE_APPEAR_PX) ? 1 : 0;
+        info[i].show = (!use_fullscreen && px < BODY_SPHERE_APPEAR_PX) ? 1 : 0;
 
         if (!g_bodies[i].alive || info[i].show) continue;
         if (b->is_star) continue;   /* stars rendered as glare only, not Phong spheres */
@@ -1312,7 +1315,7 @@ void render_frame(const float view[16], const float proj[16],
             glUniform1iv(s_sp_impact_kind, nspots, kinds);
         }
 
-        glUniform1i(s_sp_inside, inside_body);
+        glUniform1i(s_sp_inside, use_fullscreen);
         glDrawElements(GL_TRIANGLES, 6, GL_UNSIGNED_INT, 0);
     }
     glBindVertexArray(0);

--- a/src/render.c
+++ b/src/render.c
@@ -100,6 +100,7 @@ static GLint  s_sp_impact_heat  = -1;
 static GLint  s_sp_impact_prog  = -1;
 static GLint  s_sp_impact_seed  = -1;
 static GLint  s_sp_impact_kind  = -1;
+static GLint  s_sp_inside       = -1;   /* 1 when camera is inside the sphere */
 
 /*
  * get_planet_type — map body name to a procedural texture variant index.
@@ -690,6 +691,7 @@ void render_init(void) {
     s_sp_impact_prog  = glGetUniformLocation(s_sphere_shader, "u_impact_progress[0]");
     s_sp_impact_seed  = glGetUniformLocation(s_sphere_shader, "u_impact_seed[0]");
     s_sp_impact_kind  = glGetUniformLocation(s_sphere_shader, "u_impact_kind[0]");
+    s_sp_inside       = glGetUniformLocation(s_sphere_shader, "u_inside");
 
     /* Frame-constant uniforms (fov_tan, aspect, screen do not change at runtime) */
     glUseProgram(s_sphere_shader);
@@ -1228,13 +1230,21 @@ void render_frame(const float view[16], const float proj[16],
          * dcam = eye_z/cos(θ), which makes the threshold oscillate when the camera
          * rotates.  eye_z is invariant under pure rotation so the transition is stable. */
         float eye_z = (float)(dxd*cam_fwd[0] + dyd*cam_fwd[1] + dzd*cam_fwd[2]);
-        float px = (eye_z > 0.0f)
-                   ? (WIN_H / 2.0f) * dr / (eye_z * half_fov_tan() + 1e-9f)
-                   : 0.0f;
+        int inside_body = (dcam < dr);
+        float px;
+        if (inside_body) {
+            /* Camera is inside the sphere — always render as sphere (large px
+             * suppresses the dot, show=0 enables sphere rendering below). */
+            px = 1000.0f;
+        } else {
+            px = (eye_z > 0.0f)
+                 ? (WIN_H / 2.0f) * dr / (eye_z * half_fov_tan() + 1e-9f)
+                 : 0.0f;
+        }
         /* Threshold: sphere first appears when its diameter (2×px) equals the dot
          * diameter (2.5px), i.e. px = 1.25 = BODY_SPHERE_APPEAR_PX. */
         body_px[i]   = px;
-        info[i].show = (px < BODY_SPHERE_APPEAR_PX) ? 1 : 0;
+        info[i].show = (!inside_body && px < BODY_SPHERE_APPEAR_PX) ? 1 : 0;
 
         if (!g_bodies[i].alive || info[i].show) continue;
         if (b->is_star) continue;   /* stars rendered as glare only, not Phong spheres */
@@ -1302,6 +1312,7 @@ void render_frame(const float view[16], const float proj[16],
             glUniform1iv(s_sp_impact_kind, nspots, kinds);
         }
 
+        glUniform1i(s_sp_inside, inside_body);
         glDrawElements(GL_TRIANGLES, 6, GL_UNSIGNED_INT, 0);
     }
     glBindVertexArray(0);

--- a/src/render.c
+++ b/src/render.c
@@ -100,7 +100,7 @@ static GLint  s_sp_impact_heat  = -1;
 static GLint  s_sp_impact_prog  = -1;
 static GLint  s_sp_impact_seed  = -1;
 static GLint  s_sp_impact_kind  = -1;
-static GLint  s_sp_inside       = -1;   /* 1 when camera is inside the sphere */
+static GLint  s_sp_use_fullscreen = -1; /* 1 when billboard would degenerate (camera near body) */
 
 /*
  * get_planet_type — map body name to a procedural texture variant index.
@@ -691,7 +691,7 @@ void render_init(void) {
     s_sp_impact_prog  = glGetUniformLocation(s_sphere_shader, "u_impact_progress[0]");
     s_sp_impact_seed  = glGetUniformLocation(s_sphere_shader, "u_impact_seed[0]");
     s_sp_impact_kind  = glGetUniformLocation(s_sphere_shader, "u_impact_kind[0]");
-    s_sp_inside       = glGetUniformLocation(s_sphere_shader, "u_inside");
+    s_sp_use_fullscreen = glGetUniformLocation(s_sphere_shader, "u_use_fullscreen");
 
     /* Frame-constant uniforms (fov_tan, aspect, screen do not change at runtime) */
     glUseProgram(s_sphere_shader);
@@ -1225,19 +1225,21 @@ void render_frame(const float view[16], const float proj[16],
         info[i].dr     = dr;
         info[i].dcam   = dcam;
 
-        /* eye_z: depth along the view axis (forward component of the relative vector).
-         * Use eye_z for the pixel-size threshold — dcam varies with view angle as
-         * dcam = eye_z/cos(θ), which makes the threshold oscillate when the camera
-         * rotates.  eye_z is invariant under pure rotation so the transition is stable. */
+        /* When the camera is close to the body (within 4 radii), the billboard
+         * degenerates at oblique view angles — the sphere centre projects near
+         * the camera plane (eye_z ≈ 0) and perspective division produces NaN/Inf.
+         * Switch to a fullscreen quad in that range; the fragment shader does
+         * the per-pixel ray-sphere intersection independently of vertex layout
+         * and produces the correct silhouette from any view direction. */
+        int use_fullscreen = (dcam < dr * 4.0f);
+
+        /* eye_z: forward-axis depth.  Used for the dot/sphere pixel-size test.
+         * Prefer eye_z over dcam because dcam = eye_z/cos(θ) oscillates with
+         * camera rotation; eye_z is invariant under pure rotation. */
         float eye_z = (float)(dxd*cam_fwd[0] + dyd*cam_fwd[1] + dzd*cam_fwd[2]);
-        /* use_fullscreen: sphere center is behind the camera (eye_z < 0) but the
-         * sphere still extends in front (eye_z > -dr).  In this case the normal
-         * billboard quad would be clipped by the near plane, so replace it with a
-         * fullscreen NDC quad.  Covers both the inside-body case and the case where
-         * the camera is just outside the surface but looking away. */
-        int use_fullscreen = (eye_z < 0.0f) && (eye_z > -dr);
         float px;
         if (use_fullscreen) {
+            /* Suppress the dot (large px) and force the sphere to render below. */
             px = 1000.0f;
         } else {
             px = (eye_z > 0.0f)
@@ -1315,7 +1317,7 @@ void render_frame(const float view[16], const float proj[16],
             glUniform1iv(s_sp_impact_kind, nspots, kinds);
         }
 
-        glUniform1i(s_sp_inside, use_fullscreen);
+        glUniform1i(s_sp_use_fullscreen, use_fullscreen);
         glDrawElements(GL_TRIANGLES, 6, GL_UNSIGNED_INT, 0);
     }
     glBindVertexArray(0);

--- a/src/ui.c
+++ b/src/ui.c
@@ -111,6 +111,14 @@ static int s_pause_menu_visible = 0;
 static int s_pause_menu_selected = 0;
 static int s_pause_menu_vsync = 0;
 
+/* Flash timer: show sim speed briefly after +/- is pressed even while paused */
+#define SPEED_FLASH_MS 1500
+static Uint64 s_speed_flash_at = 0;  /* SDL tick (ms) when last speed change occurred; 0 = no flash */
+
+void ui_notify_speed_change(void) {
+    s_speed_flash_at = SDL_GetTicks64();
+}
+
 /* Layout structs computed fresh each frame so resizing is free. */
 typedef struct {
     int n;
@@ -664,7 +672,9 @@ void ui_render(void) {
 
     /* Format sim speed string */
     char ss_str[64];
-    if (g_paused)
+    int flashing = s_speed_flash_at != 0 &&
+                   (SDL_GetTicks64() - s_speed_flash_at) < SPEED_FLASH_MS;
+    if (g_paused && !flashing)
         snprintf(ss_str, sizeof(ss_str), "Paused");
     else {
         double days = g_sim_speed / DAY;

--- a/src/ui.h
+++ b/src/ui.h
@@ -7,5 +7,6 @@
 void ui_init(void);
 void ui_set_pause_menu(int visible, int selected, int vsync_enabled);
 int ui_pause_menu_hit_test(int mouse_x, int mouse_y);
+void ui_notify_speed_change(void);
 void ui_render(void);
 void ui_shutdown(void);


### PR DESCRIPTION
## What does this PR do?

Fixes planet spheres and atmosphere glow disappearing when the camera is inside or near a body, and polishes several inspect-mode UX rough edges.

## Related Issue
Part of #11

## Changes

- **`assets/shaders/phong.vert`** — Added `u_use_fullscreen` uniform. When the camera is within 4 body radii, outputs a fullscreen NDC quad instead of the billboard. The billboard's perspective projection degenerates whenever the sphere centre projects near the camera plane (division by ~0 → NaN/Inf), which caused the body to disappear at any oblique view angle up close. The fragment shader reconstructs per-pixel rays from `gl_FragCoord` independently of vertex layout, so a fullscreen quad produces the correct silhouette from any position or look direction. Renamed `u_inside` → `u_use_fullscreen` to reflect that the trigger covers near-outside cases too.

- **`assets/shaders/atm.vert`** — Applied the same distance-based fullscreen trigger (`dcam < 4r`) to the atmosphere glow shader, replacing the previous inside-only check. Removed the now-unused `u_cam_fwd` declaration.

- **`src/render.c`** — Computes `use_fullscreen = (dcam < dr * 4.0f)` per body; sets `px = 1000` to suppress the dot renderer and `info[i].show = 0` to allow sphere rendering when fullscreen is active. Renamed `s_sp_inside` → `s_sp_use_fullscreen` for consistency.

- **`src/inspect.c`** — Three inspect-mode UX improvements:
  1. **Moon picking filter**: skips moons during cursor picking when the moon is tiny on screen (< 5 px) and overlaps its parent's screen disc, preventing accidental moon selection when targeting a planet like Saturn.
  2. **Travel lockout (bugfix)**: `inspect_begin_orbit` now ignores clicks while a fly-in animation is running (matches existing policy in `orbit_mouse`/`orbit_zoom`). Guard requires `g_inspect_orbit_mode` so initial selections are unaffected.
  3. **Same-body no-op**: clicking a body already being inspected at its target orbit distance is a no-op (1 % tolerance), avoiding a ~1.5 s animation that produced no visible motion.

## Testing

- Verified planet spheres render correctly from inside a body looking in all directions (toward center, orthogonal, directly away).
- Confirmed atmosphere glow remains visible at all angles near a planet surface.
- Confirmed Mars moons (Phobos, Deimos) are no longer accidentally selected when clicking Mars from typical viewing distances.
- Verified inspect travel cannot be interrupted by clicking mid-animation.
- Verified clicking the same body after a completed travel is a no-op (no spurious animation).
- Syntax-checked all modified `.c` files with `gcc -fsyntax-only`.

## Screenshots / Videos

<!-- Before: planet disappears when looking away from center while inside body -->
<!-- After: planet renders correctly from any view direction at close range -->